### PR TITLE
V10: Fix cook replacing journal pages with mystery man

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -350,7 +350,7 @@ async function cookWithOptions(options = { formattingCheck: true }) {
 
                 // Fix missing images
                 if (!jsonInput.img && !jsonInput.pages) {
-					// Skip if a journal
+                    // Skip if a journal
                     jsonInput.img = "icons/svg/mystery-man.svg";
                 }
                 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -349,7 +349,8 @@ async function cookWithOptions(options = { formattingCheck: true }) {
                 fixTokenName(jsonInput);
 
                 // Fix missing images
-                if (!jsonInput.img) {
+                if (!jsonInput.img && !jsonInput.pages) {
+					// Skip if a journal
                     jsonInput.img = "icons/svg/mystery-man.svg";
                 }
                 


### PR DESCRIPTION
Closes #740 

Currently, `cook` replaces a journal's content with a single image page with the mystery man icon. This is because cook sets `img` for any document without `img` (which journals in V10 by definition don't have) to mystery man. This merge changes that so that if the current document is a journal, it is skipped.