### PR TITLE
V10: Drag and Drop and other misc fixes

### DIFF
--- a/src/module/actor/actor-inventory-utils.js
+++ b/src/module/actor/actor-inventory-utils.js
@@ -215,7 +215,7 @@ export async function moveItemBetweenActorsAsync(sourceActor, itemToMove, target
             }
 
             const duplicatedData = duplicate(itemToCreate.item);
-            if (duplicatedData.data.equipped) {
+            if (itemToCreate.item.data.equipped) { //duplicate() doesn't duplicate .data getter
                 duplicatedData.data.equipped = false;
             }
             
@@ -247,7 +247,9 @@ export async function moveItemBetweenActorsAsync(sourceActor, itemToMove, target
         }
 
         /** Ensure the original to-move item has the quantity correct. */
-        itemData[0].data.quantity = quantity;
+        if (itemData[0].system?.quantity) { //Check for V10
+            itemData[0].system.quantity = quantity; //.data isn't on duplicated objects, so no easy way to do this on V9
+        }
 
         if (itemData.length != items.length) {
             console.log(['Mismatch in item count', itemData, items]);

--- a/src/module/actor/actor-inventory-utils.js
+++ b/src/module/actor/actor-inventory-utils.js
@@ -247,8 +247,10 @@ export async function moveItemBetweenActorsAsync(sourceActor, itemToMove, target
         }
 
         /** Ensure the original to-move item has the quantity correct. */
-        if (itemData[0].system?.quantity) { //Check for V10
-            itemData[0].system.quantity = quantity; //.data isn't on duplicated objects, so no easy way to do this on V9
+        if (isNewerVersion(game.version, '10.0')) {
+            itemData[0].system.quantity = quantity;
+        } else {
+            itemData[0].data.quantity
         }
 
         if (itemData.length != items.length) {

--- a/src/module/actor/actor-inventory-utils.js
+++ b/src/module/actor/actor-inventory-utils.js
@@ -215,9 +215,7 @@ export async function moveItemBetweenActorsAsync(sourceActor, itemToMove, target
             }
 
             const duplicatedData = duplicate(itemToCreate.item);
-            if (itemToCreate.item.data.equipped) { //duplicate() doesn't duplicate .data getter
-                duplicatedData.data.equipped = false;
-            }
+            duplicatedData.system.equipped = false;
             
             items.push({item: duplicatedData, children: contents, parent: itemToCreate.parent});
         }
@@ -247,11 +245,7 @@ export async function moveItemBetweenActorsAsync(sourceActor, itemToMove, target
         }
 
         /** Ensure the original to-move item has the quantity correct. */
-        if (isNewerVersion(game.version, '10.0')) {
-            itemData[0].system.quantity = quantity;
-        } else {
-            itemData[0].data.quantity
-        }
+        itemData[0].system.quantity = quantity;
 
         if (itemData.length != items.length) {
             console.log(['Mismatch in item count', itemData, items]);

--- a/src/module/actor/sheet/base.js
+++ b/src/module/actor/sheet/base.js
@@ -820,12 +820,9 @@ export class ActorSheetSFRPG extends ActorSheet {
         const update = { "quantity": bigStack };
         await actorHelper.updateItem(item.id, update);
 
-        const itemData = duplicate(item.data);
-        if (isNewerVersion(game.version, '10.0')) {
-            itemData.data = item.data.data; //duplicate doesn't copy .data getter, so we have to graft it on manually.
-        }
+        const itemData = duplicate(item);
         itemData.id = null;
-        itemData.data.quantity = smallStack;
+        itemData.system.quantity = smallStack;
         itemData.effects = [];
         await actorHelper.createItem(itemData);
     }
@@ -1031,7 +1028,7 @@ export class ActorSheetSFRPG extends ActorSheet {
                 ui.notifications.warn(game.i18n.format("SFRPG.ActorSheet.Inventory.Interface.ItemCollectionPickupNoGMError"));
             }
             return;
-        } else if (parsedDragData.uuid.includes("Compendium") || parsedDragData.pack) {
+        } else if (parsedDragData.uuid.includes("Compendium")) {
 
             const createResult = await targetActor.createItem(itemData.data._source);
             const addedItem = targetActor.getItem(createResult[0].id);
@@ -1051,14 +1048,13 @@ export class ActorSheetSFRPG extends ActorSheet {
             }
 
             return itemInTargetActor;
-        } else if (parsedDragData.uuid.includes("Actor") || parsedDragData.data) {
-            if (isNewerVersion(game.version, '10.0')) {
-                const splitUUID = parsedDragData.uuid.split(".");
-                let actorID = "";
-                if (splitUUID[0] === "Actor") {
-                    actorID = splitUUID[1];
-                }
+        } else if (parsedDragData.uuid.includes("Actor")) {
+            const splitUUID = parsedDragData.uuid.split(".");
+            let actorID = "";
+            if (splitUUID[0] === "Actor") {
+                actorID = splitUUID[1];
             }
+            
             const sourceActor = new ActorItemHelper(actorID || parsedDragData.actorId, parsedDragData.tokenId, parsedDragData.sceneId);
             if (!ActorItemHelper.IsValidHelper(sourceActor)) {
                 ui.notifications.warn(game.i18n.format("SFRPG.ActorSheet.Inventory.Interface.DragFromExternalTokenError"));

--- a/src/module/actor/sheet/base.js
+++ b/src/module/actor/sheet/base.js
@@ -821,7 +821,9 @@ export class ActorSheetSFRPG extends ActorSheet {
         await actorHelper.updateItem(item.id, update);
 
         const itemData = duplicate(item.data);
-        itemData.data = item.data.data; //duplicate doesn't copy .data getter, so we have to graft it on manually.
+        if (isNewerVersion(game.version, '10.0')) {
+            itemData.data = item.data.data; //duplicate doesn't copy .data getter, so we have to graft it on manually.
+        }
         itemData.id = null;
         itemData.data.quantity = smallStack;
         itemData.effects = [];
@@ -1029,7 +1031,7 @@ export class ActorSheetSFRPG extends ActorSheet {
                 ui.notifications.warn(game.i18n.format("SFRPG.ActorSheet.Inventory.Interface.ItemCollectionPickupNoGMError"));
             }
             return;
-        } else if (parsedDragData.uuid.includes("Compendium")) {
+        } else if (parsedDragData.uuid.includes("Compendium") || parsedDragData.pack) {
 
             const createResult = await targetActor.createItem(itemData.data._source);
             const addedItem = targetActor.getItem(createResult[0].id);
@@ -1049,13 +1051,15 @@ export class ActorSheetSFRPG extends ActorSheet {
             }
 
             return itemInTargetActor;
-        } else if (parsedDragData.uuid.includes("Actor")) {
-            const splitUUID = parsedDragData.uuid.split(".");
-            let actorID = "";
-            if (splitUUID[0] === "Actor") {
-                actorID = splitUUID[1];
+        } else if (parsedDragData.uuid.includes("Actor") || parsedDragData.data) {
+            if (isNewerVersion(game.version, '10.0')) {
+                const splitUUID = parsedDragData.uuid.split(".");
+                let actorID = "";
+                if (splitUUID[0] === "Actor") {
+                    actorID = splitUUID[1];
+                }
             }
-            const sourceActor = new ActorItemHelper(actorID, parsedDragData.tokenId, parsedDragData.sceneId);
+            const sourceActor = new ActorItemHelper(actorID || parsedDragData.actorId, parsedDragData.tokenId, parsedDragData.sceneId);
             if (!ActorItemHelper.IsValidHelper(sourceActor)) {
                 ui.notifications.warn(game.i18n.format("SFRPG.ActorSheet.Inventory.Interface.DragFromExternalTokenError"));
                 return;

--- a/src/module/actor/sheet/base.js
+++ b/src/module/actor/sheet/base.js
@@ -981,6 +981,8 @@ export class ActorSheetSFRPG extends ActorSheet {
     }
 
     async processDroppedData(event, parsedDragData) {
+        console.log(event)
+        console.log(parsedDragData)
         const targetActor = new ActorItemHelper(this.actor.id, this.token?.id, this.token?.parent?.id);
         if (!ActorItemHelper.IsValidHelper(targetActor)) {
             ui.notifications.warn(game.i18n.format("SFRPG.ActorSheet.Inventory.Interface.DragToExternalTokenError"));
@@ -1043,6 +1045,7 @@ export class ActorSheetSFRPG extends ActorSheet {
         
         const itemInTargetActor = await moveItemBetweenActorsAsync(targetActor, addedItem, targetActor, targetContainer);
         if (itemInTargetActor === addedItem) {
+            console.log(this._onSortItem)
             await this._onSortItem(event, itemInTargetActor.data);
             return itemInTargetActor;
         }
@@ -1053,7 +1056,7 @@ export class ActorSheetSFRPG extends ActorSheet {
             return;
         }
 
-        const itemToMove = await sourceActor.getItem(parsedDragData.data._id);
+        const itemToMove = await sourceActor.getItem(parsedDragData.id);
 
         if (!this.acceptedItemTypes.includes(itemToMove.type)) {
             // Reject item

--- a/src/module/actor/sheet/base.js
+++ b/src/module/actor/sheet/base.js
@@ -981,8 +981,6 @@ export class ActorSheetSFRPG extends ActorSheet {
     }
 
     async processDroppedData(event, parsedDragData) {
-        console.log(event)
-        console.log(parsedDragData)
         const targetActor = new ActorItemHelper(this.actor.id, this.token?.id, this.token?.parent?.id);
         if (!ActorItemHelper.IsValidHelper(targetActor)) {
             ui.notifications.warn(game.i18n.format("SFRPG.ActorSheet.Inventory.Interface.DragToExternalTokenError"));

--- a/src/module/actor/sheet/character.js
+++ b/src/module/actor/sheet/character.js
@@ -73,6 +73,7 @@ export class ActorSheetSFRPGCharacter extends ActorSheetSFRPG {
             item.img = item.img || DEFAULT_TOKEN;
             item.isStack = item.data.quantity ? item.data.quantity > 1 : false;
             item.isOnCooldown = item.data.recharge && !!item.data.recharge.value && (item.data.recharge.charged === false);
+            item.isOpen = item.type === "container" ? item.data.container.isOpen : false
             item.hasAttack = ["mwak", "rwak", "msak", "rsak"].includes(item.data.actionType) && (!["weapon", "shield"].includes(item.type) || item.data.equipped);
             item.hasDamage = item.data.damage?.parts && item.data.damage.parts.length > 0 && (!["weapon", "shield"].includes(item.type) || item.data.equipped);
             item.hasUses = item.document.canBeUsed();

--- a/src/module/actor/sheet/character.js
+++ b/src/module/actor/sheet/character.js
@@ -73,7 +73,7 @@ export class ActorSheetSFRPGCharacter extends ActorSheetSFRPG {
             item.img = item.img || DEFAULT_TOKEN;
             item.isStack = item.data.quantity ? item.data.quantity > 1 : false;
             item.isOnCooldown = item.data.recharge && !!item.data.recharge.value && (item.data.recharge.charged === false);
-            item.isOpen = item.type === "container" ? item.data.container.isOpen : false
+            item.isOpen = item.type === "container" ? item.data.container.isOpen : true;
             item.hasAttack = ["mwak", "rwak", "msak", "rsak"].includes(item.data.actionType) && (!["weapon", "shield"].includes(item.type) || item.data.equipped);
             item.hasDamage = item.data.damage?.parts && item.data.damage.parts.length > 0 && (!["weapon", "shield"].includes(item.type) || item.data.equipped);
             item.hasUses = item.document.canBeUsed();

--- a/src/sfrpg.js
+++ b/src/sfrpg.js
@@ -197,6 +197,9 @@ Hooks.once('init', async function () {
     Items.unregisterSheet("core", ItemSheet);
     Items.registerSheet("sfrpg", ItemSheetSFRPG, { makeDefault: true });
 
+    console.log("Starfinder | [READY] Preloading handlebar templates");
+    preloadHandlebarsTemplates();
+
     const finishTime = (new Date()).getTime();
     console.log(`Starfinder | [INIT] Done (operation took ${finishTime - initTime} ms)`);
 });
@@ -279,9 +282,6 @@ Hooks.once("ready", async () => {
 
     console.log("Starfinder | [READY] Setting up AOE template overrides");
     templateOverrides();
-
-    console.log("Starfinder | [READY] Preloading handlebar templates");
-    preloadHandlebarsTemplates();
 
     console.log("Starfinder | [READY] Caching starship actions");
     ActorSheetSFRPGStarship.ensureStarshipActions();


### PR DESCRIPTION
(remade PR because git decided we needed to bring this branch up to date with dev)
-Moved HTML template preload to init because sheets refuse to open otherwise.
-Explicitly add `isOpen` to containers, as it didn't seem to be adding before, fixing containers not opening or closing
-Refactor drag-drop to actor sheets to use Item.fromDropData, in the process removed some redundant logic, like if the item, came from a compendium or the sidebar. I've managed to get containers 99% functional, there are some minor bugs: some items refuse to stack, and the console spits out all sorts of messages about unknown items, even though the items are being moved fine.