### PR TITLE
V10: Fix text fields always showing the editor page

### DIFF
--- a/src/module/actor/sheet/character.js
+++ b/src/module/actor/sheet/character.js
@@ -27,7 +27,7 @@ export class ActorSheetSFRPGCharacter extends ActorSheetSFRPG {
         return path + "character-sheet.html";
     }
 
-    getData() {
+    async getData() {
         const sheetData = super.getData();
 
         let hp = sheetData.data.attributes.hp;
@@ -35,6 +35,10 @@ export class ActorSheetSFRPGCharacter extends ActorSheetSFRPG {
         if (hp.tempmax === 0) delete hp.tempmax;
 
         sheetData["disableExperience"] = game.settings.get("sfrpg", "disableExperienceTracking");
+        
+        // Enrich text editors
+        sheetData.enrichedBiography = await TextEditor.enrichHTML(this.object.system.details.biography.value, {async: true});
+        sheetData.enrichedGMNotes = await TextEditor.enrichHTML(this.object.system.details.biography.gmNotes, {async: true});
 
         return sheetData;
     }

--- a/src/module/actor/sheet/hazard.js
+++ b/src/module/actor/sheet/hazard.js
@@ -20,6 +20,15 @@ export class ActorSheetSFRPGHazard extends ActorSheetSFRPG {
         return "systems/sfrpg/templates/actors/hazard-sheet-full.html";
     }
 
+    async getData() {
+        const data = super.getData();
+
+        // Enrich text editors
+        data.enrichedDescription = await TextEditor.enrichHTML(this.object.system.details.description.value, {async: true});
+
+        return data;
+    }
+
     activateListeners(html) {
         super.activateListeners(html);
 

--- a/src/module/actor/sheet/starship.js
+++ b/src/module/actor/sheet/starship.js
@@ -32,7 +32,7 @@ export class ActorSheetSFRPGStarship extends ActorSheetSFRPG {
         return "systems/sfrpg/templates/actors/starship-sheet-full.html";
     }
 
-    getData() {
+    async getData() {
         const data = super.getData();
 
         let tier = parseFloat(data.data.details.tier || 0);
@@ -40,6 +40,9 @@ export class ActorSheetSFRPGStarship extends ActorSheetSFRPG {
         data.labels["tier"] = tier >= 1 ? String(tier) : tiers[tier] || 1;
 
         this._getCrewData(data);
+
+        // Encrich text editors
+        data.enrichedDescription = await TextEditor.enrichHTML(this.object.system.details.notes, {async: true});
 
         return data;
     }

--- a/src/module/actor/sheet/vehicle.js
+++ b/src/module/actor/sheet/vehicle.js
@@ -22,7 +22,7 @@ export class ActorSheetSFRPGVehicle extends ActorSheetSFRPG {
         return "systems/sfrpg/templates/actors/vehicle-sheet-full.html";
     }
 
-    getData() {
+    async getData() {
         const data = super.getData();
 
         let lvl = parseFloat(data.data.details.level || 0);
@@ -31,6 +31,9 @@ export class ActorSheetSFRPGVehicle extends ActorSheetSFRPG {
 
         this._getCrewData(data)
         this._getHangarBayData(data)
+
+        // Encrich text editors
+        data.enrichedDescription = await TextEditor.enrichHTML(this.object.system.details.description.value, {async: true});
 
         return data;
     }

--- a/src/module/item/sheet.js
+++ b/src/module/item/sheet.js
@@ -88,7 +88,7 @@ export class ItemSheetSFRPG extends ItemSheet {
      * Prepare item sheet data
      * Start with the base item data and extending with additional properties for rendering.
      */
-    getData() {
+    async getData() {
         const data = super.getData();
 
         data.itemData = this.document.data.data;
@@ -185,6 +185,11 @@ export class ItemSheetSFRPG extends ItemSheet {
 
         data.hasSpeed = this.item.data.data.weaponType === "tracking" || (this.item.data.data.special && this.item.data.data.special["limited"]);
         data.hasCapacity = this.item.hasCapacity();
+
+        // Enrich text editors
+        data.enrichedDescription = await TextEditor.enrichHTML(this.object.system.description.value, {async: true});
+        data.enrichedShortDescription = await TextEditor.enrichHTML(this.object.system.description.short, {async: true});
+        data.enrichedGMNotes = await TextEditor.enrichHTML(this.object.system.description.gmNotes, {async: true});
 
         return data;
     }

--- a/src/sfrpg.js
+++ b/src/sfrpg.js
@@ -629,27 +629,6 @@ function setupHandlebars() {
         return left || right;
     });
 
-    Handlebars.registerHelper('editorPlus', function (options) {
-        const target = options.hash['target'];
-        if ( !target ) throw new Error("You must define the name of a target field.");
-    
-        // Enrich the content
-        const isOwner = Boolean(options.hash['isOwner']);
-        const rolls = Boolean(options.hash['rolls']);
-        const rollData = options.hash['rollData'];
-        const content = TextEditor.enrichHTML(options.hash['content'] || "", {secrets: isOwner, documents: true, rolls: rolls, rollData: rollData});
-        const maxSize = Boolean(options.hash['maxSize']) ? ` style="flex: 1;"` : "";
-    
-        // Construct the HTML
-        let editor = $(`<div class="editor flexcol"${maxSize}><div class="editor-content"${maxSize} data-edit="${target}">${content}</div></div>`);
-    
-        // Append edit button
-        const button = Boolean(options.hash['button']);
-        const editable = Boolean(options.hash['editable']);
-        if ( button && editable ) editor.append($('<a class="editor-edit"><i class="fas fa-edit"></i></a>'));
-        return new Handlebars.SafeString(editor[0].outerHTML);
-    });
-
     Handlebars.registerHelper('createTippy', function (options) {
         const title = options.hash['title'];
         const subtitle = options.hash['subtitle'];

--- a/src/templates/actors/hazard-sheet-full.html
+++ b/src/templates/actors/hazard-sheet-full.html
@@ -203,7 +203,12 @@
         
         {{!-- Description Tab --}}
         <div class="tab biography flexcol" data-group="primary" data-tab="notes">
-            {{editorPlus content=data.details.description.value target="data.details.description.value" button=true isOwner=isOwner editable=editable rolls=false rollData=data}}
+            {{editor
+                enrichedDescription
+                target="data.details.description.value"
+                button=true
+                editable=editable
+            }}
         </div>
     </section>
 </form>

--- a/src/templates/actors/hazard-sheet-limited.html
+++ b/src/templates/actors/hazard-sheet-limited.html
@@ -10,7 +10,12 @@
     <!-- BODY -->
     <section class="sheet-body">
         <div class="tab biography">
-            {{editorPlus content=data.details.description.value target="data.details.description.value" button=true isOwner=isOwner editable=editable rolls=false rollData=data}}
+            {{editor
+                enrichedDescription
+                target="data.details.description.value"
+                button=true
+                editable=editable
+            }}
         </div>
     </section>
 

--- a/src/templates/actors/parts/actor-biography.html
+++ b/src/templates/actors/parts/actor-biography.html
@@ -48,7 +48,12 @@
 
     <section class="bio-body">
         <div class="tab flexrow" data-group="biographyTabs" data-tab="biography">
-                {{editorPlus content=data.details.biography.value target="data.details.biography.value" button=true isOwner=isOwner editable=editable rolls=false rollData=data}}
+            {{editor
+                enrichedBiography
+                target="data.details.biography.value"
+                button=true
+                editable=editable
+            }}
         </div>
         <div class="tab" data-group="biographyTabs" data-tab="ecology">
             <div class="flexrow">
@@ -88,7 +93,12 @@
         </div>
         {{#if isGM}}
         <div class="tab flexrow" data-group="biographyTabs" data-tab="gmNotes">
-            {{editorPlus content=data.details.biography.gmNotes target="data.details.biography.gmNotes" button=true isOwner=isOwner editable=editable rolls=false rollData=data}}
+            {{editor
+                enrichedGMNotes
+                target="data.details.biography.gmNotes"
+                button=true
+                editable=editable
+            }}
         </div>
         {{/if}}
     </section>

--- a/src/templates/actors/starship-sheet-full.html
+++ b/src/templates/actors/starship-sheet-full.html
@@ -668,7 +668,12 @@
 
         {{!-- Biography Tab --}}
         <div class="tab biography flexcol" data-group="primary" data-tab="notes">
-            {{editorPlus content=data.details.notes target="data.details.notes" button=true isOwner=isOwner editable=editable rolls=false rollData=data}}
+            {{editor
+                enrichedDescription
+                target="data.details.notes"
+                button=true
+                editable=editable
+            }}
         </div>
     </section>
 

--- a/src/templates/actors/starship-sheet-limited.html
+++ b/src/templates/actors/starship-sheet-limited.html
@@ -10,7 +10,12 @@
     <!-- BODY -->
     <section class="sheet-body">
         <div class="tab biography">
-            {{editorPlus content=data.details.biography.value target="data.details.biography.value" button=true isOwner=isOwner editable=editable rolls=false rollData=data}}
+            {{editor
+                enrichedDescription
+                target="data.details.notes"
+                button=true
+                editable=editable
+            }}
         </div>
     </section>
 

--- a/src/templates/actors/vehicle-sheet-full.html
+++ b/src/templates/actors/vehicle-sheet-full.html
@@ -359,7 +359,12 @@
 
         {{!-- Notes Tab --}}
         <div class="tab biography flexcol" data-group="primary" data-tab="notes">
-            {{editorPlus content=data.details.description.value target="data.details.description.value" button=true isOwner=isOwner editable=editable rolls=false rollData=data}}
+            {{editor
+                enrichedDescription
+                target="data.details.description.value"
+                button=true
+                editable=editable
+            }}
         </div>
     </section>
 </form>

--- a/src/templates/actors/vehicle-sheet-limited.html
+++ b/src/templates/actors/vehicle-sheet-limited.html
@@ -10,8 +10,12 @@
     <!-- BODY -->
     <section class="sheet-body">
         <div class="tab biography">
-            {{editorPlus content=data.details.biography.value target="data.details.biography.value" button=true isOwner=isOwner editable=editable rolls=false rollData=data}}
-        </div>
+            {{editor
+                enrichedDescription
+                target="data.details.description.value"
+                button=true
+                editable=editable
+            }}
     </section>
 
     <!-- SIDEBAR -->

--- a/src/templates/items/parts/item-description.html
+++ b/src/templates/items/parts/item-description.html
@@ -57,14 +57,29 @@
 
         <section class="desc-body">
             <div class="tab flexrow" data-group="descriptionTabs" data-tab="description">
-                {{editorPlus content=itemData.description.value target="data.description.value" button=true isOwner=isOwner editable=editable rolls=false rollData=itemData}}
+                {{editor
+                    enrichedDescription
+                    target="data.description.value"
+                    button=true
+                    editable=editable
+                }}
             </div>
             <div class="tab flexrow" data-group="descriptionTabs" data-tab="descriptionShort">
-                {{editorPlus content=itemData.description.short target="data.description.short" button=true isOwner=isOwner editable=editable rolls=false rollData=itemData}}
+                {{editor
+                    enrichedShortDescription
+                    target="data.description.short"
+                    button=true
+                    editable=editable
+                }}
             </div>
             {{#if isGM}}
             <div class="tab flexrow" data-group="descriptionTabs" data-tab="gmNotes">
-                {{editorPlus content=itemData.description.gmNotes target="data.description.gmNotes" button=true isOwner=isOwner editable=editable rolls=false rollData=itemData}}
+                {{editor
+                    enrichedGMNotes
+                    target="data.description.gmNotes"
+                    button=true
+                    editable=editable
+                }}
             </div>
             {{/if}}
         </section>


### PR DESCRIPTION
Currently, text fields (such as the biography on an actor) always show the editor page, even after being saved. This merge fixes that by properly migrating to the new `editor` handlebar helper (and stripping out whatever `editorPlus` was, since the new `editor` handlebar helper does all `editorPlus` did). This is still using TinyMCE; we could migrate to ProseMirror if we want.