### PR TITLE
Allow damage sections to share radio selections as Damage Groups

### DIFF
--- a/src/lang/de.json
+++ b/src/lang/de.json
@@ -697,6 +697,7 @@
                 "Cold": "Kälte",
                 "Custom": "Custom",
                 "DamageGroup": "Damage Group {group}",
+                "DamageGroupTooltip": "If damage sections share a group, you may only enable one from that group when making a damage roll. You may freely enable/disable damage sections that lack a group.",
                 "Electricity": "Elektrizität",
                 "Fire": "Feuer",
                 "Force": "Energie",

--- a/src/lang/de.json
+++ b/src/lang/de.json
@@ -696,9 +696,11 @@
                 "Bludgeoning": "Wucht",
                 "Cold": "Kälte",
                 "Custom": "Custom",
+                "DamageGroup": "Damage Group {group}",
                 "Electricity": "Elektrizität",
                 "Fire": "Feuer",
                 "Force": "Energie",
+                "GrouplessDamage": "Groupless Damage",
                 "Hint": "This is a list of damage types that apply to this damage roll.",
                 "Nonlethal": "Nichttödlich",
                 "Operators": {

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -696,9 +696,11 @@
                 "Bludgeoning": "Bludgeoning",
                 "Cold": "Cold",
                 "Custom": "Custom",
+                "DamageGroup": "Damage Group {group}",
                 "Electricity": "Electricity",
                 "Fire": "Fire",
                 "Force": "Force",
+                "GrouplessDamage": "Groupless Damage",
                 "Hint": "This is a list of the different damage sections that are available for this damage roll.",
                 "Nonlethal": "Nonlethal",
                 "Operators": {

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -697,6 +697,7 @@
                 "Cold": "Cold",
                 "Custom": "Custom",
                 "DamageGroup": "Damage Group {group}",
+                "DamageGroupTooltip": "If damage sections share a group, you may only enable one from that group when making a damage roll. You may freely enable/disable damage sections that lack a group.",
                 "Electricity": "Electricity",
                 "Fire": "Fire",
                 "Force": "Force",

--- a/src/lang/fr.json
+++ b/src/lang/fr.json
@@ -697,6 +697,7 @@
                 "Cold": "Froid",
                 "Custom": "Personnalisé",
                 "DamageGroup": "Damage Group {group}",
+                "DamageGroupTooltip": "If damage sections share a group, you may only enable one from that group when making a damage roll. You may freely enable/disable damage sections that lack a group.",
                 "Electricity": "Electricité",
                 "Fire": "Feu",
                 "Force": "Force",

--- a/src/lang/fr.json
+++ b/src/lang/fr.json
@@ -696,9 +696,11 @@
                 "Bludgeoning": "Contondant",
                 "Cold": "Froid",
                 "Custom": "Personnalisé",
+                "DamageGroup": "Damage Group {group}",
                 "Electricity": "Electricité",
                 "Fire": "Feu",
                 "Force": "Force",
+                "GrouplessDamage": "Groupless Damage",
                 "Hint": "Liste de types de dégâts qui s'appliquent sur ce jet de dégâts.",
                 "Nonlethal": "Non létal",
                 "Operators": {

--- a/src/lang/it.json
+++ b/src/lang/it.json
@@ -697,6 +697,7 @@
                 "Cold": "Freddo",
                 "Custom": "Custom",
                 "DamageGroup": "Damage Group {group}",
+                "DamageGroupTooltip": "If damage sections share a group, you may only enable one from that group when making a damage roll. You may freely enable/disable damage sections that lack a group.",
                 "Electricity": "Elettrico",
                 "Fire": "Fuoco",
                 "Force": "Forza",

--- a/src/lang/it.json
+++ b/src/lang/it.json
@@ -696,9 +696,11 @@
                 "Bludgeoning": "Contundente",
                 "Cold": "Freddo",
                 "Custom": "Custom",
+                "DamageGroup": "Damage Group {group}",
                 "Electricity": "Elettrico",
                 "Fire": "Fuoco",
                 "Force": "Forza",
+                "GrouplessDamage": "Groupless Damage",
                 "Hint": "This is a list of damage types that apply to this damage roll.",
                 "Nonlethal": "Non Letale",
                 "Operators": {

--- a/src/lang/ja.json
+++ b/src/lang/ja.json
@@ -697,6 +697,7 @@
                 "Cold": "[冷気]",
                 "Custom": "Custom",
                 "DamageGroup": "Damage Group {group}",
+                "DamageGroupTooltip": "If damage sections share a group, you may only enable one from that group when making a damage roll. You may freely enable/disable damage sections that lack a group.",
                 "Electricity": "[電気]",
                 "Fire": "[火]",
                 "Force": "[力場]",

--- a/src/lang/ja.json
+++ b/src/lang/ja.json
@@ -696,9 +696,11 @@
                 "Bludgeoning": "[殴打]",
                 "Cold": "[冷気]",
                 "Custom": "Custom",
+                "DamageGroup": "Damage Group {group}",
                 "Electricity": "[電気]",
                 "Fire": "[火]",
                 "Force": "[力場]",
+                "GrouplessDamage": "Groupless Damage",
                 "Hint": "This is a list of damage types that apply to this damage roll.",
                 "Nonlethal": "Nonlethal",
                 "Operators": {

--- a/src/lang/pt-BR.json
+++ b/src/lang/pt-BR.json
@@ -696,9 +696,11 @@
                 "Bludgeoning": "Contusão",
                 "Cold": "Frio",
                 "Custom": "Custom",
+                "DamageGroup": "Damage Group {group}",
                 "Electricity": "Eletricidade",
                 "Fire": "Fogo",
                 "Force": "Poder",
+                "GrouplessDamage": "Groupless Damage",
                 "Hint": "This is a list of damage sections that apply to this damage roll.",
                 "Nonlethal": "Não letal",
                 "Operators": {

--- a/src/lang/pt-BR.json
+++ b/src/lang/pt-BR.json
@@ -697,6 +697,7 @@
                 "Cold": "Frio",
                 "Custom": "Custom",
                 "DamageGroup": "Damage Group {group}",
+                "DamageGroupTooltip": "If damage sections share a group, you may only enable one from that group when making a damage roll. You may freely enable/disable damage sections that lack a group.",
                 "Electricity": "Eletricidade",
                 "Fire": "Fogo",
                 "Force": "Poder",

--- a/src/less/apps.less
+++ b/src/less/apps.less
@@ -87,7 +87,7 @@ a.content-link, a.inline-roll {
   }
 
   // Checkbox Labels
-  label.checkbox {
+  label.checkbox, label.radio {
     flex: auto;
     margin: 0;
     line-height: 20px;
@@ -95,9 +95,15 @@ a.content-link, a.inline-roll {
     text-align: right;
     input[type="checkbox"] {
       height: auto;
-      margin: 0 5px 0;
+      margin: 0 3px;
       position: relative;
       top: 3px;
+    }
+    input[type="radio"] {
+        height: auto;
+        margin: 0 4px;
+        position: relative;
+        top: 3px;
     }
   }
 
@@ -139,11 +145,11 @@ a.content-link, a.inline-roll {
     border-top: @borderGroove;
     border-bottom: @borderGroove;
   }
-  
+
   .form-rest {
     margin-bottom: 7px
   }
-  
+
   .form-repair {
     margin-bottom: 7px
   }
@@ -365,7 +371,7 @@ a.content-link, a.inline-roll {
     flex: 0 0 @navHeight;
     margin-bottom: 5px;
     .exo2();
-    
+
     .item {
       height: 30px;
       line-height: 32px;

--- a/src/module/apps/roll-dialog.js
+++ b/src/module/apps/roll-dialog.js
@@ -227,7 +227,7 @@ export default class RollDialog extends Dialog {
     }
 
     _onDamageSectionRadio(event) {
-        let damageGroups = Object.entries(this.damageGroups).map(i => i[1]);
+        let damageGroups = this.damageGroups;
 
         const selectorGroup = event.currentTarget.name;
         const selectorId = event.currentTarget.id;
@@ -242,7 +242,7 @@ export default class RollDialog extends Dialog {
     }
 
     _onDamageSectionCheckbox(event) {
-        let damageGroups = Object.entries(this.damageGroups).map(i => i[1]);
+        let damageGroups = this.damageGroups;
 
         const selectorGroup = event.currentTarget.name;
         const selectorId = event.currentTarget.id;
@@ -250,7 +250,6 @@ export default class RollDialog extends Dialog {
         const selectedGroup = damageGroups[selectorGroup];
 
         selectedGroup[selectorId].enabled = event.currentTarget.checked;
-        console.log(damageGroups);
     }
 
     submit(button) {

--- a/src/module/item/item.js
+++ b/src/module/item/item.js
@@ -87,7 +87,7 @@ export class ItemSFRPG extends Mix(Item).with(ItemActivationMixin, ItemCapacityM
             labels.eac = data.armor.eac ? `${data.armor.eac} EAC` : "";
             labels.kac = data.armor.kac ? `${data.armor.kac} KAC` : "";
         }
-        
+
         // Activated Items
         if (data.hasOwnProperty("activation")) {
 
@@ -96,13 +96,13 @@ export class ItemSFRPG extends Mix(Item).with(ItemActivationMixin, ItemCapacityM
             if (act) {
                 if (act.type === "none"){
                     labels.activation = game.i18n.localize("SFRPG.AbilityActivationTypesNoneButton");
-                }                 
+                }
                 else {
                     labels.activation = [
                         act.cost,
                         C.abilityActivationTypes[act.type]
                     ].filterJoin(" ");
-                }                
+                }
             }
 
             let tgt = data.target || {};
@@ -155,12 +155,12 @@ export class ItemSFRPG extends Mix(Item).with(ItemActivationMixin, ItemCapacityM
     }
 
     /**
-     * Check to ensure that this item has a modifiers data object set, if not then set it. 
+     * Check to ensure that this item has a modifiers data object set, if not then set it.
      * These will always be needed from hence forth, so we'll just make sure that they always exist.
-     * 
+     *
      * @param {Object}      data The item data to check against.
      * @param {String|Null} prop A specific property name to check.
-     * 
+     *
      * @returns {Object}         The modified data object with the modifiers data object added.
      */
     _ensureHasModifiers(data, prop = null) {
@@ -189,7 +189,7 @@ export class ItemSFRPG extends Mix(Item).with(ItemActivationMixin, ItemCapacityM
         }
 
         this.updateSource(updates)
-        
+
         return super._preCreate(data, options, user)
     };
 
@@ -304,11 +304,11 @@ export class ItemSFRPG extends Mix(Item).with(ItemActivationMixin, ItemCapacityM
             user: game.user.id,
             type: CONST.CHAT_MESSAGE_TYPES.OTHER,
             content: html,
-            flags: { 
-                level: this.system.level, 
+            flags: {
+                level: this.system.level,
                 core: {
                     canPopout: true
-                } 
+                }
             },
             rollMode: rollMode,
             speaker: token ? ChatMessage.getSpeaker({token: token}) : ChatMessage.getSpeaker({actor: this.actor})
@@ -401,7 +401,7 @@ export class ItemSFRPG extends Mix(Item).with(ItemActivationMixin, ItemCapacityM
         const containedItems = [];
         while (itemsToTest.length > 0) {
             const itemToTest = itemsToTest.shift();
-            
+
             const contents = itemToTest?.system?.container?.contents;
             if (contents) {
                 for (const content of contents) {
@@ -657,7 +657,7 @@ export class ItemSFRPG extends Mix(Item).with(ItemActivationMixin, ItemCapacityM
     /**
      * Place an attack roll using an item (weapon, feat, spell, or equipment)
      * Rely upon the DiceSFRPG.d20Roll logic for the core implementation
-     * 
+     *
      * Supported options:
      * disableDamageAfterAttack: If the system setting "Roll damage with attack" is enabled, setting this flag to true will disable this behavior.
      * disableDeductAmmo: Setting this to true will prevent ammo being deducted if applicable.
@@ -679,11 +679,11 @@ export class ItemSFRPG extends Mix(Item).with(ItemActivationMixin, ItemCapacityM
         if (!abl && (this.actor.type === "npc" || this.actor.type === "npc2")) abl = "";
         else if (!abl && (this.type === "spell")) abl = actorData.attributes.spellcasting || "int";
         else if (itemData.properties?.operative && actorData.abilities.dex.value > actorData.abilities.str.value) abl = "dex"
-        else if (!abl) abl = "str";        
+        else if (!abl) abl = "str";
 
         // Define Roll parts
         const parts = [];
-        
+
         if (Number.isNumeric(itemData.attackBonus) && itemData.attackBonus !== 0) parts.push("@item.attackBonus");
         if (abl) parts.push(`@abilities.${abl}.mod`);
         if (["character", "drone"].includes(this.actor.type)) parts.push("@attributes.baseAttackBonus.value");
@@ -784,12 +784,12 @@ export class ItemSFRPG extends Mix(Item).with(ItemActivationMixin, ItemCapacityM
         if (availableCapacity < usage) {
             ui.notifications.warn(game.i18n.format("SFRPG.ItemNoAmmo", {name: this.name}));
         }
-        
+
         const rollContext = RollContext.createItemRollContext(this, this.actor, {itemData: itemData});
 
         /** Create additional modifiers. */
         const additionalModifiers = duplicate(SFRPG.globalAttackRollModifiers);
-        
+
         /** Apply bonus rolled mods from relevant attack roll formula modifiers. */
         for (const rolledMod of rolledMods) {
             additionalModifiers.push({
@@ -824,7 +824,7 @@ export class ItemSFRPG extends Mix(Item).with(ItemActivationMixin, ItemCapacityM
      * @param {Html} html The html from the dailog
      * @param {Array} parts The parts of the roll
      * @param {Object} data The data
-     * 
+     *
      * Supported options:
      * disableDamageAfterAttack: If the system setting "Roll damage with attack" is enabled, setting this flag to true will disable this behavior.
      * disableDeductAmmo: Setting this to true will prevent ammo being deducted if applicable.
@@ -863,7 +863,7 @@ export class ItemSFRPG extends Mix(Item).with(ItemActivationMixin, ItemCapacityM
     /**
      * Place an attack roll for a starship using an item.
      * @param {Object} options Options to pass to the attack roll
-     * 
+     *
      * Supported options:
      * disableDamageAfterAttack: If the system setting "Roll damage with attack" is enabled, setting this flag to true will disable this behavior.
      * disableDeductAmmo: Setting this to true will prevent ammo being deducted if applicable.
@@ -878,7 +878,7 @@ export class ItemSFRPG extends Mix(Item).with(ItemActivationMixin, ItemCapacityM
             parts = ["max(@gunner.attributes.baseAttackBonus.value, @gunner.skills.pil.ranks)", "@gunner.abilities.dex.mod"]
         };
         const title = game.settings.get('sfrpg', 'useCustomChatCards') ? game.i18n.format("SFRPG.Rolls.AttackRoll") : game.i18n.format("SFRPG.Rolls.AttackRollFull", {name: this.name});
-        
+
         if (this.hasCapacity()) {
             if (this.getCurrentCapacity() <= 0) {
                 ui.notifications.warn(game.i18n.format("SFRPG.StarshipSheet.Weapons.NoCapacity"));
@@ -1024,10 +1024,9 @@ export class ItemSFRPG extends Mix(Item).with(ItemActivationMixin, ItemCapacityM
         for (const part of parts) {
             part.isDamageSection = true;
         }
-        
+
         const acceptedModifiers = [SFRPGEffectType.ALL_DAMAGE];
-        
-        console.log(this.system.actionType);
+
         if (["msak", "rsak"].includes(this.system.actionType) || (this.type === "spell"  && this.system.actionType === "save")) {
             acceptedModifiers.push(SFRPGEffectType.SPELL_DAMAGE);
         } else if (this.system.actionType === "rwak") {
@@ -1114,16 +1113,16 @@ export class ItemSFRPG extends Mix(Item).with(ItemActivationMixin, ItemCapacityM
                 title = game.i18n.format("SFRPG.Rolls.DamageRollFull", {name: this.name});
             }
         }
-        
+
         const rollContext = RollContext.createItemRollContext(this, this.actor, {itemData: itemData, ownerData: rollData});
 
         /** Create additional modifiers. */
         const additionalModifiers = [];
-        
+
         if (itemData.properties?.archaic && isWeapon) {
             additionalModifiers.push({bonus: { name: game.i18n.format("SFRPG.WeaponPropertiesArchaic"), modifier: "-5", enabled: true, notes: game.i18n.format("SFRPG.WeaponPropertiesArchaicTooltip") } });
         }
-        
+
         for (const rolledMod of rolledMods) {
             additionalModifiers.push({
                 bonus: rolledMod
@@ -1282,7 +1281,7 @@ export class ItemSFRPG extends Mix(Item).with(ItemActivationMixin, ItemCapacityM
 
         // Define Roll Data
         const rollContext = RollContext.createItemRollContext(this, this.actor, {itemData: itemData});
-    
+
         const title = game.i18n.localize(`SFRPG.Items.Action.OtherFormula`);
         const rollResult = await DiceSFRPG.createRoll({
             rollContext: rollContext,
@@ -1323,7 +1322,7 @@ export class ItemSFRPG extends Mix(Item).with(ItemActivationMixin, ItemCapacityM
         if (itemData.actionType && itemData.actionType !== "save") {
             options = options || {};
             options.flavorOverride = game.i18n.format("SFRPG.Items.Consumable.UseChatMessage", {consumableName: this.name});
-            
+
             const result = await this.rollDamage({}, options);
             if (!result[0]) {
                 // Roll was cancelled, don't consume.
@@ -1332,7 +1331,7 @@ export class ItemSFRPG extends Mix(Item).with(ItemActivationMixin, ItemCapacityM
         } else {
             let htmlOptions = { secrets: this.actor?.isOwner || true, rollData: this };
             htmlOptions.rollData.owner = this.actor?.system;
-    
+
             // Basic template rendering data
             const token = this.actor.token;
             const templateData = {
@@ -1351,7 +1350,7 @@ export class ItemSFRPG extends Mix(Item).with(ItemActivationMixin, ItemCapacityM
             const html = await renderTemplate(template, templateData);
 
             const flavor = game.i18n.format("SFRPG.Items.Consumable.UseChatMessage", {consumableName: this.name});
-    
+
             // Basic chat message data
             const chatData = {
                 user: game.user.id,
@@ -1361,7 +1360,7 @@ export class ItemSFRPG extends Mix(Item).with(ItemActivationMixin, ItemCapacityM
                 flags: { level: this.system.level },
                 speaker: token ? ChatMessage.getSpeaker({token: token}) : ChatMessage.getSpeaker({actor: this.actor})
             };
-    
+
             // Toggle default roll mode
             const rollMode = game.settings.get("core", "rollMode");
             if (["gmroll", "blindroll"].includes(rollMode)) {
@@ -1370,7 +1369,7 @@ export class ItemSFRPG extends Mix(Item).with(ItemActivationMixin, ItemCapacityM
             if (rollMode === "blindroll") {
                 chatData["blind"] = true;
             }
-    
+
             // Create the chat message
             ChatMessage.create(chatData, { displaySheet: false });
         }
@@ -1576,10 +1575,10 @@ export class ItemSFRPG extends Mix(Item).with(ItemActivationMixin, ItemCapacityM
         if (controlled.length === 1) return controlled[0].actor;
         else throw new Error(`You must designate a specific Token as the roll target`);
     }
-    
+
     /**
      * Add a modifier to this actor.
-     * 
+     *
      * @param {Object}        data               The data needed to create the modifier
      * @param {String}        data.name          The name of this modifier. Used to identify the modfier.
      * @param {Number|String} data.modifier      The modifier value.
@@ -1595,15 +1594,15 @@ export class ItemSFRPG extends Mix(Item).with(ItemActivationMixin, ItemCapacityM
      * @param {String|null}   data.id            Override the randomly generated id with this.
      */
     async addModifier({
-        name = "", 
-        modifier = 0, 
-        type = SFRPGModifierTypes.UNTYPED, 
-        modifierType = SFRPGModifierType.CONSTANT, 
+        name = "",
+        modifier = 0,
+        type = SFRPGModifierTypes.UNTYPED,
+        modifierType = SFRPGModifierType.CONSTANT,
         effectType = SFRPGEffectType.SKILL,
         subtab = "misc",
-        valueAffected = "", 
-        enabled = true, 
-        source = "", 
+        valueAffected = "",
+        enabled = true,
+        source = "",
         notes = "",
         condition = "",
         id = null
@@ -1633,18 +1632,18 @@ export class ItemSFRPG extends Mix(Item).with(ItemActivationMixin, ItemCapacityM
 
     /**
      * Delete a modifier for this Actor.
-     * 
+     *
      * @param {String} id The id for the modifier to delete
      */
     async deleteModifier(id) {
         const modifiers = this.system.modifiers.filter(mod => mod._id !== id);
-        
+
         await this.update({"system.modifiers": modifiers});
     }
 
     /**
      * Edit a modifier for an Actor.
-     * 
+     *
      * @param {String} id The id for the modifier to edit
      */
     editModifier(id) {
@@ -1660,28 +1659,28 @@ export async function _onScalingCantripsSettingChanges() {
     const d6scaling = "lookupRange(@details.cl.value,1,7,2,10,3,13,4,15,5,17,7,19,9)d6+lookupRange(@details.cl.value,0,3,floor(@details.level.value/2))";
     const npcd3scaling = "lookupRange(@details.cr,1,7,2,10,3,13,4,15,5,17,7,19,9)d(lookupRange(@details.cr,3,7,4))+lookupRange(@details.cr,0,3,floor(@details.cr/2))";
     const npcd6scaling = "lookupRange(@details.cr,1,7,2,10,3,13,4,15,5,17,7,19,9)d6+lookupRange(@details.cr,0,3,floor(@details.cr/2))";
-    
+
     const setting = (game.settings.get("sfrpg", "scalingCantrips"));
     let count = 0;
     let actorCount = 0;
-    
+
     for (let actor of game.actors.contents) {
         const isNPC = ['npc','npc2'].includes(actor.type);
-        
+
         let updates = [];
         let params = await (actor.items).filter(i => i.system.scaling?.d3 || i.system.scaling?.d6);
         if (params.length > 0) {
             updates = params.map( (currentValue) => {
                 return {_id: currentValue.id, "system.damage.parts": currentValue.system.damage.parts, scaling: currentValue.system.scaling};
             })
-        
+
             for (let currentValue of updates) {
                 if (currentValue.scaling.d3) {
                     currentValue['system.damage.parts'][0].formula = (setting) ? ((isNPC) ? npcd3scaling : d3scaling) : "1d3";
                 } else if (currentValue.scaling.d6) {
                     currentValue['system.damage.parts'][0].formula = (setting) ? ((isNPC) ? npcd6scaling : d6scaling) : "1d6";
                 }
-                
+
                 delete currentValue.scaling;
             }
         await actor.updateEmbeddedDocuments("Item", updates);
@@ -1699,23 +1698,23 @@ export async function _onScalingCantripDrop(addedItem, targetActor) {
     const d6scaling = "lookupRange(@details.cl.value,1,7,2,10,3,13,4,15,5,17,7,19,9)d6+lookupRange(@details.cl.value,0,3,floor(@details.level.value/2))";
     const npcd3scaling = "lookupRange(@details.cr,1,7,2,10,3,13,4,15,5,17,7,19,9)d(lookupRange(@details.cr,3,7,4))+lookupRange(@details.cr,0,3,floor(@details.cr/2))";
     const npcd6scaling = "lookupRange(@details.cr,1,7,2,10,3,13,4,15,5,17,7,19,9)d6+lookupRange(@details.cr,0,3,floor(@details.cr/2))";
-    
+
     const isNPC = ['npc','npc2'].includes(targetActor.actor.type);
-    
+
     if (addedItem.system.scaling?.d3) {
-    
+
         const updates = duplicate(addedItem.system.damage.parts);
         updates[0].formula = (isNPC) ? npcd3scaling : d3scaling;
-        
+
         await addedItem.update({"system.damage.parts": updates});
         console.log(`Starfinder | Updated ${addedItem.name} to use the ${ (isNPC) ? 'NPC ' : ""}d3 scaling formula.`);
-        
+
     } else if (addedItem.system.scaling?.d6) {
-        
+
         const updates = duplicate(addedItem.system.damage.parts);
         updates[0].formula = (isNPC) ? npcd6scaling : d6scaling;
-        
+
         await addedItem.update({"system.damage.parts": updates});
         console.log(`Starfinder | Updated ${addedItem.name} to use the ${ (isNPC) ? "NPC " : ""}d6 scaling formula.`);
-    }  
+    }
 }

--- a/src/module/item/sheet.js
+++ b/src/module/item/sheet.js
@@ -1,4 +1,4 @@
-import { SFRPG } from "../config.js"
+import { SFRPG } from "../config.js";
 import { RPC } from "../rpc.js";
 
 const itemSizeArmorClassModifier = {
@@ -136,7 +136,7 @@ export class ItemSheetSFRPG extends ItemSheet {
                 data.placeholders.savingThrow = data.placeholders.savingThrow || {};
                 data.placeholders.savingThrow.formula = `@itemLevel + @owner.abilities.dex.mod`;
                 data.placeholders.savingThrow.value = data.placeholders.savingThrow.value ?? 10;
-                
+
                 this.item.flags.placeholders = data.placeholders;
                 this._computeSavingThrowValue(itemLevel, data.placeholders.savingThrow.formula)
                     .then((total) => this.onPlaceholderUpdated(this.item, total))
@@ -155,7 +155,7 @@ export class ItemSheetSFRPG extends ItemSheet {
                 data.placeholders.savingThrow = data.placeholders.savingThrow || {};
                 data.placeholders.savingThrow.formula = `@itemLevel + @owner.abilities.dex.mod`;
                 data.placeholders.savingThrow.value = data.placeholders.savingThrow.value ?? 10;
-                
+
                 this.item.flags.placeholders = data.placeholders;
                 this._computeSavingThrowValue(itemLevel, data.placeholders.savingThrow.formula)
                     .then((total) => this.onPlaceholderUpdated(this.item, total))
@@ -230,7 +230,7 @@ export class ItemSheetSFRPG extends ItemSheet {
         {
             // Only systems which can be activated have an activation status
             if (this.document.canBeActivated() === false) {
-                return ""
+                return "";
             }
 
             return this.document.isActive() ? "Activated" : "Not Activated";
@@ -258,15 +258,15 @@ export class ItemSheetSFRPG extends ItemSheet {
                     name: CONFIG.SFRPG.weaponProperties[e[0]],
                     tooltip: CONFIG.SFRPG.weaponPropertiesTooltips[e[0]]
                 })
-            )
-        );
+                )
+            );
         } else if (item.type === "spell") {
             const desc = (Object.entries(itemData.descriptors)).filter(e => e[1] === true).map(e => ({
-                    name: CONFIG.SFRPG.descriptors[e[0]],
-                    tooltip: (CONFIG.SFRPG.descriptorsTooltips[e[0]]) ? CONFIG.SFRPG.descriptorsTooltips[e[0]] : null
-                })
+                name: CONFIG.SFRPG.descriptors[e[0]],
+                tooltip: (CONFIG.SFRPG.descriptorsTooltips[e[0]]) ? CONFIG.SFRPG.descriptorsTooltips[e[0]] : null
+            })
             );
-           
+
             props.push(
                 {name: labels.components, tooltip: null},
                 {name: labels.materials, tooltip: null},
@@ -274,7 +274,7 @@ export class ItemSheetSFRPG extends ItemSheet {
                 itemData.sr ? {name: "Spell Resistence", tooltip: null} : null,
                 itemData.dismissible ? {name: "Dismissible", tooltip: null} : null,
                 ...desc
-            )
+            );
         } else if (item.type === "equipment") {
             props.push({
                 name: CONFIG.SFRPG.armorTypes[itemData.armor.type],
@@ -286,14 +286,14 @@ export class ItemSheetSFRPG extends ItemSheet {
             });
         } else if (item.type === "feat") {
             const desc = (Object.entries(itemData.descriptors)).filter(e => e[1] === true).map(e => ({
-                    name: CONFIG.SFRPG.descriptors[e[0]],
-                    tooltip: (CONFIG.SFRPG.descriptorsTooltips[e[0]]) ? CONFIG.SFRPG.descriptorsTooltips[e[0]] : null
-                })
+                name: CONFIG.SFRPG.descriptors[e[0]],
+                tooltip: (CONFIG.SFRPG.descriptorsTooltips[e[0]]) ? CONFIG.SFRPG.descriptorsTooltips[e[0]] : null
+            })
             );
-            
+
             props.push(
-            {name: labels.featType, tooltip: null},
-            ...desc
+                {name: labels.featType, tooltip: null},
+                ...desc
             );
         } else if (item.type === "starshipWeapon") {
             props.push({
@@ -315,7 +315,7 @@ export class ItemSheetSFRPG extends ItemSheet {
                 name: game.i18n.format("SFRPG.Items.Shield.ACP", { acp: item.acp.signedString() }),
                 tooltip: null
             });
-            
+
             const wieldedBonus = itemData.proficient ? (itemData.bonus.wielded || 0) : 0;
             const alignedBonus = itemData.proficient ? (itemData.bonus.aligned || 0) : 0;
             props.push({
@@ -334,7 +334,7 @@ export class ItemSheetSFRPG extends ItemSheet {
                 let sensesDeliminated = item.senses.senses.split(",");
                 for (let index = 0; index < sensesDeliminated.length; index++)
                 {
-                    var sense = sensesDeliminated[index];
+                    let sense = sensesDeliminated[index];
                     props.push(sense);
                 }
             }
@@ -355,7 +355,7 @@ export class ItemSheetSFRPG extends ItemSheet {
                 {name: labels.range, tooltip: null},
                 {name: labels.target, tooltip: null},
                 {name: labels.duration, tooltip: null}
-            )
+            );
         }
         return props.filter(p => !!p && !!p.name);
     }
@@ -407,20 +407,23 @@ export class ItemSheetSFRPG extends ItemSheet {
         let damage = Object.entries(formData).filter(e => e[0].startsWith("system.damage.parts"));
         formData["system.damage.parts"] = damage.reduce((arr, entry) => {
             let [i, key, type] = entry[0].split(".").slice(3);
-            if (!arr[i]) arr[i] = { name: "", formula: "", types: {} };
+            if (!arr[i]) arr[i] = { name: "", formula: "", types: {}, group: null };
 
             switch (key) {
-                case 'name':
-                    arr[i].name = entry[1];
-                    break;
-                case 'formula':
-                    arr[i].formula = entry[1];
-                    break;
-                case 'types':
-                    if (type) arr[i].types[type] = entry[1];
-                    break;
+            case 'name':
+                arr[i].name = entry[1];
+                break;
+            case 'formula':
+                arr[i].formula = entry[1];
+                break;
+            case 'types':
+                if (type) arr[i].types[type] = entry[1];
+                break;
+            case 'group':
+                arr[i].group = entry[1];
+                break;
             }
-            
+
             return arr;
         }, []);
 
@@ -431,14 +434,14 @@ export class ItemSheetSFRPG extends ItemSheet {
             if (!arr[i]) arr[i] = { formula: "", types: {}, operator: "" };
 
             switch (key) {
-                case 'formula':
-                    arr[i].formula = entry[1];
-                    break;
-                case 'types':
-                    if (type) arr[i].types[type] = entry[1];
-                    break;
+            case 'formula':
+                arr[i].formula = entry[1];
+                break;
+            case 'types':
+                if (type) arr[i].types[type] = entry[1];
+                break;
             }
-            
+
             return arr;
         }, []);
 
@@ -539,7 +542,7 @@ export class ItemSheetSFRPG extends ItemSheet {
             const damage = this.item.system.damage;
             return this.item.update({
                 "system.damage.parts": damage.parts.concat([
-                    { name: "", formula: "", types: {} }
+                    { name: "", formula: "", types: {}, group: null }
                 ])
             });
         }
@@ -580,7 +583,7 @@ export class ItemSheetSFRPG extends ItemSheet {
 
     /**
      * Add a modifer to this item.
-     * 
+     *
      * @param {Event} event The originating click event
      */
     _onModifierCreate(event) {
@@ -594,7 +597,7 @@ export class ItemSheetSFRPG extends ItemSheet {
 
     /**
      * Delete a modifier from the item.
-     * 
+     *
      * @param {Event} event The originating click event
      */
     async _onModifierDelete(event) {
@@ -607,7 +610,7 @@ export class ItemSheetSFRPG extends ItemSheet {
 
     /**
      * Edit a modifier for an item.
-     * 
+     *
      * @param {Event} event The orginating click event
      */
     _onModifierEdit(event) {
@@ -621,7 +624,7 @@ export class ItemSheetSFRPG extends ItemSheet {
 
     /**
      * Toggle a modifier to be enabled or disabled.
-     * 
+     *
      * @param {Event} event The originating click event
      */
     async _onToggleModifierEnabled(event) {
@@ -831,16 +834,16 @@ export class ItemSheetSFRPG extends ItemSheet {
 
         const attr = event.currentTarget.dataset.edit;
         const fp = new FilePicker({
-          type: "image",
-          current: currentImage,
-          callback: path => {
-            visualization[visualizationIndex].image = path;
-            this.item.update({
-                "system.combatTracker.visualization": visualization
-            });
-          },
-          top: this.position.top + 40,
-          left: this.position.left + 10
+            type: "image",
+            current: currentImage,
+            callback: path => {
+                visualization[visualizationIndex].image = path;
+                this.item.update({
+                    "system.combatTracker.visualization": visualization
+                });
+            },
+            top: this.position.top + 40,
+            left: this.position.left + 10
         });
         return fp.browse();
     }

--- a/src/templates/chat/roll-dialog.html
+++ b/src/templates/chat/roll-dialog.html
@@ -36,28 +36,32 @@
 </div>
 
 <div class="damage-type-selector-list">
-    <h3 class="damage-type-list-title noborder" data-tippy-content="{{localize "SFRPG.Damage.Types.Hint"}}">{{localize "SFRPG.Damage.Types.Title"}}</h3>
+    {{#if (gt (length damageGroups) 1) }}
+        <h3 class="damage-type-list-title noborder" data-tippy-content="{{localize "SFRPG.Damage.Types.Hint"}}">{{localize "SFRPG.Damage.Types.Title"}}</h3>
+    {{/if}}
     {{#each damageGroups as |group i|}}
         <h3 class="damage-type-list-title noborder" data-tippy-content="{{localize "SFRPG.Damage.Types.Hint"}}">
-            {{#if (eq (i) "null")}}
-                Groupless Damage
-            {{else}}
-                Damage Group {{i}}
+            {{#if (or (gt (length ../damageGroups) 1)(gt (length group) 1)) }}
+                {{#if (or (eq (i) "null")(eq (i) "undefined"))}}
+                    {{localize "SFRPG.Damage.Types.GrouplessDamage"}}
+                {{else}}
+                    {{localize "SFRPG.Damage.Types.DamageGroup" group=i}}
+                {{/if}}
             {{/if}}
             </h3>
 
         <div class="damage-type-label">
             {{#each this as |part j|}}
-                {{#if (and ../../hasDamageTypes (gt (length group) 1) (not (eq (i) "null"))) }}
+                {{#if (and ../../hasDamageTypes (gt (length group) 1) (not (or (eq (i) "null")(eq (i) "undefined"))) ) }}
                     <p class="damage-type">
-                        <label class="checkbox">
+                        <label class="radio">
                             <input class="damageSection" type="radio" name="{{part.group}}" id={{@index}} {{checked part.enabled}}/>{{part.name}}: {{part.formula}} {{part.type}}
                         </label>
                     </p>
-                {{else}}
+                {{else if (or (gt (length ../../damageGroups) 1)(gt (length group) 1)) }}
                     <p class="damage-type">
                         <label class="checkbox">
-                            <input class="damageSection" type="checkbox" name="{{@../index}}" id={{@index}} {{checked part.enabled}}/>{{part.name}}: {{part.formula}} {{part.type}}
+                            <input class="damageSection" type="checkbox" name="{{i}}" id={{@index}} {{checked part.enabled}}/>{{part.name}}: {{part.formula}} {{part.type}}
                         </label>
                     </p>
                 {{/if}}

--- a/src/templates/chat/roll-dialog.html
+++ b/src/templates/chat/roll-dialog.html
@@ -35,20 +35,40 @@
     </form>
 </div>
 
-{{#if (and hasDamageTypes (gt (length damageSections) 1))}}
 <div class="damage-type-selector-list">
     <h3 class="damage-type-list-title noborder" data-tippy-content="{{localize "SFRPG.Damage.Types.Hint"}}">{{localize "SFRPG.Damage.Types.Title"}}</h3>
-    <div class="damage-type-label">
-        {{#each damageSections as |part i|}}
-        <p class="damage-type">
-            <label class="checkbox">
-                <input class="damageSection" type="checkbox" name="{{i}}" {{checked part.enabled}} />{{part.name}}: {{part.formula}} {{part.type}}
-            </label>
-        </p>
-        {{/each}}
+    {{#each damageGroups as |group i|}}
+        {{#if (or (gt (length ../damageGroups) 1)(eq (i) "null") )}}
+            <h3 class="damage-type-list-title noborder" data-tippy-content="{{localize "SFRPG.Damage.Types.Hint"}}">
+                {{#if (eq (i) "null")}}
+                    Groupless Damage
+                {{else}}
+                    Damage Group {{i}}
+                {{/if}}
+                </h3>
+
+            <div class="damage-type-label">
+                {{#each this as |part j|}}
+                    {{#if (and ../../hasDamageTypes (gt (length group) 1) (not (eq (i) "null"))) }}
+                        <p class="damage-type">
+                            <label class="checkbox">
+                                <input class="damageSection" type="radio" name="{{part.group}}" id={{@index}} {{checked part.enabled}}/>{{part.name}}: {{part.formula}} {{part.type}}
+                            </label>
+                        </p>
+                    {{else}}
+                        <p class="damage-type">
+                            <label class="checkbox">
+                                <input class="damageSection" type="checkbox" name="{{@../index}}" id={{@index}} {{checked part.enabled}}/>{{part.name}}: {{part.formula}} {{part.type}}
+                            </label>
+                        </p>
+                    {{/if}}
+            {{/each}}
+        {{/if}}
+    {{/each}}
     </div>
 </div>
-{{/if}}
+
+
 
 {{#if hasModifiers}}
 <div>
@@ -60,7 +80,7 @@
             <h3 class="modifier-list-header-name noborder">{{localize "SFRPG.Rolls.Dialog.ModifierName"}}</h3>
             <div class="modifier-list-header-modifier">{{localize "SFRPG.Rolls.Dialog.ModifierEffect"}}</div>
         </li>
-        
+
         {{#each availableModifiers as |modifier id|}}
         <li class="modifier flexrow toggle-modifier" data-modifier-index="{{id}}" {{#if modifier.notes}}data-tippy-content="<b>{{modifier.name}}</b><br/>{{modifier.notes}}"{{/if}}>
             <a class="modifier-enabled" title="{{modifier.name}}">{{#if modifier.enabled}}<i class="far fa-check-square">{{else}}<i class="far fa-square"></i>{{/if}}</i></a>

--- a/src/templates/chat/roll-dialog.html
+++ b/src/templates/chat/roll-dialog.html
@@ -38,32 +38,30 @@
 <div class="damage-type-selector-list">
     <h3 class="damage-type-list-title noborder" data-tippy-content="{{localize "SFRPG.Damage.Types.Hint"}}">{{localize "SFRPG.Damage.Types.Title"}}</h3>
     {{#each damageGroups as |group i|}}
-        {{#if (or (gt (length ../damageGroups) 1)(eq (i) "null") )}}
-            <h3 class="damage-type-list-title noborder" data-tippy-content="{{localize "SFRPG.Damage.Types.Hint"}}">
-                {{#if (eq (i) "null")}}
-                    Groupless Damage
-                {{else}}
-                    Damage Group {{i}}
-                {{/if}}
-                </h3>
+        <h3 class="damage-type-list-title noborder" data-tippy-content="{{localize "SFRPG.Damage.Types.Hint"}}">
+            {{#if (eq (i) "null")}}
+                Groupless Damage
+            {{else}}
+                Damage Group {{i}}
+            {{/if}}
+            </h3>
 
-            <div class="damage-type-label">
-                {{#each this as |part j|}}
-                    {{#if (and ../../hasDamageTypes (gt (length group) 1) (not (eq (i) "null"))) }}
-                        <p class="damage-type">
-                            <label class="checkbox">
-                                <input class="damageSection" type="radio" name="{{part.group}}" id={{@index}} {{checked part.enabled}}/>{{part.name}}: {{part.formula}} {{part.type}}
-                            </label>
-                        </p>
-                    {{else}}
-                        <p class="damage-type">
-                            <label class="checkbox">
-                                <input class="damageSection" type="checkbox" name="{{@../index}}" id={{@index}} {{checked part.enabled}}/>{{part.name}}: {{part.formula}} {{part.type}}
-                            </label>
-                        </p>
-                    {{/if}}
-            {{/each}}
-        {{/if}}
+        <div class="damage-type-label">
+            {{#each this as |part j|}}
+                {{#if (and ../../hasDamageTypes (gt (length group) 1) (not (eq (i) "null"))) }}
+                    <p class="damage-type">
+                        <label class="checkbox">
+                            <input class="damageSection" type="radio" name="{{part.group}}" id={{@index}} {{checked part.enabled}}/>{{part.name}}: {{part.formula}} {{part.type}}
+                        </label>
+                    </p>
+                {{else}}
+                    <p class="damage-type">
+                        <label class="checkbox">
+                            <input class="damageSection" type="checkbox" name="{{@../index}}" id={{@index}} {{checked part.enabled}}/>{{part.name}}: {{part.formula}} {{part.type}}
+                        </label>
+                    </p>
+                {{/if}}
+        {{/each}}
     {{/each}}
     </div>
 </div>

--- a/src/templates/items/parts/item-action.html
+++ b/src/templates/items/parts/item-action.html
@@ -99,9 +99,12 @@
             </div>
         </div>
         <div class="damage-part-formula form-group">
-            <label>{{ localize "SFRPG.Damage.Types.DamageGroup" }}</label>
+            <label>{{ localize "SFRPG.Damage.Types.DamageGroup" group=""}}</label>
             <div class="form-fields">
-                <input type="number" name="system.damage.parts.{{i}}.group" value="{{lookup this "group"}}"/>
+                <input type="number" name="system.damage.parts.{{i}}.group" value="{{lookup this "group"}}" data-tooltip="
+                <strong>{{ localize 'SFRPG.Damage.Types.DamageGroup' group=''}}</strong>
+                <br>
+                <p>{{ localize 'SFRPG.Damage.Types.DamageGroupTooltip' group=''}}</p>"/>
             </div>
         </div>
         <div class="damage-part-type form-group stacked">

--- a/src/templates/items/parts/item-action.html
+++ b/src/templates/items/parts/item-action.html
@@ -98,6 +98,12 @@
                 <input type="text" name="system.damage.parts.{{i}}.formula" value="{{lookup this "formula"}}"/>
             </div>
         </div>
+        <div class="damage-part-formula form-group">
+            <label>Damage Group</label>
+            <div class="form-fields">
+                <input type="number" name="system.damage.parts.{{i}}.group" value="{{lookup this "group"}}"/>
+            </div>
+        </div>
         <div class="damage-part-type form-group stacked">
             <div class="form-group form-group-stacked">
                 <label>{{localize "Energy Damage"}}</label>

--- a/src/templates/items/parts/item-action.html
+++ b/src/templates/items/parts/item-action.html
@@ -99,7 +99,7 @@
             </div>
         </div>
         <div class="damage-part-formula form-group">
-            <label>Damage Group</label>
+            <label>{{ localize "SFRPG.Damage.Types.DamageGroup" }}</label>
             <div class="form-fields">
                 <input type="number" name="system.damage.parts.{{i}}.group" value="{{lookup this "group"}}"/>
             </div>


### PR DESCRIPTION
Damage sections can be grouped by number. You can only select one damage section in a given group. Un-grouped damage sections work as before. This allows for choices of damage, for example damaging cantrips.

~~TODO: Localisations and CSS~~