### PR TITLE
chatMessage changes

### DIFF
--- a/src/module/actor/actor.js
+++ b/src/module/actor/actor.js
@@ -547,6 +547,8 @@ export class ActorSFRPG extends Actor {
             title:  `Ability Check - ${label}`,
             flavor: null,
             speaker: ChatMessage.getSpeaker({ actor: this }),
+			chatMessage: options.chatMessage,
+			onClose: options.onClose,									
             dialogOptions: {
                 left: options.event ? options.event.clientX - 80 : null,
                 top: options.event ? options.event.clientY - 80 : null
@@ -582,6 +584,8 @@ export class ActorSFRPG extends Actor {
             title: `Save - ${label}`,
             flavor: null,
             speaker: ChatMessage.getSpeaker({ actor: this }),
+			chatMessage: options.chatMessage,
+			onClose: options.onClose,							
             dialogOptions: {
                 left: options.event ? options.event.clientX - 80 : null,
                 top: options.event ? options.event.clientY - 80 : null
@@ -608,6 +612,8 @@ export class ActorSFRPG extends Actor {
             title: `Skill Check - ${CONFIG.SFRPG.skills[skillId.substring(0, 3)]}`,
             flavor: null,
             speaker: ChatMessage.getSpeaker({ actor: this }),
+			chatMessage: options.chatMessage,
+			onClose: options.onClose,									
             dialogOptions: {
                 left: options.event ? options.event.clientX - 80 : null,
                 top: options.event ? options.event.clientY - 80 : null
@@ -664,6 +670,8 @@ export class ActorSFRPG extends Actor {
             title: `Skill Check - ${CONFIG.SFRPG.skills["pil"]}`,
             flavor: null,
             speaker: ChatMessage.getSpeaker({ actor: this }),
+			chatMessage: options.chatMessage,
+			onClose: options.onClose,									
             dialogOptions: {
                 left: options.event ? options.event.clientX - 80 : null,
                 top: options.event ? options.event.clientY - 80 : null

--- a/src/module/actor/actor.js
+++ b/src/module/actor/actor.js
@@ -547,8 +547,8 @@ export class ActorSFRPG extends Actor {
             title:  `Ability Check - ${label}`,
             flavor: null,
             speaker: ChatMessage.getSpeaker({ actor: this }),
-			chatMessage: options.chatMessage,
-			onClose: options.onClose,									
+            chatMessage: options.chatMessage,
+            onClose: options.onClose,									
             dialogOptions: {
                 left: options.event ? options.event.clientX - 80 : null,
                 top: options.event ? options.event.clientY - 80 : null
@@ -584,8 +584,8 @@ export class ActorSFRPG extends Actor {
             title: `Save - ${label}`,
             flavor: null,
             speaker: ChatMessage.getSpeaker({ actor: this }),
-			chatMessage: options.chatMessage,
-			onClose: options.onClose,							
+            chatMessage: options.chatMessage,
+            onClose: options.onClose,							
             dialogOptions: {
                 left: options.event ? options.event.clientX - 80 : null,
                 top: options.event ? options.event.clientY - 80 : null
@@ -612,8 +612,8 @@ export class ActorSFRPG extends Actor {
             title: `Skill Check - ${CONFIG.SFRPG.skills[skillId.substring(0, 3)]}`,
             flavor: null,
             speaker: ChatMessage.getSpeaker({ actor: this }),
-			chatMessage: options.chatMessage,
-			onClose: options.onClose,									
+            chatMessage: options.chatMessage,
+            onClose: options.onClose,									
             dialogOptions: {
                 left: options.event ? options.event.clientX - 80 : null,
                 top: options.event ? options.event.clientY - 80 : null
@@ -670,8 +670,8 @@ export class ActorSFRPG extends Actor {
             title: `Skill Check - ${CONFIG.SFRPG.skills["pil"]}`,
             flavor: null,
             speaker: ChatMessage.getSpeaker({ actor: this }),
-			chatMessage: options.chatMessage,
-			onClose: options.onClose,									
+            chatMessage: options.chatMessage,
+            onClose: options.onClose,									
             dialogOptions: {
                 left: options.event ? options.event.clientX - 80 : null,
                 top: options.event ? options.event.clientY - 80 : null

--- a/src/module/dice.js
+++ b/src/module/dice.js
@@ -90,11 +90,12 @@ export class DiceSFRPG {
                     content: flavor
                 };
 				
-                if(chatMessage)
+                if (chatMessage) {
                     ChatMessage.create(chatData, { chatBubble: true });
+                }
             }
 
-            let useCustomCard = game.settings.get("sfrpg", "useCustomChatCards");
+            let useCustomCard = game.settings.get("sfrpg", "useCustomChatCards") && chatMessage;
             let errorToThrow = null;
             if (useCustomCard) {
                 //Push the roll to the ChatBox
@@ -118,7 +119,7 @@ export class DiceSFRPG {
                     const insertIndex = rollContent.indexOf(`<section class="tooltip-part">`);
                     const explainedRollContent = rollContent.substring(0, insertIndex) + preparedRollExplanation + rollContent.substring(insertIndex);
             
-                    if(chatMessage){
+                    if (chatMessage){
                         ChatMessage.create({
                             flavor: title,
                             speaker: speaker,
@@ -402,7 +403,7 @@ export class DiceSFRPG {
                 tagContent += `</footer></div>`;
             }
 
-            let useCustomCard = game.settings.get("sfrpg", "useCustomChatCards");
+            let useCustomCard = game.settings.get("sfrpg", "useCustomChatCards") && chatMessage;
             let errorToThrow = null;
             if (useCustomCard) {
                 //Push the roll to the ChatBox
@@ -426,7 +427,7 @@ export class DiceSFRPG {
                     const insertIndex = rollContent.indexOf(`<section class="tooltip-part">`);
                     const explainedRollContent = rollContent.substring(0, insertIndex) + preparedRollExplanation + rollContent.substring(insertIndex);
             
-                    if(chatMessage){
+                    if (chatMessage){
                         ChatMessage.create({
                             flavor: flavor,
                             speaker: speaker,

--- a/src/module/dice.js
+++ b/src/module/dice.js
@@ -119,15 +119,15 @@ export class DiceSFRPG {
                     const explainedRollContent = rollContent.substring(0, insertIndex) + preparedRollExplanation + rollContent.substring(insertIndex);
             
                     if(chatMessage){
-						ChatMessage.create({
-							flavor: title,
-							speaker: speaker,
-							content: explainedRollContent,
-							rollMode: rollMode,
-							roll: roll,
-							type: CONST.CHAT_MESSAGE_TYPES.ROLL,
-							sound: CONFIG.sounds.dice
-						});
+                        ChatMessage.create({
+                            flavor: title,
+                            speaker: speaker,
+                            content: explainedRollContent,
+                            rollMode: rollMode,
+                            roll: roll,
+                            type: CONST.CHAT_MESSAGE_TYPES.ROLL,
+                            sound: CONFIG.sounds.dice
+                        });
                     }
                 });
             }
@@ -427,15 +427,15 @@ export class DiceSFRPG {
                     const explainedRollContent = rollContent.substring(0, insertIndex) + preparedRollExplanation + rollContent.substring(insertIndex);
             
                     if(chatMessage){
-						ChatMessage.create({
-							flavor: flavor,
-							speaker: speaker,
-							content: explainedRollContent + tagContent,
-							rollMode: rollMode,
-							roll: roll,
-							type: CONST.CHAT_MESSAGE_TYPES.ROLL,
-							sound: CONFIG.sounds.dice
-						});
+                        ChatMessage.create({
+                            flavor: flavor,
+                            speaker: speaker,
+                            content: explainedRollContent + tagContent,
+                            rollMode: rollMode,
+                            roll: roll,
+                            type: CONST.CHAT_MESSAGE_TYPES.ROLL,
+                            sound: CONFIG.sounds.dice
+                        });
                     }
                 });
             }

--- a/src/module/dice.js
+++ b/src/module/dice.js
@@ -21,7 +21,7 @@ export class DiceSFRPG {
     * @param {Object} dialogOptions      Modal dialog options
     */
     static async d20Roll({ event = new Event(''), parts, rollContext, title, speaker, flavor, advantage = true,
-        critical = 20, fumble = 1, onClose, dialogOptions }) {
+        critical = 20, fumble = 1, chatMessage = true, onClose, dialogOptions }) {
         
         if (!rollContext?.isValid()) {
             console.log(['Invalid rollContext', rollContext]);
@@ -89,8 +89,9 @@ export class DiceSFRPG {
                     speaker: speaker,
                     content: flavor
                 };
-        
-                ChatMessage.create(chatData, { chatBubble: true });
+				
+				if(chatMessage)
+					ChatMessage.create(chatData, { chatBubble: true });
             }
 
             let useCustomCard = game.settings.get("sfrpg", "useCustomChatCards");
@@ -117,15 +118,17 @@ export class DiceSFRPG {
                     const insertIndex = rollContent.indexOf(`<section class="tooltip-part">`);
                     const explainedRollContent = rollContent.substring(0, insertIndex) + preparedRollExplanation + rollContent.substring(insertIndex);
             
-                    ChatMessage.create({
-                        flavor: title,
-                        speaker: speaker,
-                        content: explainedRollContent,
-                        rollMode: rollMode,
-                        roll: roll,
-                        type: CONST.CHAT_MESSAGE_TYPES.ROLL,
-                        sound: CONFIG.sounds.dice
-                    });
+					if(chatMessage){
+						ChatMessage.create({
+							flavor: title,
+							speaker: speaker,
+							content: explainedRollContent,
+							rollMode: rollMode,
+							roll: roll,
+							type: CONST.CHAT_MESSAGE_TYPES.ROLL,
+							sound: CONFIG.sounds.dice
+						});
+					}
                 });
             }
 
@@ -276,7 +279,7 @@ export class DiceSFRPG {
     * @param {Function} onClose         Callback for actions to take when the dialog form is closed
     * @param {Object} dialogOptions     Modal dialog options
     */
-    static async damageRoll({ event = new Event(''), parts, criticalData, damageTypes, rollContext, title, speaker, flavor, critical = true, onClose, dialogOptions }) {
+    static async damageRoll({ event = new Event(''), parts, criticalData, damageTypes, rollContext, title, speaker, flavor, critical = true, chatMessage = true, onClose, dialogOptions }) {
         flavor = flavor || title;
 
         if (!rollContext?.isValid()) {
@@ -423,15 +426,17 @@ export class DiceSFRPG {
                     const insertIndex = rollContent.indexOf(`<section class="tooltip-part">`);
                     const explainedRollContent = rollContent.substring(0, insertIndex) + preparedRollExplanation + rollContent.substring(insertIndex);
             
-                    ChatMessage.create({
-                        flavor: flavor,
-                        speaker: speaker,
-                        content: explainedRollContent + tagContent,
-                        rollMode: rollMode,
-                        roll: roll,
-                        type: CONST.CHAT_MESSAGE_TYPES.ROLL,
-                        sound: CONFIG.sounds.dice
-                    });
+					if(chatMessage){
+						ChatMessage.create({
+							flavor: flavor,
+							speaker: speaker,
+							content: explainedRollContent + tagContent,
+							rollMode: rollMode,
+							roll: roll,
+							type: CONST.CHAT_MESSAGE_TYPES.ROLL,
+							sound: CONFIG.sounds.dice
+						});
+					}
                 });
             }
 

--- a/src/module/dice.js
+++ b/src/module/dice.js
@@ -90,8 +90,8 @@ export class DiceSFRPG {
                     content: flavor
                 };
 				
-				if(chatMessage)
-					ChatMessage.create(chatData, { chatBubble: true });
+                if(chatMessage)
+                    ChatMessage.create(chatData, { chatBubble: true });
             }
 
             let useCustomCard = game.settings.get("sfrpg", "useCustomChatCards");
@@ -118,7 +118,7 @@ export class DiceSFRPG {
                     const insertIndex = rollContent.indexOf(`<section class="tooltip-part">`);
                     const explainedRollContent = rollContent.substring(0, insertIndex) + preparedRollExplanation + rollContent.substring(insertIndex);
             
-					if(chatMessage){
+                    if(chatMessage){
 						ChatMessage.create({
 							flavor: title,
 							speaker: speaker,
@@ -128,7 +128,7 @@ export class DiceSFRPG {
 							type: CONST.CHAT_MESSAGE_TYPES.ROLL,
 							sound: CONFIG.sounds.dice
 						});
-					}
+                    }
                 });
             }
 
@@ -426,7 +426,7 @@ export class DiceSFRPG {
                     const insertIndex = rollContent.indexOf(`<section class="tooltip-part">`);
                     const explainedRollContent = rollContent.substring(0, insertIndex) + preparedRollExplanation + rollContent.substring(insertIndex);
             
-					if(chatMessage){
+                    if(chatMessage){
 						ChatMessage.create({
 							flavor: flavor,
 							speaker: speaker,
@@ -436,7 +436,7 @@ export class DiceSFRPG {
 							type: CONST.CHAT_MESSAGE_TYPES.ROLL,
 							sound: CONFIG.sounds.dice
 						});
-					}
+                    }
                 });
             }
 

--- a/src/module/item/item.js
+++ b/src/module/item/item.js
@@ -735,7 +735,7 @@ export class ItemSFRPG extends mix(Item).with(ItemCapacityMixin) {
             flavor: this.data?.data?.chatFlavor,
             speaker: ChatMessage.getSpeaker({ actor: this.actor }),
             critical: crit,
-			chatMessage: options.chatMessage,				
+            chatMessage: options.chatMessage,				
             dialogOptions: {
                 left: options.event ? options.event.clientX - 80 : null,
                 top: options.event ? options.event.clientY - 80 : null
@@ -835,7 +835,7 @@ export class ItemSFRPG extends mix(Item).with(ItemCapacityMixin) {
             title: title,
             speaker: ChatMessage.getSpeaker({ actor: this.actor }),
             critical: 20,
-			chatMessage: options.chatMessage,						
+            chatMessage: options.chatMessage,						
             dialogOptions: {
                 left: options.event ? options.event.clientX - 80 : null,
                 top: options.event ? options.event.clientY - 80 : null
@@ -882,7 +882,7 @@ export class ItemSFRPG extends mix(Item).with(ItemCapacityMixin) {
             title: title,
             speaker: ChatMessage.getSpeaker({ actor: this.actor }),
             critical: 20,
-			chatMessage: options.chatMessage,						
+            chatMessage: options.chatMessage,						
             dialogOptions: {
                 left: options.event ? options.event.clientX - 80 : null,
                 top: options.event ? options.event.clientY - 80 : null
@@ -1044,7 +1044,7 @@ export class ItemSFRPG extends mix(Item).with(ItemCapacityMixin) {
             title: title,
             damageTypes: damageTypes,
             speaker: ChatMessage.getSpeaker({ actor: this.actor }),
-			chatMessage: options.chatMessage,						
+            chatMessage: options.chatMessage,						
             dialogOptions: {
                 width: 400,
                 top: event ? event.clientY - 80 : null,
@@ -1087,7 +1087,7 @@ export class ItemSFRPG extends mix(Item).with(ItemCapacityMixin) {
             rollContext: rollContext,
             title: title,
             speaker: ChatMessage.getSpeaker({ actor: this.actor }),
-			chatMessage: options.chatMessage,						
+            chatMessage: options.chatMessage,						
             dialogOptions: {
                 skipUI: true,
                 width: 400,

--- a/src/module/item/item.js
+++ b/src/module/item/item.js
@@ -735,6 +735,7 @@ export class ItemSFRPG extends mix(Item).with(ItemCapacityMixin) {
             flavor: this.data?.data?.chatFlavor,
             speaker: ChatMessage.getSpeaker({ actor: this.actor }),
             critical: crit,
+			chatMessage: options.chatMessage,				
             dialogOptions: {
                 left: options.event ? options.event.clientX - 80 : null,
                 top: options.event ? options.event.clientY - 80 : null
@@ -834,6 +835,7 @@ export class ItemSFRPG extends mix(Item).with(ItemCapacityMixin) {
             title: title,
             speaker: ChatMessage.getSpeaker({ actor: this.actor }),
             critical: 20,
+			chatMessage: options.chatMessage,						
             dialogOptions: {
                 left: options.event ? options.event.clientX - 80 : null,
                 top: options.event ? options.event.clientY - 80 : null
@@ -880,6 +882,7 @@ export class ItemSFRPG extends mix(Item).with(ItemCapacityMixin) {
             title: title,
             speaker: ChatMessage.getSpeaker({ actor: this.actor }),
             critical: 20,
+			chatMessage: options.chatMessage,						
             dialogOptions: {
                 left: options.event ? options.event.clientX - 80 : null,
                 top: options.event ? options.event.clientY - 80 : null
@@ -1041,6 +1044,7 @@ export class ItemSFRPG extends mix(Item).with(ItemCapacityMixin) {
             title: title,
             damageTypes: damageTypes,
             speaker: ChatMessage.getSpeaker({ actor: this.actor }),
+			chatMessage: options.chatMessage,						
             dialogOptions: {
                 width: 400,
                 top: event ? event.clientY - 80 : null,
@@ -1083,6 +1087,7 @@ export class ItemSFRPG extends mix(Item).with(ItemCapacityMixin) {
             rollContext: rollContext,
             title: title,
             speaker: ChatMessage.getSpeaker({ actor: this.actor }),
+			chatMessage: options.chatMessage,						
             dialogOptions: {
                 skipUI: true,
                 width: 400,
@@ -1128,6 +1133,7 @@ export class ItemSFRPG extends mix(Item).with(ItemCapacityMixin) {
             rollContext: rollContext,
             title: title,
             speaker: ChatMessage.getSpeaker({ actor: this.actor }),
+			chatMessage: options.chatMessage,						
             dialogOptions: {
                 width: 400,
                 top: event ? event.clientY - 80 : null,
@@ -1196,6 +1202,7 @@ export class ItemSFRPG extends mix(Item).with(ItemCapacityMixin) {
             ChatMessage.create({
                 flavor: itemData.chatFlavor || title,
                 speaker: ChatMessage.getSpeaker({ actor: this.actor }),
+				chatMessage: options.chatMessage,					 
                 content: explainedRollContent,
                 rollMode: game.settings.get("core", "rollMode"),
                 roll: rollResult.roll,

--- a/src/module/item/item.js
+++ b/src/module/item/item.js
@@ -1133,7 +1133,7 @@ export class ItemSFRPG extends mix(Item).with(ItemCapacityMixin) {
             rollContext: rollContext,
             title: title,
             speaker: ChatMessage.getSpeaker({ actor: this.actor }),
-			chatMessage: options.chatMessage,						
+            chatMessage: options.chatMessage,
             dialogOptions: {
                 width: 400,
                 top: event ? event.clientY - 80 : null,
@@ -1202,7 +1202,7 @@ export class ItemSFRPG extends mix(Item).with(ItemCapacityMixin) {
             ChatMessage.create({
                 flavor: itemData.chatFlavor || title,
                 speaker: ChatMessage.getSpeaker({ actor: this.actor }),
-				chatMessage: options.chatMessage,					 
+                chatMessage: options.chatMessage,
                 content: explainedRollContent,
                 rollMode: game.settings.get("core", "rollMode"),
                 roll: rollResult.roll,


### PR DESCRIPTION
I have a module that would like to roll ability, skills and saving throws.  Problem is I don't want the request to automatically open a Chat Message.  I've attempted some interested code to work around it, but DnD5e has a handy option of requesting that a dice roll doesn't open a ChatMessage, and I'd very kindly like to add it to Starfinder.