### PR TITLE
add action buttons in item collections

### DIFF
--- a/src/less/variables.less
+++ b/src/less/variables.less
@@ -98,3 +98,7 @@
     .flex3 { flex: 3; }
     .flex4 { flex: 4; }
 }
+
+.flexnowrap {
+    flex-wrap: nowrap;
+}

--- a/src/templates/actors/parts/actor-inventory-item.hbs
+++ b/src/templates/actors/parts/actor-inventory-item.hbs
@@ -5,7 +5,7 @@
                     {{#if (and (not (eq item.type "feat")) (or item.config.isStack (getStarfinderBoolean "alwaysShowQuantity")))}}({{item.system.quantity}}) {{/if}}
                     {{item.name}}
                 </h4>
-                {{#if (and isOwner (or (eq item.type "consumable") (and bigItem (or item.config.hasAttack item.config.hasDamage))))}}
+                {{#if (and isOwner (or (eq item.type "consumable") (or item.config.hasAttack item.config.hasDamage)))}}
                 <div class="item-action flexcol">
                     {{#if (eq item.type "consumable")}}
                         <button type="button" class="tag use">{{localize "SFRPG.Items.Consumable.UseAction"}}</button>
@@ -68,14 +68,14 @@
             {{#if isOwner}}
             <div class="item-controls">
                 {{#if (not disableEquipping)}}
-                {{!-- TODO: Remove this massive or chain once all weapons, shields, equipments, and containers have their data.equippable flag set in their json definitions --}}
-                {{#if (and (or (or (or (or (eq item.type "weapon") (eq item.type "shield")) (eq item.type "equipment")) (eq item.type "container")) item.system.equippable) bigItem)}}
-                {{#if item.system.equipped}}
-                <a class="item-control item-equip" title="{{localize "SFRPG.ActorSheet.Inventory.Item.Unequip"}}"><i class="fas fa-check"></i></a>
-                {{else}}
-                <a class="item-control item-equip" title="{{localize "SFRPG.ActorSheet.Inventory.Item.Equip"}}"><i class="far fa-square"></i></a>
-                {{/if}}
-                {{/if}}
+                    {{!-- TODO: Remove this massive or chain once all weapons, shields, equipments, and containers have their data.equippable flag set in their json definitions --}}
+                    {{#if (or (or (or (or (eq item.type "weapon") (eq item.type "shield")) (eq item.type "equipment")) (eq item.type "container")) item.system.equippable)}}
+                        {{#if item.system.equipped}}
+                            <a class="item-control item-equip" title="{{localize "SFRPG.ActorSheet.Inventory.Item.Unequip"}}"><i class="fas fa-check"></i></a>
+                        {{else}}
+                            <a class="item-control item-equip" title="{{localize "SFRPG.ActorSheet.Inventory.Item.Equip"}}"><i class="far fa-square"></i></a>
+                        {{/if}}
+                    {{/if}}
                 {{/if}}
                 <a class="item-control item-edit" title="{{localize "SFRPG.ActorSheet.Inventory.Item.Edit"}}"><i class="fas fa-edit"></i></a>
                 <a class="item-control item-delete" title="{{localize "SFRPG.ActorSheet.Inventory.Item.Delete"}}"><i class="fas fa-trash"></i></a>

--- a/src/templates/actors/parts/actor-inventory-item.hbs
+++ b/src/templates/actors/parts/actor-inventory-item.hbs
@@ -6,7 +6,7 @@
                     {{item.name}}
                 </h4>
                 {{#if (and isOwner (or (eq item.type "consumable") (or item.config.hasAttack item.config.hasDamage)))}}
-                <div class="item-action flexcol">
+                <div class="item-action {{#if item.parentItem}}flexrow flexnowrap{{else}}flexcol{{/if}}">
                     {{#if (eq item.type "consumable")}}
                         <button type="button" class="tag use">{{localize "SFRPG.Items.Consumable.UseAction"}}</button>
                     {{else}}


### PR DESCRIPTION
- enabled item action buttons inside item collections

This was requested by @Iankid to make solar crystals work inside a Solar Weapon.
Just a more flexible approach to allow all items to have their buttons.