### PR TITLE
V10: Canvas Drop handler fixes

### DIFF
--- a/src/module/canvas.js
+++ b/src/module/canvas.js
@@ -273,3 +273,145 @@ function openLootCollectionSheet(event) {
     lootCollectionSheet.options.viewPermission = -1;
     lootCollectionSheet.render(true);
 }
+
+export async function canvasHandlerV10(canvas) {
+    event.preventDefault();
+
+    let data = null;
+    try {
+        data = JSON.parse(event.dataTransfer.getData('text/plain'));
+    } catch (err) {
+        defaultDropHandler(event);
+        return false;
+    }
+
+    // We're only interested in overriding item drops.
+    if (!data || (data.type !== "Item" && data.type !== "ItemCollection")) {
+        return false;
+    }
+
+    // Transform the cursor position to canvas space
+    const [x, y] = [event.clientX, event.clientY];
+    const t = canvas.stage.worldTransform;
+    data.x = (x - t.tx) / canvas.stage.scale.x;
+    data.y = (y - t.ty) / canvas.stage.scale.y;
+
+    data.x -= Math.floor(canvas.grid.size / 2);
+    data.y -= Math.floor(canvas.grid.size / 2);
+
+    if (!event.shiftKey) {
+        const point = canvas.grid.getSnappedPosition(data.x, data.y, canvas.activeLayer.gridPrecision);
+        data.x = point.x;
+        data.y = point.y;
+    }
+
+    if (data.type === "Item") {
+        if (!canvas.initialized) { return; }
+        //console.log("Canvas::handleItemDrop()");
+        
+        // Potential sources:
+        // Actor sheet, Token Actor sheet (May be linked to an Actor), Sidebar Item, Compendium
+        let sourceActor = null;
+        let sourceItem = null;
+        let sourceItemData = null;
+        if (data.uuid.includes("Compendium")) {
+            // Source is compendium
+            //console.log("> Dragged item from compendium: " + data.pack);
+            const document = await fromUuid(data.uuid);
+            sourceItemData = duplicate(document.data);
+        } else if (data["tokenId"]) { //No equivalent in V10?
+            // Source is token sheet
+            //console.log(["> Dragged item from token: ", data]);
+            const sourceToken = canvas.tokens.get(data.tokenId);
+            if (!sourceToken) {
+                ui.notifications.info(game.i18n.format("SFRPG.ActorSheet.Inventory.Interface.DragFromExternalTokenError"));
+                return;
+            }
+            sourceActor = new ActorItemHelper(sourceToken.actor.id, sourceToken.id, sourceToken.scene.id);
+            sourceItemData = duplicate(data.data);
+            sourceItem = sourceActor.getItem(sourceItemData._id);
+        } else if (data.uuid.includes("Actor")) {
+            let UUID = data.uuid.split(".");
+            let actorID = "";
+            if (UUID[0] === "Actor") {
+                actorID = UUID[1];
+            }
+            
+            // Source is actor sheet
+            //console.log("> Dragged item from actor: " + data.actorId);
+            sourceActor = new ActorItemHelper(actorID, null, null);
+            sourceItemData = duplicate(data.data);
+            sourceItem = sourceActor.getItem(sourceItemData.id);
+        } else if (data.uuid.includes("Item")) {
+            // Source is sidebar
+            //console.log("> Dragged item from sidebar: " + data.id);
+            sourceItem = await fromUuid(data.uuid);
+            sourceItemData = duplicate(sourceItem.data);
+        } else {
+            // Source is anywhere else
+            // TODO: Check what dragging from placable menu will look like
+            console.log("> Dragged item from unknown source!");
+            console.log(event);
+            console.log(data);
+            return;
+        }
+    
+        // Potential targets:
+        // Canvas (floor), Token Actor (may be linked)
+        let targetActor = null;
+        for (const placeable of canvas.tokens.placeables) {
+            if (data.x < placeable.x + placeable.width && data.x > placeable.x && data.y < placeable.y + placeable.height && data.y > placeable.y && placeable instanceof Token) {
+                targetActor = placeable.actor;
+                break;
+            }
+        }
+    
+        // Create a placeable instead and do item transferral there.
+        if (targetActor === null) {
+            let transferringItems = [sourceItemData];
+            if (sourceActor !== null && sourceItemData.data.container?.contents && sourceItemData.data.container.contents.length > 0) {
+                const containersToTest = [sourceItemData];
+                while (containersToTest.length > 0)
+                {
+                    const container = containersToTest.shift();
+                    const children = sourceActor.filterItems(x => container.data.container.contents.find(y => y.id === x.id));
+                    if (children) {
+                        for (const child of children) {
+                            transferringItems.push(child.data);
+    
+                            if (child.data.data.container?.contents && child.data.data.container.contents.length > 0) {
+                                containersToTest.push(child.data);
+                            }
+                        }
+                    }
+                }
+            }
+            transferringItems = transferringItems.map(x => { //"rename" .system to .data so placeItemCollectionOnCanvas reads it correctly.
+                x.data = x.system;
+                return x;
+            })
+            const hasDropped = placeItemCollectionOnCanvas(data.x, data.y, transferringItems, true);
+            if (hasDropped) {
+                // Remove old items
+                if (sourceActor) {
+                    const idsToDrop = [];
+                    for (const droppedItem of transferringItems) {
+                        idsToDrop.push(droppedItem._id);
+                    }
+                    sourceActor.deleteItem(idsToDrop);
+                }
+            }
+    
+            return true;
+        }
+    
+        const target = new ActorItemHelper(targetActor.id, targetActor.token.id, targetActor.token.parent.id)
+    
+        if (sourceItem) {
+            return moveItemBetweenActorsAsync(sourceActor, sourceItem, target);
+        } else {
+            return target.createItem(sourceItemData);
+        }
+    }
+    return false;
+}

--- a/src/sfrpg.js
+++ b/src/sfrpg.js
@@ -9,7 +9,7 @@
 import { SFRPG } from "./module/config.js";
 import { preloadHandlebarsTemplates } from "./module/templates.js";
 import { registerSystemSettings } from "./module/settings.js";
-import { measureDistances, getBarAttribute, handleItemDropCanvas } from "./module/canvas.js";
+import { measureDistances, handleItemDropCanvas, canvasHandlerV10 } from "./module/canvas.js";
 import { ActorSFRPG } from "./module/actor/actor.js";
 import { initializeRemoteInventory, ActorItemHelper } from "./module/actor/actor-inventory-utils.js";
 import { ActorSheetSFRPGCharacter } from "./module/actor/sheet/character.js";
@@ -285,7 +285,7 @@ Hooks.once("ready", async () => {
 
     console.log("Starfinder | [READY] Overriding canvas drop handler");
     if (isNewerVersion(game.version, '10.0')) {
-        console.warn("Starfinder | [READY] Canvas drop handler not yet implemented.");
+        Hooks.on("dropCanvasData", (canvas) => canvasHandlerV10(canvas));
     } else {
         if (canvas.initialized) {
             defaultDropHandler = canvas._dragDrop.callbacks.drop;


### PR DESCRIPTION
Loot actor sheets still behave oddly. This fix just restores dropping items to the canvas using a Hook instead of monkey patching core (which mainly consists of taking the existing functions, and rejigging them to work on the hook and on V10). Isolated it to its own function too.