### PR TITLE
Restore chat card descriptions

### DIFF
--- a/src/templates/chat/item-card.html
+++ b/src/templates/chat/item-card.html
@@ -5,13 +5,13 @@
     </header>
 
     <div class="card-content">
-        {{#if system.description.short}}
-            {{{system.description.short}}}
+        {{#if item.system.description.short}}
+            {{{item.system.description.short}}}
         {{else}}
-            {{{system.description.value}}}
+            {{{item.system.description.value}}}
         {{/if}}
-        {{#if system.materials.value}}
-        <p><strong>{{ localize "SFRPG.ChatReqMats" }}.</strong> {{system.materials.value}}</p>
+        {{#if item.system.materials.value}}
+        <p><strong>{{ localize "SFRPG.ChatReqMats" }}.</strong> {{item.system.materials.value}}</p>
         {{/if}}
     </div>
 


### PR DESCRIPTION
Currently, chat cards of items (assumably spells too) have no descriptions due to the recent migration.

(reverting it to `data` could've worked, but going through `item.system` does too; they're both on the chat card data object)