### PR TITLE
Damage dialog text color fix

### DIFF
--- a/src/less/roll.less
+++ b/src/less/roll.less
@@ -9,7 +9,6 @@
 
   div.damage-type-selector-list {
     .damage-type-list-title {
-      color: @colorOlive;
       font-weight: bold;
       font-size: 1em;
       border-bottom: 1px solid @borderDark;
@@ -17,7 +16,6 @@
     }
 
     .damage-type {
-      color: @colorOlive;
     }
   }
 

--- a/src/less/roll.less
+++ b/src/less/roll.less
@@ -14,9 +14,6 @@
       border-bottom: 1px solid @borderDark;
       margin-top: 5px;
     }
-
-    .damage-type {
-    }
   }
 
   ul.modifier-list {


### PR DESCRIPTION
Removed color override from Damage dialog window. Allowing compatibility with UI mods.