### PR TITLE
Whisper chat cards for hidden combatants

### DIFF
--- a/src/module/combat/combat.js
+++ b/src/module/combat/combat.js
@@ -481,7 +481,7 @@ export class CombatSFRPG extends Combat {
         const chatData = {
             type: CONST.CHAT_MESSAGE_TYPES.OTHER,
             speaker: ChatMessage.getSpeaker({ actor: eventData.newCombatant, token: eventData.newCombatant?.token, alias: speakerName }),
-            whisper: eventData.newCombatant.hidden ? [game.user.data._id] : [],            
+            whisper: eventData.newCombatant.hidden ? [ChatMessage.getWhisperRecipients("GM")] : [],            
             content: html
         };
 

--- a/src/module/combat/combat.js
+++ b/src/module/combat/combat.js
@@ -481,7 +481,7 @@ export class CombatSFRPG extends Combat {
         const chatData = {
             type: CONST.CHAT_MESSAGE_TYPES.OTHER,
             speaker: ChatMessage.getSpeaker({ actor: eventData.newCombatant, token: eventData.newCombatant?.token, alias: speakerName }),
-            whisper: eventData.newCombatant.hidden ? [ChatMessage.getWhisperRecipients("GM")] : [],            
+            whisper: eventData.newCombatant.hidden ? ChatMessage.getWhisperRecipients("GM") : [],            
             content: html
         };
 

--- a/src/module/combat/combat.js
+++ b/src/module/combat/combat.js
@@ -481,6 +481,7 @@ export class CombatSFRPG extends Combat {
         const chatData = {
             type: CONST.CHAT_MESSAGE_TYPES.OTHER,
             speaker: ChatMessage.getSpeaker({ actor: eventData.newCombatant, token: eventData.newCombatant?.token, alias: speakerName }),
+            whisper: eventData.newCombatant.hidden ? [game.user.data._id] : [],            
             content: html
         };
 


### PR DESCRIPTION
When a token in the combat tracker is hidden and it's turn comes up in the initiative this will stop it from announcing it to everyone automatically by whispering to the GM.