### PR TITLE
Added colours and fix error checking in cook

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1133,7 +1133,11 @@ async function postCook() {
     }
 
     if (!cookAborted) {
-        console.log(chalk.greenBright(`\nCompendiums cooked with ${cookErrorCount} errors!\nDon't forget to restart Foundry to refresh compendium data!\n`));
+        if (cookErrorCount > 0) {
+            console.log(chalk.redBright(`\nCompendiums cooked with ${chalk.bold(cookErrorCount)} errors. Please check the files listed above and try again.`));
+        } else {
+            console.log(chalk.greenBright(`\nCompendiums cooked with ${cookErrorCount} errors!\nDon't forget to restart Foundry to refresh compendium data!\n`));
+        }
     } else {
         throw Error(chalk.redBright(`\nCook aborted after ${cookErrorCount} critical errors!\n`));
     }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -48,9 +48,9 @@ function getManifest() {
     return json;
 }
 
-/********************/
+/** ******************/
 /*		BUILD		*/
-/********************/
+/** ******************/
 
 /**
  * Build Less
@@ -81,7 +81,7 @@ async function copyFiles() {
         `${name}.js`,
         'module.json',
         'system.json',
-        'template.json',
+        'template.json'
     ];
     try {
         for (const file of statics) {
@@ -97,7 +97,7 @@ async function copyFiles() {
 
 /**
  * Copy only those files that we want to watch while developing.
- * 
+ *
  * Over time, with the inclusion of tons of images and icons, the number
  * of files that are being copied over to the dist folder has increased by
  * a large amount. This was causing the watch process to slow to a crawl while
@@ -114,7 +114,7 @@ async function copyWatchFiles() {
         `${name}.js`,
         'module.json',
         'system.json',
-        'template.json',
+        'template.json'
     ];
     try {
         for (const file of statics) {
@@ -129,7 +129,7 @@ async function copyWatchFiles() {
 }
 
 /**
- * Does the same as copyFiles, except it only moves the 
+ * Does the same as copyFiles, except it only moves the
  * README, OGL, and LICENSE files. These aren't needed for
  * development, but they should be in the package.
  */
