### PR TITLE
Partly fix character sheets not opening after changes to base.js

### DIFF
--- a/src/module/actor/sheet/base.js
+++ b/src/module/actor/sheet/base.js
@@ -74,7 +74,7 @@ export class ActorSheetSFRPG extends ActorSheet {
             config: CONFIG.SFRPG
         };
 
-        data.items = [...this.actor.items];
+        data.items = [...this.actor.items.values()];
         data.items.sort((a, b) => (a.sort || 0) - (b.sort || 0));
         data.labels = this.actor.labels || {};
         data.filters = this._filters;

--- a/src/module/actor/sheet/base.js
+++ b/src/module/actor/sheet/base.js
@@ -74,7 +74,7 @@ export class ActorSheetSFRPG extends ActorSheet {
             config: CONFIG.SFRPG
         };
 
-        data.items = this.actor.items;
+        data.items = [...this.actor.items];
         data.items.sort((a, b) => (a.sort || 0) - (b.sort || 0));
         data.labels = this.actor.labels || {};
         data.filters = this._filters;


### PR DESCRIPTION
Currently, opening a character sheet throws an error that `data.items.sort` is not a function, because `data.items` is not an array. This change makes `data.items` an array. (character sheets still refuse to open, because we're trying to assign to getters with `hasAttack` and `hasDamage`. Not sure how it worked before, but it throws now 🤷‍♂️)