### PR TITLE
Damage Mitigation Fix

### DIFF
--- a/src/module/rules/actions/actor/calculate-damage-mitigation.js
+++ b/src/module/rules/actions/actor/calculate-damage-mitigation.js
@@ -13,7 +13,7 @@ function tryResolveModifier(modifier, rollContext) {
     if (result.hadError) {
         return 0;
     }
-    return result.result;
+    return result.total;
 }
 
 export default function (engine) {


### PR DESCRIPTION
Damage mitigation, and resistance, wouldn't process formula due to an issue with an incorrect reference to a variable in an object. This should fix that issue by referencing the right variable.