@@ -186,9 +186,9 @@ function buildWatch() {
  */
 function JSONstringifyOrder( obj, space, sortingMode = "default" )
 {
-    var allKeys = [];
-    var seen = {};
-    JSON.stringify(obj, function (key, value) {
+    let allKeys = [];
+    let seen = {};
+    JSON.stringify(obj, function(key, value) {
         if (!(key in seen)) {
             allKeys.push(key);
             seen[key] = null;
@@ -196,7 +196,7 @@ function JSONstringifyOrder( obj, space, sortingMode = "default" )
         return value;
     });
     allKeys.sort();
-    
+
     if (sortingMode === "item") {
         // Ensure name is after _id, and type is after name.
         const idIndex = allKeys.indexOf("_id");
@@ -213,7 +213,7 @@ function JSONstringifyOrder( obj, space, sortingMode = "default" )
             allKeys.splice(idIndex + 2, 0, "type");
         }
     }
-    
+
     return JSON.stringify(obj, allKeys, space);
 }
 
@@ -247,7 +247,7 @@ async function unpackPacks() {
         if (limitToPack && !file.includes(limitToPack)) {
             continue;
         }
-        
+
         if (file.endsWith(".db")) {
             let fileWithoutExt = file.substr(0, file.length - 3);
             let unpackDir = `./src/items/${fileWithoutExt}`;
@@ -261,7 +261,7 @@ async function unpackPacks() {
             console.log(`> Unpacking ${sourceFile} into ${unpackDir}`);
             await unpack(sourceFile, unpackDir);
 
-            console.log(`> Done.`);
+            console.log(chalk.greenBright(`> Done.`));
         }
     }
 
@@ -273,9 +273,9 @@ async function unpackPacks() {
 /**
  * Cook db source json files into .db files with nedb
  */
-var cookErrorCount = 0;
-var cookAborted = false;
-var packErrors = {};
+let cookErrorCount = 0;
+let cookAborted = false;
+let packErrors = {};
 var limitToPack = null;
 async function cookPacksNoFormattingCheck() {
     await cookWithOptions({ formattingCheck: false });
@@ -284,10 +284,10 @@ async function cookPacks(params) {
     await cookWithOptions({parameters: params, formattingCheck: true});
 }
 async function cookWithOptions(options = { formattingCheck: true }) {
-    console.log(`Cooking db files`);
-    for (let i = 3; i<process.argv.length; i++) {
+    console.log(chalk.blueBright(`Cooking db files`));
+    for (let i = 3; i < process.argv.length; i++) {
         if (process.argv[i] === '--pack') {
-            limitToPack = process.argv[i+1];
+            limitToPack = process.argv[i + 1];
             i++;
         }
     }
@@ -314,7 +314,7 @@ async function cookWithOptions(options = { formattingCheck: true }) {
                 console.log(`> Removing ${outputFile}`);
                 await fs.unlinkSync(outputFile);
             }
-            
+
             db = new AsyncNedb({ filename: outputFile, autoload: true });
         }
 
@@ -330,13 +330,13 @@ async function cookWithOptions(options = { formattingCheck: true }) {
                 if (!(directory in packErrors)) {
                     packErrors[directory] = [];
                 }
-                packErrors[directory].push(`${filePath}: Error parsing file: ${err}`);
+                packErrors[directory].push(`${chalk.bold(filePath)}: Error parsing file: ${err}`);
                 cookErrorCount++;
                 continue;
             }
 
             // Cached conditions to be referenced later
-            if (directory === "conditions") {
+            if (directory === "conditions" && jsonInput.name !== "Invisible") {
                 conditionsCache[jsonInput._id] = jsonInput;
             }
             // Cached setting to be referenced later
@@ -353,7 +353,7 @@ async function cookWithOptions(options = { formattingCheck: true }) {
                     // Skip if a journal
                     jsonInput.img = "icons/svg/mystery-man.svg";
                 }
-                
+
                 const movingActorTypes = ["character", "drone", "npc"];
                 if (movingActorTypes.includes(jsonInput.type)) {
                     tryMigrateActorSpeed(jsonInput);
@@ -369,12 +369,12 @@ async function cookWithOptions(options = { formattingCheck: true }) {
             await db.asyncInsert(jsonInput);
         }
         if (!limitToPack || directory === limitToPack) {
-            console.log(`> Finished processing data for ${directory}.`);
+            console.log(chalk.greenBright(`> Finished processing data for ${directory}.`));
         }
     }
 
     if (cookErrorCount > 0) {
-        console.log(`\nCritical parsing errors occurred, aborting cook.`);
+        console.error(chalk.red(`\nCritical parsing errors occurred, aborting cook.`));
         cookAborted = true;
         return 1;
     }
@@ -385,14 +385,14 @@ async function cookWithOptions(options = { formattingCheck: true }) {
 
     if (options.formattingCheck === true) {
         console.log(`\nStarting formatting check.`);
-        formattingCheck(allItems)
+        formattingCheck(allItems);
     }
     else {
         console.log(`\n*Skipping* formatting check.`);
     }
 
     console.log(`\nStarting consistency check.`);
-    consistencyCheck(allItems, compendiumMap)
+    consistencyCheck(allItems, compendiumMap);
 
     console.log(`\nUpdating items with updated IDs.\n`);
 
@@ -417,7 +417,7 @@ function regularExpressionForFindingItemsInCache(cache) {
 function ensureTokenDefaults(item) {
     if (!item) return;
     if (!item.prototypeToken) return;
-    
+
     // Did not add Character because iconics come in multiple levels, and we don't want to include level in the name.
     const actorTypes = ["npc", "starship", "vehicle", "npc2", "hazard"];
 
@@ -429,20 +429,20 @@ function ensureTokenDefaults(item) {
     item.prototypeToken.sight.enabled = false; // Sight is disabled for NPCs by default
     item.prototypeToken.bar1.attribute = "attributes.hp"; // Most tokens have hp as their first bat
     item.prototypeToken.bar2.attribute = ""; // The 2nd bar is set per token type
-    item.prototypeToken.disposition = -1 // Hostile by default
-    item.prototypeToken.displayBars = 20; //Show bars on hover
-    item.prototypeToken.displayName = 20; //Show name on hover
+    item.prototypeToken.disposition = -1; // Hostile by default
+    item.prototypeToken.displayBars = 20; // Show bars on hover
+    item.prototypeToken.displayName = 20; // Show name on hover
 
     if (["npc", "npc2"].includes(item.type) && item.system.attributes.rp.max > 0) {
         item.prototypeToken.bar2.attribute = "attributes.rp"; // If the NPC has resolve points, set them as the 2nd bar
     } else if (item.type === "character") {
         item.prototypeToken.disposition = 1; // Friendly
-        item.prototypeToken.bar2.attribute = "attributes.sp"; //2nd bar as stamina
+        item.prototypeToken.bar2.attribute = "attributes.sp"; // 2nd bar as stamina
     } else if (item.type === "starship") {
         item.prototypeToken.disposition = 0; // Neutral
-        item.prototypeToken.bar2.attribute = "attributes.shields"; //2nd bar as shields
+        item.prototypeToken.bar2.attribute = "attributes.shields"; // 2nd bar as shields
     } else if (item.type === "vehicle") {
-        item.prototypeToken.disposition = 0; //Neutral
+        item.prototypeToken.disposition = 0; // Neutral
     }
 }
 
@@ -452,7 +452,7 @@ function tryMigrateActorSpeed(jsonInput) {
     if (speedValue) {
         let baseSpeed = speedValue;
         if (baseSpeed && isNaN(baseSpeed)) {
-            baseSpeed = baseSpeed.replace(/\D/g,'');
+            baseSpeed = baseSpeed.replace(/\D/g, '');
             baseSpeed = Number(baseSpeed);
         }
 
@@ -460,7 +460,7 @@ function tryMigrateActorSpeed(jsonInput) {
         if (!baseSpeed || isNaN(baseSpeed)) {
             baseSpeed = 30;
         }
-        
+
         jsonInput.system.attributes.speed = {
             land: { base: 0 },
             flying: { base: 0 },
@@ -470,7 +470,7 @@ function tryMigrateActorSpeed(jsonInput) {
             special: "",
             mainMovement: "land"
         };
-        
+
         const lowercaseSpeedValue = speedValue.toLowerCase();
         if (lowercaseSpeedValue.includes("climb")) {
             jsonInput.system.attributes.speed.climbing.base = baseSpeed;
@@ -488,9 +488,9 @@ function tryMigrateActorSpeed(jsonInput) {
             jsonInput.system.attributes.speed.land.base = baseSpeed;
             jsonInput.system.attributes.speed.mainMovement = "land";
         }
-        
+
         let finalSpecial = "";
-        if (speedValue != baseSpeed) {
+        if (speedValue !== baseSpeed) {
             finalSpecial += "original base: " + speedValue.trim();
         }
         if (specialValue) {
@@ -499,7 +499,7 @@ function tryMigrateActorSpeed(jsonInput) {
             }
             finalSpecial += specialValue.trim();
         }
-        
+
         jsonInput.system.attributes.speed.special = finalSpecial;
     }
 }
@@ -513,39 +513,40 @@ function tryMigrateActorSpeed(jsonInput) {
 // conditions / setting cache and regular expression are generated during beginning of cooking and used during formatting checks
 var conditionsCache = {};
 var settingCache = {};
-var conditionsRegularExpression;
-var settingRegularExpression;
-var poisonAndDiseasesRegularExpression = new RegExp("(poison|disease)", "g");
-var validArmorTypes = ["light", "power", "heavy", "shield"];
-var validCreatureSizes = ["fine", "diminutive", "tiny", "small", "medium", "large", "huge", "gargantuan", "colossal"];
+let conditionsRegularExpression;
+let settingRegularExpression;
+let poisonAndDiseasesRegularExpression = new RegExp("(poison|disease)", "g");
+let validArmorTypes = ["light", "power", "heavy", "shield"];
+let validCreatureSizes = ["fine", "diminutive", "tiny", "small", "medium", "large", "huge", "gargantuan", "colossal"];
 function formattingCheck(allItems) {
     for (const item of allItems) {
         const data = item;
+        const itemData = item.data;
         const pack = item.pack;
 
-        if (!data || !data.system || !data.type) {
+        if (!data || !itemData || !itemData.system || !itemData.type) {
             continue; // Malformed data or journal entry - outside the scope of the formatting check
         }
-        
+
         // We only check formatting of aliens, vehicles & equipment for now
-        if (data.type === "npc" || data.type === "npc2") {
+        if (itemData.type === "npc" || itemData.type === "npc2") {
             // NOTE: `checkEcology` off by default as it currently produces hundreds of errors.
-            formattingCheckAlien(data, pack, item.file, { checkLinks: true, checkEcology: false })
+            formattingCheckAlien(itemData, pack, item.file, { checkLinks: true, checkEcology: false });
         }
-        else if (data.type === "equipment") {
-            formattingCheckItems(data, pack, item.file, { checkImage: true, checkSource: true, checkPrice: true, checkLevel: true, checkLinks: true })
+        else if (itemData.type === "equipment") {
+            formattingCheckItems(itemData, pack, item.file, { checkImage: true, checkSource: true, checkPrice: true, checkLevel: true, checkLinks: true });
         }
-        else if (data.type === "vehicle") {
-            formattingCheckVehicle(data, pack, item.file, { checkLinks: true });
+        else if (itemData.type === "vehicle") {
+            formattingCheckVehicle(itemData, pack, item.file, { checkLinks: true });
         }
-        else if (data.type === "spell") {
-            formattingCheckSpell(data, pack, item.file, { checkLinks: true });
+        else if (itemData.type === "spell") {
+            formattingCheckSpell(itemData, pack, item.file, { checkLinks: true });
         }
-        else if (data.type === "race") {
-            formattingCheckRace(data, pack, item.file, { checkLinks: true });
+        else if (itemData.type === "race") {
+            formattingCheckRace(itemData, pack, item.file, { checkLinks: true });
         }
-        else if (data.type === "feat") {
-            formattingCheckFeat(data, pack, item.file, { checkLinks: true });
+        else if (itemData.type === "feat") {
+            formattingCheckFeat(itemData, pack, item.file, { checkLinks: true });
         }
     }
 }
@@ -554,44 +555,44 @@ function formattingCheckRace(data, pack, file, options = { checkLinks: true }) {
 
     // Validate name
     if (!data.name || data.name.endsWith(' ') || data.name.startsWith(' ')) {
-        addWarningForPack(`${file}: Name is not well formatted "${data.name}.`, pack);
+        addWarningForPack(`${chalk.bold(file)}: Name is not well formatted "${data.name}.`, pack);
     }
 
     // Validate HP values
     if (data.system.hp.value < 0) {
-        addWarningForPack(`${file}: HP value not entered correctly.`, pack);
+        addWarningForPack(`${chalk.bold(file)}: HP value not entered correctly.`, pack);
     }
 
     if (data.system.size) {
         if (!validCreatureSizes.includes(data.system.size)) {
-            addWarningForPack(`${file}: Size value not entered correctly.`, pack);
+            addWarningForPack(`${chalk.bold(file)}: Size value not entered correctly.`, pack);
         }
     }
     else {
-        addWarningForPack(`${file}: Size value not entered correctly.`, pack);
+        addWarningForPack(`${chalk.bold(file)}: Size value not entered correctly.`, pack);
     }
 
     // Validate image
     if (data.img && !data.img.startsWith("systems") && !data.img.startsWith("icons")) {
-        addWarningForPack(`${file}: Image is pointing to invalid location "${data.name}.`, pack);
+        addWarningForPack(`${chalk.bold(file)}: Image is pointing to invalid location "${data.name}.`, pack);
     }
 
     // Validate source
     let source = data.system.source;
     if (!source) {
-        addWarningForPack(`${file}: Missing source field.`, pack);
+        addWarningForPack(`${chalk.bold(file)}: Missing source field.`, pack);
         return;
     }
     if (!isSourceValid(source)) {
-        addWarningForPack(`${file}: Improperly formatted source field "${source}.`, pack);
+        addWarningForPack(`${chalk.bold(file)}: Improperly formatted source field "${source}.`, pack);
     }
 
     // Check biography for references to conditions
     if (options.checkLinks) {
-        let description = data.system.description.value
+        let description = data.system.description.value;
         let result = searchDescriptionForUnlinkedCondition(description);
         if (result.found) {
-            addWarningForPack(`${file}: Found reference to ${result.match} in description without link.`, pack);
+            addWarningForPack(`${chalk.bold(file)}: Found reference to ${result.match} in description without link.`, pack);
         }
     }
 }
@@ -600,50 +601,45 @@ function formattingCheckAlien(data, pack, file, options = { checkLinks: true, ch
 
     // Validate name
     if (!data.name || data.name.endsWith(' ') || data.name.startsWith(' ')) {
-        addWarningForPack(`${file}: Name is not well formatted "${data.name}.`, pack);
+        addWarningForPack(`${chalk.bold(file)}: Name is not well formatted "${data.name}.`, pack);
     }
     // Validate attributes
     // Validate HP & Stamina Points
     if (!data.system.attributes || !data.system.attributes.hp || !data.system.attributes.sp) {
-        addWarningForPack(`${file}: Missing HP/SP values.`, pack);
+        addWarningForPack(`${chalk.bold(file)}: Missing HP/SP values.`, pack);
         return;
     }
     // Validate HP values
-    else if (data.system.attributes.hp.value != data.system.attributes.hp.max) {
-        addWarningForPack(`${file}: HP value not entered correctly.`, pack);
-    }
-    // Validate SP values
-    if (data.system.attributes.sp.value != data.system.attributes.sp.max) {
-        addWarningForPack(`${file}: SP value not entered correctly.`, pack);
+    else if (data.system.attributes.hp.value !== data.system.attributes.hp.max) {
+        addWarningForPack(`${chalk.bold(file)}: HP value not entered correctly.`, pack);
     }
 
     if (data.system.traits.size) {
         if (!validCreatureSizes.includes(data.system.traits.size)) {
-            addWarningForPack(`${file}: Size value not entered correctly.`, pack);
+            addWarningForPack(`${chalk.bold(file)}: Size value not entered correctly.`, pack);
         }
-    }
-    else {
-        addWarningForPack(`${file}: Size value not entered correctly.`, pack);
+    } else {
+        addWarningForPack(`${chalk.bold(file)}: Size value not entered correctly.`, pack);
     }
 
     // Validate image
     if (data.img && !data.img.startsWith("systems") && !data.img.startsWith("icons")) {
-        addWarningForPack(`${file}: Image is pointing to invalid location "${data.name}.`, pack);
+        addWarningForPack(`${chalk.bold(file)}: Image is pointing to invalid location "${chalk.bold(data.name)}.`, pack);
     }
 
     // Validate token image
-    if (data.token.img && !data.token.img.startsWith("systems") && !data.token.img.startsWith("icons")) {
-        addWarningForPack(`${file}: Image is pointing to invalid location "${data.name}.`, pack);
+    if (data.prototypeToken.img && !data.prototypeToken.img.startsWith("systems") && !data.prototypeToken.img.startsWith("icons")) {
+        addWarningForPack(`${chalk.bold(file)}: Image is pointing to invalid location "${chalk.bold(data.name)}.`, pack);
     }
 
     // Validate source
     let source = data.system.details.source;
     if (!source) {
-        addWarningForPack(`${file}: Missing source field.`, pack);
+        addWarningForPack(`${chalk.bold(file)}: Missing source field.`, pack);
         return;
     }
     if (!isSourceValid(source)) {
-        addWarningForPack(`${file}: Improperly formatted source field "${source}.`, pack);
+        addWarningForPack(`${chalk.bold(file)}: Improperly formatted source field "${chalk.bold(source)}.`, pack);
     }
 
     if (options.checkEcology === true) {
@@ -651,30 +647,30 @@ function formattingCheckAlien(data, pack, file, options = { checkLinks: true, ch
         let environment = data.system.details.environment;
         let organization = data.system.details.organization;
         if (environment === null || environment === "") {
-            addWarningForPack(`${file}: Environment is missing.`, pack);
+            addWarningForPack(`${fichalk.bold(file)}: Environment is missing.`, pack);
         }
         if (organization === null || organization === "") {
-            addWarningForPack(`${file}: Organization is missing.`, pack);
+            addWarningForPack(`${chalk.bold(file)}: Organization is missing.`, pack);
         }
     }
 
     if (options.checkLinks === true) {
-        let description = data.system.details.biography.value
+        let description = data.system.details.biography.value;
         // Check biography for references to conditions
         let conditionResult = searchDescriptionForUnlinkedCondition(description);
         if (conditionResult.found) {
-            addWarningForPack(`${file}: Found reference to ${conditionResult.match} in biography without link.`, pack);
+            addWarningForPack(`${chalk.bold(file)}: Found reference to ${chalk.bold(conditionResult.match)} in biography without link.`, pack);
         }
         // Check biography for references to the setting
         let settingResult = searchDescriptionForUnlinkedReference(description, settingRegularExpression);
         if (settingResult.found) {
-            addWarningForPack(`${file}: Found reference to ${settingResult.match} in description without link.`, pack);
+            addWarningForPack(`${chalk.bold(file)}: Found reference to ${chalk.bold(settingResult.match)} in description without link.`, pack);
         }
     }
 
     // Validate items
     for (i in data.items) {
-        formattingCheckItems(data.items[i], pack, file, { checkImage: true, checkSource: false, checkPrice: false, checkLinks: options.checkLinks })
+        formattingCheckItems(data.items[i], pack, file, { checkImage: true, checkSource: false, checkPrice: false, checkLinks: options.checkLinks });
     }
 }
 
@@ -682,14 +678,14 @@ function formattingCheckItems(data, pack, file, options = { checkImage: true, ch
 
     // Validate name
     if (!data.name || data.name.endsWith(' ') || data.name.startsWith(' ')) {
-        addWarningForPack(`${file}: Name is not well formatted "${data.name}.`, pack);
+        addWarningForPack(`${chalk.bold(file)}: Name is not well formatted "${chalk.bold(data.name)}.`, pack);
     }
 
     // Validate image
     if (options.checkImage) {
-        if (data.img && // Only validate if img is set
-            !data.img.startsWith("systems") && !data.img.startsWith("icons")) {
-            addWarningForPack(`${file}: Image is pointing to invalid location "${data.name}.`, pack);
+        if (data.img // Only validate if img is set
+            && !data.img.startsWith("systems") && !data.img.startsWith("icons")) {
+            addWarningForPack(`${chalk.bold(file)}: Image is pointing to invalid location "${chalk.bold(data.name)}.`, pack);
         }
     }
 
@@ -697,7 +693,7 @@ function formattingCheckItems(data, pack, file, options = { checkImage: true, ch
     if (options.checkSource) {
         let source = data.system.source;
         if (!isSourceValid(source)) {
-            addWarningForPack(`${file}: Improperly formatted source field "${source}.`, pack);
+            addWarningForPack(`${chalk.bold(file)}: Improperly formatted source field "${chalk.bold(source)}".`, pack);
         }
     }
 
@@ -705,7 +701,7 @@ function formattingCheckItems(data, pack, file, options = { checkImage: true, ch
     if (options.checkPrice) {
         let price = data.system.price;
         if (!price || price <= 0) {
-            addWarningForPack(`${file}: Improperly formatted armor price field "${price}.`, pack);
+            addWarningForPack(`${chalk.bold(file)}: Improperly formatted armor price field "${chalk.bold(price)}.`, pack);
         }
     }
 
@@ -713,7 +709,7 @@ function formattingCheckItems(data, pack, file, options = { checkImage: true, ch
     if (options.checkLevel) {
         let level = data.system.level;
         if (!level || level <= 0) {
-            addWarningForPack(`${file}: Improperly formatted armor level field "${level}.`, pack);
+            addWarningForPack(`${chalk.bold(file)}: Improperly formatted armor level field "${chalk.bold(level)}.`, pack);
         }
     }
 
@@ -723,31 +719,31 @@ function formattingCheckItems(data, pack, file, options = { checkImage: true, ch
     }
 
     // If armor
-    let armor = data.system.armor
+    let armor = data.system.armor;
     if (armor) {
         // Validate armor type
-        let armorType = data.system.armor.type
+        let armorType = data.system.armor.type;
         if (!validArmorTypes.includes(armorType)) {
-            addWarningForPack(`${file}: Improperly formatted armor type field "${armorType}.`, pack);
+            addWarningForPack(`${chalk.bold(file)}: Improperly formatted armor type field "${chalk.bold(armorType)}.`, pack);
         }
     }
 
     // Validate links
     if (options.checkLinks) {
-        let description = data.system.description.value
+        let description = data.system.description.value;
 
         if (description) {
 
             // Check description for references to conditions
             let conditionResult = searchDescriptionForUnlinkedReference(description, conditionsRegularExpression);
             if (conditionResult.found) {
-                addWarningForPack(`${file}: Found reference to ${conditionResult.match} in description without link.`, pack);
+                addWarningForPack(`${chalk.bold(file)}: Found reference to ${chalk.bold(conditionResult.match)} in description without link.`, pack);
             }
 
             // Check description for references to poisons / diseases
             let poisonResult = searchDescriptionForUnlinkedReference(description, poisonAndDiseasesRegularExpression);
             if (poisonResult.found) {
-                addWarningForPack(`${file}: Found reference to ${poisonResult.match} in description without link.`, pack);
+                addWarningForPack(`${chalk.bold(file)}: Found reference to ${chalk.bold(poisonResult.match)} in description without link.`, pack);
             }
         }
         else {
@@ -759,10 +755,10 @@ function formattingCheckItems(data, pack, file, options = { checkImage: true, ch
 
 function formattingCheckWeapons(data, pack, file) {
 
-    let lowecaseName = data.name.toLowerCase()
+    let lowecaseName = data.name.toLowerCase();
     if (lowecaseName.includes("multiattack")) {
         // Should be [MultiATK]
-        addWarningForPack(`${file}: Improperly formatted multiattack name field "${data.name}.`, pack);
+        addWarningForPack(`${chalk.bold(file)}: Improperly formatted multiattack name field "${chalk.bold(data.name)}.`, pack);
     }
     if (lowecaseName.includes("multiatk")) {
 
@@ -771,7 +767,7 @@ function formattingCheckWeapons(data, pack, file) {
         }
         else {
             // Anything else is close, but is slightly off
-            addWarningForPack(`${file}: Improperly formatted multiattack name field "${data.name}.`, pack);
+            addWarningForPack(`${chalk.bold(file)}: Improperly formatted multiattack name field "${chalk.bold(data.name)}.`, pack);
         }
     }
 }
@@ -780,43 +776,43 @@ function formattingCheckVehicle(data, pack, file, options = { checkLinks: true }
 
     // Validate name
     if (!data.name || data.name.endsWith(' ') || data.name.startsWith(' ')) {
-        addWarningForPack(`${file}: Name is not well formatted "${data.name}.`, pack);
+        addWarningForPack(`${chalk.bold(file)}: Name is not well formatted "${chalk.bold(data.name)}.`, pack);
     }
 
     // Validate image
     if (data.img && !data.img.startsWith("systems") && !data.img.startsWith("icons")) {
-        addWarningForPack(`${file}: Image is pointing to invalid location "${data.name}.`, pack);
+        addWarningForPack(`${chalk.bold(file)}: Image is pointing to invalid location "${chalk.bold(data.name)}.`, pack);
     }
 
     // Validate source
     let source = data.system.details.source;
     if (!source) {
-        addWarningForPack(`${file}: Missing source field.`, pack);
+        addWarningForPack(`${chalk.bold(file)}: Missing source field.`, pack);
         return;
     }
     if (!isSourceValid(source)) {
-        addWarningForPack(`${file}: Improperly formatted source field "${source}.`, pack);
+        addWarningForPack(`${chalk.bold(file)}: Improperly formatted source field "${chalk.bold(source)}.`, pack);
     }
 
     // Validate price
     let price = data.system.details.price;
     if (!price || price <= 0) {
-        addWarningForPack(`${file}: Improperly formatted vehicle price field "${armorType}.`, pack);
+        addWarningForPack(`${chalk.bold(file)}: Improperly formatted vehicle price field "${chalk.bold(armorType)}.`, pack);
     }
 
     // Validate level
     let level = data.system.details.level;
     if (!level || level <= 0) {
-        addWarningForPack(`${file}: Improperly formatted vehicle level field "${armorType}.`, pack);
+        addWarningForPack(`${chalk.bold(file)}: Improperly formatted vehicle level field "${chalk.bold(armorType)}.`, pack);
     }
 
     // Check description for references to conditions
     if (options.checkLinks) {
-        let description = data.system.details.description.value
+        let description = data.system.details.description.value;
         if (description) {
             let result = searchDescriptionForUnlinkedCondition(description);
             if (result.found) {
-                addWarningForPack(`${file}: Found reference to ${result.match} in description without link.`, pack);
+                addWarningForPack(`${chalk.bold(file)}: Found reference to ${chalk.bold(result.match)} in description without link.`, pack);
             }
         }
         else {
@@ -826,7 +822,7 @@ function formattingCheckVehicle(data, pack, file, options = { checkLinks: true }
 
     // Validate items
     for (i in data.items) {
-        formattingCheckItems(data.items[i], pack, file, { checkImage: true, checkSource: false, checkPrice: false, checkLinks: options.checkLinks })
+        formattingCheckItems(data.items[i], pack, file, { checkImage: true, checkSource: false, checkPrice: false, checkLinks: options.checkLinks });
     }
 }
 
@@ -834,37 +830,37 @@ function formattingCheckSpell(data, pack, file, options = { checkLinks: true }) 
 
     // Validate name
     if (!data.name || data.name.endsWith(' ') || data.name.startsWith(' ')) {
-        addWarningForPack(`${file}: Name is not well formatted "${data.name}.`, pack);
+        addWarningForPack(`${chalk.bold(file)}: Name is not well formatted "${chalk.bold(data.name)}.`, pack);
     }
 
     // Validate image
     if (data.img && !data.img.startsWith("systems") && !data.img.startsWith("icons")) {
-        addWarningForPack(`${file}: Image is pointing to invalid location "${data.name}.`, pack);
+        addWarningForPack(`${chalk.bold(file)}: Image is pointing to invalid location "${chalk.bold(data.name)}.`, pack);
     }
 
     // Validate source
     let source = data.system.source;
     if (!source) {
-        addWarningForPack(`${file}: Missing source field.`, pack);
+        addWarningForPack(`${chalk.bold(file)}: Missing source field.`, pack);
         return;
     }
     if (!isSourceValid(source)) {
-        addWarningForPack(`${file}: Improperly formatted source field "${source}.`, pack);
+        addWarningForPack(`${chalk.bold(file)}: Improperly formatted source field "${chalk.bold(source)}.`, pack);
     }
 
-    //Check spell description for unlinked references to conditions
+    // Check spell description for unlinked references to conditions
     if (options.checkLinks === true) {
-        let description = data.system.description.value
+        let description = data.system.description.value;
 
         // Check references to conditions
         let conditionResult = searchDescriptionForUnlinkedReference(description, conditionsRegularExpression);
         if (conditionResult.found) {
-            addWarningForPack(`${file}: Found reference to ${conditionResult.match} in description without link.`, pack);
+            addWarningForPack(`${chalk.bold(file)}: Found reference to ${chalk.bold(conditionResult.match)} in description without link.`, pack);
         }
         // Check references to the setting
         let settingResult = searchDescriptionForUnlinkedReference(description, settingRegularExpression);
         if (settingResult.found) {
-            addWarningForPack(`${file}: Found reference to ${settingResult.match} in description without link.`, pack);
+            addWarningForPack(`${chalk.bold(file)}: Found reference to ${chalk.bold(settingResult.match)} in description without link.`, pack);
         }
     }
 }
@@ -873,12 +869,12 @@ function formattingCheckFeat(data, pack, file, options = { checkLinks: true }) {
 
     // Validate name
     if (!data.name || data.name.endsWith(' ') || data.name.startsWith(' ')) {
-        addWarningForPack(`${file}: Name is not well formatted "${data.name}.`, pack);
+        addWarningForPack(`${chalk.bold(file)}: Name is not well formatted "${chalk.bold(data.name)}.`, pack);
     }
 
     // Validate image
     if (data.img && !data.img.startsWith("systems") && !data.img.startsWith("icons")) {
-        addWarningForPack(`${file}: Image is pointing to invalid location "${data.name}.`, pack);
+        addWarningForPack(`${chalk.bold(file)}: Image is pointing to invalid location "${chalk.bold(data.name)}.`, pack);
     }
 
     // NOTE: We don't validate `source` for feats as we currently are not decided if we should use this field as
@@ -886,16 +882,16 @@ function formattingCheckFeat(data, pack, file, options = { checkLinks: true }) {
     // feat)
 
     if (options.checkLinks === true) {
-        let description = data.system.description.value
+        let description = data.system.description.value;
         // Check description for references to conditions
         let conditionResult = searchDescriptionForUnlinkedReference(description, conditionsRegularExpression);
         if (conditionResult.found) {
-            addWarningForPack(`${file}: Found reference to ${conditionResult.match} in description without link.`, pack);
+            addWarningForPack(`${chalk.bold(file)}: Found reference to ${chalk.bold(conditionResult.match)} in description without link.`, pack);
         }
         // Check description for references to the setting
         let settingResult = searchDescriptionForUnlinkedReference(description, settingRegularExpression);
         if (settingResult.found) {
-            addWarningForPack(`${file}: Found reference to ${settingResult.match} in description without link.`, pack);
+            addWarningForPack(`${chalk.bold(file)}: Found reference to ${chalk.bold(settingResult.match)} in description without link.`, pack);
         }
     }
 }
@@ -910,7 +906,7 @@ function searchDescriptionForUnlinkedCondition(description) {
 function searchDescriptionForUnlinkedReference(description, regularExpression) {
 
     let matches = [...description.matchAll(regularExpression)];
-    //Found a potential reference to a condition
+    // Found a potential reference to a condition
     if (matches && matches.length > 0) {
         // Capture the character before and after each match and use some basic heuristics to decide if it's an linked condition in the description
         for (let match of matches) {
@@ -925,7 +921,7 @@ function searchDescriptionForUnlinkedReference(description, regularExpression) {
             let characterAfter = description.substring(characterAfterIndex, characterAfterIndex + 1);
             let delimiterCharacters = [">", "<", ";", ",", "/", "(", ")", "."];
 
-            var unlinkedReferenceFound = false;
+            let unlinkedReferenceFound = false;
             // If surrounded by { and } we assume it is linked and continue
             if (characterBefore === "{" && characterAfter === "}") {
                 continue;
@@ -939,14 +935,14 @@ function searchDescriptionForUnlinkedReference(description, regularExpression) {
             else if (delimiterCharacters.includes(characterBefore) && (delimiterCharacters.includes(characterAfter) || characterAfter === " ")) {
                 // The condition was found between two delimiters, most likely in the contents of an html tag.
                 // Or it was found at the tail of a delimiter followed by a space (at the end of a comma separated list.
-                unlinkedReferenceFound = true
+                unlinkedReferenceFound = true;
             }
-                // Condition was found after a space but right before a delimiting character, like the end of a sentence.
+            // Condition was found after a space but right before a delimiting character, like the end of a sentence.
             // Or hugging opening brackets, or the start of a comma separated list.
             else if ((delimiterCharacters.includes(characterBefore) || characterBefore === " ") && delimiterCharacters.includes(characterAfter)) {
                 unlinkedReferenceFound = true;
             }
-                // This is a simple rule of thumb which checks of the word in question is surrounded by `&nbsp;`. In this case we'll ignore,
+            // This is a simple rule of thumb which checks of the word in question is surrounded by `&nbsp;`. In this case we'll ignore,
             // as this can be used to escape a condition word (ie. `Burning`) in an otherwise unrelated context (ie. `... the Burning Archipelago...`)
             else if (characterBefore === ";" && characterAfter === "&") {
                 unlinkedReferenceFound = false;
@@ -964,7 +960,7 @@ function searchDescriptionForUnlinkedReference(description, regularExpression) {
 function isSourceValid(source) {
 
     // NOTE: One day this should be changed if they publish further Core books (Galaxy Exploration Manual included for posterity)
-    const CoreBooksSourceMatch = [...source.matchAll(/(CRB|AR|PW|COM|SOM|NS|GEM|TR|GM|DC) pg\. [\d]+/g)];
+    const CoreBooksSourceMatch = [...source.matchAll(/(CRB|AR|PW|COM|SOM|NS|GEM|TR|GM|DC|IS) pg\. [\d]+/g)];
     // NOTE: One day this should be increased when they publish further Alien Archives (Alien Archive 5 included for posterity)
     const AlienArchiveSourceMatch = [...source.matchAll(/AA([1-5]) pg\. [\d]+/g)];
     const AdventurePathSourceMatch = [...source.matchAll(/AP #[\d]+ pg\. [\d]+/g)];
@@ -972,16 +968,16 @@ function isSourceValid(source) {
     const StarfinderAdventureSourceMatch =  [...source.matchAll(/SA:\S+ pg\. [\d]+/g)];
 
     if (CoreBooksSourceMatch && CoreBooksSourceMatch.length > 0) {
-       // ✅ formatted Core book source
-       return true;
+        // ✅ formatted Core book source
+        return true;
     }
     else if (AlienArchiveSourceMatch && AlienArchiveSourceMatch.length > 0) {
-       // ✅ formatted Alien Archives source
-       return true;
+        // ✅ formatted Alien Archives source
+        return true;
     }
     else if (AdventurePathSourceMatch && AdventurePathSourceMatch.length > 0) {
-       // ✅ formatted Adventure path source
-       return true;
+        // ✅ formatted Adventure path source
+        return true;
     }
     else if (StarfinderSocietySourceMatch && StarfinderSocietySourceMatch.length > 0) {
         // ✅ formatted Starfinder Society source
@@ -993,7 +989,7 @@ function isSourceValid(source) {
     }
     else if (source === "ACD") {
         //  ✅ formatted Alien Card Deck source
-        return true
+        return true;
     }
 
     return false;
@@ -1012,9 +1008,10 @@ function addWarningForPack(warning, pack) {
 function consistencyCheck(allItems, compendiumMap) {
     for (let item of allItems) {
         let data = item;
-        if (!data || !data.system || !data.system.description) continue;
+        let itemData = item.data;
+        if (!data || !itemData || !itemData.system || !itemData.system.description) continue;
 
-        let desc = data.system.description.value;
+        let desc = itemData.system.description.value;
         if (!desc) continue;
 
         let pack = item.pack;
@@ -1030,7 +1027,7 @@ function consistencyCheck(allItems, compendiumMap) {
                 if (!(pack in packErrors)) {
                     packErrors[pack] = [];
                 }
-                packErrors[pack].push(`${item.file}: Using @Item to reference to '${localItemName}' (with id: ${localItemId}), @Item is not allowed in compendiums. Please use '@Compendium[sfrpg.${pack}.${localItemId}]' instead.`);
+                packErrors[pack].push(`${chalk.bold(item.file)}: Using @Item to reference to '${chalk.bold(localItemName)}' (with id: ${chalk.bold(localItemId)}), @Item is not allowed in compendiums. Please use '${chalk.bold('@Compendium[sfrpg.' + pack + "." + localItemId + "]")}' instead.`);
                 cookErrorCount++;
             }
         }
@@ -1045,7 +1042,7 @@ function consistencyCheck(allItems, compendiumMap) {
                 if (!(pack in packErrors)) {
                     packErrors[pack] = [];
                 }
-                packErrors[pack].push(`${item.file}: Using @JournalEntry to reference to '${localItemName}' (with id: ${localItemId}), @JournalEntry is not allowed in compendiums. Please use '@Compendium[sfrpg.${pack}.${localItemId}]' instead.`);
+                packErrors[pack].push(`${chalk.bold(item.file)}: Using @JournalEntry to reference to '${chalk.bold(localItemName)}' (with id: ${chalk.bold(localItemId)}), @JournalEntry is not allowed in compendiums. Please use '${chalk.bold('@Compendium[sfrpg.' + pack + "." + localItemId + "]")}' instead.`);
                 cookErrorCount++;
             }
         }
@@ -1054,14 +1051,14 @@ function consistencyCheck(allItems, compendiumMap) {
         if (compendiumMatch && compendiumMatch.length > 0) {
             for (let otherItem of compendiumMatch) {
                 let link = otherItem[1];
-                let otherItemName = (otherItem.length == 4) ? otherItem[3] || link : link;
+                let otherItemName = (otherItem.length === 4) ? otherItem[3] || link : link;
 
                 let linkParts = link.split('.');
                 if (linkParts.length !== 3) {
                     if (!(pack in packErrors)) {
                         packErrors[pack] = [];
                     }
-                    packErrors[pack].push(`${item.file}: Compendium link to '${link}' is not valid. It does not have enough segments in the link. Expected format is sfrpg.compendiumName.itemId.`);
+                    packErrors[pack].push(`${chalk.bold(item.file)}: Compendium link to '${chalk.bold(link)}' is not valid. It does not have enough segments in the link. Expected format is sfrpg.compendiumName.itemId.`);
                     cookErrorCount++;
                     continue;
                 }
@@ -1075,12 +1072,12 @@ function consistencyCheck(allItems, compendiumMap) {
                     if (!(pack in packErrors)) {
                         packErrors[pack] = [];
                     }
-                    packErrors[pack].push(`${item.file}: Compendium link to '${otherItemName}' (with id: ${otherItemId}) is not referencing the sfrpg system, but instead using '${system}'.`);
+                    packErrors[pack].push(`${chalk.bold(item.file)}: Compendium link to '${chalk.bold(otherItemName)}' (with id: ${chalk.bold(otherItemId)}) is not referencing the sfrpg system, but instead using '${chalk.bold(system)}'.`);
                     cookErrorCount++;
                 }
 
                 // @Compendium links to the same compendium could be @Item links instead.
-                /*if (otherPack === pack) {
+                /* if (otherPack === pack) {
                     if (!(pack in packErrors)) {
                         packErrors[pack] = [];
                     }
@@ -1093,25 +1090,25 @@ function consistencyCheck(allItems, compendiumMap) {
                     if (!(pack in packErrors)) {
                         packErrors[pack] = [];
                     }
-                    packErrors[pack].push(`${item.file}: '${otherItemName}' (with id: ${otherItemId}) cannot find '${otherPack}', is there an error in the compendium name?`);
+                    packErrors[pack].push(`${chalk.bold(item.file)}: '${chalk.bold(otherItemName)}' (with id: ${chalk.bold(otherItemId)}) cannot find '${chalk.bold(otherPack)}', is there an error in the compendium name?`);
                     cookErrorCount++;
                     continue;
                 }
 
                 // @Compendium links must link to a valid item ID.
-                var itemExists = false;
+                let itemExists = false;
                 if (otherItemId in compendiumMap[otherPack]) {
                     itemExists = true;
                 } else {
-                    let foundItem = allItems.find(x => x.pack === otherPack && (x.name == otherItemId || x.name == otherItemName));
-                    itemExists = foundItem !== null;
+                    let foundItem = allItems.find(x => x.pack === otherPack && x._id === otherItemId);
+                    itemExists = !!foundItem;
                 }
 
                 if (!itemExists) {
                     if (!(pack in packErrors)) {
                         packErrors[pack] = [];
                     }
-                    packErrors[pack].push(`${item.file}: '${otherItemName}' (with id: ${otherItemId}) not found in '${otherPack}'.`);
+                    packErrors[pack].push(`${chalk.bold(item.file)}: '${chalk.bold(otherItemName)}' (with id: ${chalk.bold(otherItemId)}) not found in '${chalk.bold(otherPack)}'.`);
                     cookErrorCount++;
                 }
             }
@@ -1123,51 +1120,51 @@ async function postCook() {
 
     if (Object.keys(packErrors).length > 0) {
         for (let pack of Object.keys(packErrors)) {
-            console.log(`\n${packErrors[pack].length} Errors cooking ${pack}.db:`);
+            console.error(chalk.redBright(`\n${packErrors[pack].length} Errors cooking ${pack}.db:`));
             for (let error of packErrors[pack]) {
-                console.log(`> ${error}`);
+                console.error(chalk.redBright(`> ${error}`));
             }
         }
     }
 
     if (!cookAborted) {
-        console.log(`\nCompendiums cooked with ${cookErrorCount} errors!\nDon't forget to restart Foundry to refresh compendium data!\n`);
+        console.log(chalk.greenBright(`\nCompendiums cooked with ${cookErrorCount} errors!\nDon't forget to restart Foundry to refresh compendium data!\n`));
     } else {
-        console.log(`\nCook aborted after ${cookErrorCount} critical errors!\n`);
+        throw Error(chalk.redBright(`\nCook aborted after ${cookErrorCount} critical errors!\n`));
     }
     return 0;
 }
 
-/********************/
+/** ******************/
 /*   LOCALIZATION   */
-/********************/
+/** ******************/
 async function copyLocalization() {
     console.log(`Opening localization files`);
-    
+
     const itemSourceDir = "./src/lang";
     const files = await fs.readdirSync(itemSourceDir);
-    
+
     // First we sort the JSON keys alphabetically
     console.log(`Sorting keys`);
     for (const filePath of files) {
         console.log(`> ${filePath}`);
         const fileRaw = await fs.readFileSync(itemSourceDir + "/" + filePath);
         const fileJson = JSON.parse(fileRaw);
-        
+
         const outRaw = JSONstringifyOrder(fileJson, 4);
         await fs.writeFileSync(itemSourceDir + "/" + filePath, outRaw);
     }
     console.log(``);
-    
+
     // Get original file data
     const englishFilePath = "./src/lang/en.json";
     const englishRaw = await fs.readFileSync(englishFilePath);
     const englishJson = JSON.parse(englishRaw);
-    
+
     const germanFilePath = "./src/lang/de.json";
     const germanRaw = await fs.readFileSync(germanFilePath);
     const germanJson = JSON.parse(germanRaw);
-    
+
     // Then we ensure all languages are in sync with English
     console.log(`Ensuring language files are in sync with English`);
     for (const filePath of files) {
@@ -1175,45 +1172,45 @@ async function copyLocalization() {
         if (isEnglish) {
             continue;
         }
-        
+
         console.log(`> ${filePath}`);
-        
+
         const languageRaw = await fs.readFileSync(itemSourceDir + "/" + filePath);
         const languageJson = JSON.parse(languageRaw);
-        
+
         let copiedJson = JSON.parse(JSON.stringify(englishJson));
         mergeDeep(copiedJson, languageJson);
-        
+
         const outRaw = JSONstringifyOrder(copiedJson, 4);
         await fs.writeFileSync(itemSourceDir + "/" + filePath, outRaw);
     }
 }
 
 function isObject(item) {
-  return (item && typeof item === 'object' && !Array.isArray(item));
+    return (item && typeof item === 'object' && !Array.isArray(item));
 }
 
 function mergeDeep(target, ...sources) {
-  if (!sources.length) return target;
-  const source = sources.shift();
+    if (!sources.length) return target;
+    const source = sources.shift();
 
-  if (isObject(target) && isObject(source)) {
-    for (const key in source) {
-      if (isObject(source[key])) {
-        if (!target[key]) Object.assign(target, { [key]: {} });
-        mergeDeep(target[key], source[key]);
-      } else {
-        Object.assign(target, { [key]: source[key] });
-      }
+    if (isObject(target) && isObject(source)) {
+        for (const key in source) {
+            if (isObject(source[key])) {
+                if (!target[key]) Object.assign(target, { [key]: {} });
+                mergeDeep(target[key], source[key]);
+            } else {
+                Object.assign(target, { [key]: source[key] });
+            }
+        }
     }
-  }
 
-  return mergeDeep(target, ...sources);
+    return mergeDeep(target, ...sources);
 }
 
-/********************/
+/** ******************/
 /*		CLEAN		*/
-/********************/
+/** ******************/
 
 /**
  * Remove built files from `dist` folder
@@ -1257,9 +1254,9 @@ async function clean() {
     }
 }
 
-/********************/
+/** ******************/
 /*		LINK		*/
-/********************/
+/** ******************/
 
 /**
  * Link build to User Data folder
@@ -1270,14 +1267,14 @@ async function linkUserData() {
 
     let destDir;
     try {
-        if (			
-            fs.existsSync(path.resolve('.', 'dist', 'module.json')) ||
-            fs.existsSync(path.resolve('.', 'src', 'module.json'))
-        ) {		
+        if (
+            fs.existsSync(path.resolve('.', 'dist', 'module.json'))
+            || fs.existsSync(path.resolve('.', 'src', 'module.json'))
+        ) {
             destDir = 'modules';
         } else if (
-            fs.existsSync(path.resolve('.', 'dist', 'system.json')) ||
-            fs.existsSync(path.resolve('.', 'src', 'system.json'))
+            fs.existsSync(path.resolve('.', 'dist', 'system.json'))
+            || fs.existsSync(path.resolve('.', 'src', 'system.json'))
         ) {
             destDir = 'systems';
         } else {
@@ -1294,7 +1291,7 @@ async function linkUserData() {
                 throw Error('User Data path invalid, no Data directory found');
 
             linkDir = path.join(config.dataPath, 'Data', destDir, name);
-            
+
         } else {
             throw Error('No User Data path defined in foundryconfig.json');
         }
@@ -1318,9 +1315,9 @@ async function linkUserData() {
 }
 
 
-/********************/
+/** ******************/
 /*	COPY USER DATA	*/
-/********************/
+/** ******************/
 
 /**
  * Copy build to User Data folder (for Docker - doesn't like symlinks)
@@ -1332,13 +1329,13 @@ async function copyUserData() {
     let destDir;
     try {
         if (
-            fs.existsSync(path.resolve('.', 'dist', 'module.json')) ||
-            fs.existsSync(path.resolve('.', 'src', 'module.json'))
+            fs.existsSync(path.resolve('.', 'dist', 'module.json'))
+            || fs.existsSync(path.resolve('.', 'src', 'module.json'))
         ) {
             destDir = 'modules';
         } else if (
-            fs.existsSync(path.resolve('.', 'dist', 'system.json')) ||
-            fs.existsSync(path.resolve('.', 'src', 'system.json'))
+            fs.existsSync(path.resolve('.', 'dist', 'system.json'))
+            || fs.existsSync(path.resolve('.', 'src', 'system.json'))
         ) {
             destDir = 'systems';
         } else {
@@ -1378,9 +1375,9 @@ async function copyUserData() {
     }
 }
 
-/*********************/
+/** *******************/
 /*		PACKAGE		 */
-/*********************/
+/** *******************/
 
 /**
  * Package build
@@ -1425,9 +1422,9 @@ async function packageBuild() {
     }
 }
 
-/*********************/
+/** *******************/
 /*		PACKAGE		 */
-/*********************/
+/** *******************/
 
 /**
  * Update version and URLs in the manifest JSON

--- a/src/items/conditions/invisible.json
+++ b/src/items/conditions/invisible.json
@@ -1,6 +1,6 @@
 {
   "_id": "ZANamqgukV0AyXBb",
-  "name": "invisible",
+  "name": "Invisible",
   "type": "feat",
   "_stats": {
     "coreVersion": "10.290",


### PR DESCRIPTION
Summary of changes here:
- Made errors red and successes green
- Formatting and consistency checking wasn't running due to bad object references, now run
- Remove SP checking on NPCs, they don't have stamina
- Updated some `token` references to `prototypeToken`
- Correct ID checking to correctly check for missing IDs
- Skip Invisible in conditions checking because it doesn't actually exist (may reverse later)
- Add IS to allowed sources

The result of these changes are that cook picks up 91 errors now which need to be fixed. See #855