### PR TITLE
Adjust spellbook column sizes

### DIFF
--- a/src/less/actors.less
+++ b/src/less/actors.less
@@ -970,7 +970,7 @@
   }
 
   .spell-dc {
-    flex: 0 0 130px;
+    flex: 0 0 150px;
     font-size: 12px;
     color: @colorTan;
     text-align: center;
@@ -991,7 +991,7 @@
   }
 
   .spell-school, .spell-action {
-    flex: 0 0 120px;
+    flex: 0 0 90px;
     font-size: 12px;
     color: @colorTan;
     text-align: center;

--- a/src/less/character.less
+++ b/src/less/character.less
@@ -366,7 +366,7 @@
 
   .spellbook {
     .item-controls {
-      flex: 0 0 66px;
+      flex: 0 0 44px;
 
       .toggle-prepared {
         color: @colorBeige;


### PR DESCRIPTION
-Make save larger to account for longer descriptors
-Remove the space for equipped on spellbook (Will require an update to Quick Insert to accommodate a 3rd button)
-Shrink action column