### PR TITLE
Entropic Strike damage update

### DIFF
--- a/src/items/class-features/entropic_strike_(su).json
+++ b/src/items/class-features/entropic_strike_(su).json
@@ -74,7 +74,8 @@
       "parts": [
         {
           "name": "Entropic Strike (Su)",
-          "formula": "(lookupRange(@classes.vanguard.levels, 0, 1, 1, 6, 2, 9, 3, 12, 4, 13, 5, 14, 6, 15, 7, 16, 8, 17, 9, 18, 10, 19, 11, 20, 12))d(lookupRange(@classes.vanguard.levels, 0, 1, 3, 3, 4, 5, 6)) + @abilities.con.mod + (lookupRange(@classes.vanguard.levels, 0, 10, @abilities.str.mod))",
+          "formula": "(lookupRange(@classes.vanguard.levels, 0, 1, 1, 6, 2, 9, 3, 12, 4, 13, 5, 14, 6, 15, 7, 16, 8, 17, 9, 18, 10, 19, 11, 20, 12))d(lookupRange(@classes.vanguard.levels, 0, 1, 3, 3, 4, 5, 6)) + @abilities.con.mod + (lookupRange(@classes.vanguard.levels, 0, 10, @abilities.str.mod) + (lookupRange(@classes.vanguard.levels, 0, 3, floor(@classes.vanguard.levels / 2))))",
+          "group": null,
           "types": {
             "acid": true,
             "bludgeoning": true,
@@ -90,6 +91,7 @@
         {
           "name": "Entropic Strike (Su) (Through Weapon. Copy to weapon)",
           "formula": "(lookupRange(@item.level, 0, 1, 1, 6, 2, 9, 3, 12, 4, 13, 5, 14, 6, 15, 7, 16, 8, 17, 9, 18, 10, 19, 11, 20, 12))d(lookupRange(@item.level, 0, 1, 3, 3, 4, 5, 6)) + @abilities.con.mod + (lookupRange(@classes.vanguard.levels, 0, 10, @abilities.str.mod))",
+          "group": null,
           "types": {
             "acid": false,
             "bludgeoning": false,
@@ -166,9 +168,11 @@
       "harrying": false,
       "holyWater": false,
       "hybrid": false,
+      "hydrodynamic": false,
       "ignite": false,
       "indirect": false,
       "injection": false,
+      "instrumental": false,
       "integrated": false,
       "line": false,
       "living": false,


### PR DESCRIPTION
Added + floor 1/2 vanguard level to strike damage.
The accounts for the special specialization that Vanguard have to their strike, in spite of the operative weapon type.