### PR TITLE
Silently fix whitespace on modifiers and damage parts

### DIFF
--- a/src/module/apps/roll-dialog.js
+++ b/src/module/apps/roll-dialog.js
@@ -126,11 +126,20 @@ export default class RollDialog extends Dialog {
 
             // Make a simplified roll
             const simplerRoll = Roll.create(modifier.modifier, context).simplifiedFormula;
+
             if (modifier.modifier[0] === "+") modifier.modifier = modifier.modifier.slice(1);
 
-            // If it actually was simplified, append the original modififer for use on the tooltip.
+            /* If it actually was simplified, append the original modififer for use on the tooltip.
+            *
+            * If the formulas are different with whitespace, that means the original likely has some weird whitespace, so let's correct that, bu we don't need to tell the user.
+            */
             if (modifier.modifier !== simplerRoll) {
                 modifier.originalFormula = modifier.modifier;
+
+                // If the formulas are still different without whitespace, then MathTerms must have been simplifed, so let's tell the user.
+                if (modifier.originalFormula.replace(/\s/g, "") !== simplerRoll.replace(/\s/g, "")) {
+                    modifier.originalFormulaTooltip = true;
+                }
             }
 
             // Sign that string
@@ -162,11 +171,17 @@ export default class RollDialog extends Dialog {
                 }
                 part.type = typeString;
 
-                // Clean up the formula
+                // If it actually was simplified, append the original modififer for use on the tooltip.
+                // If the formulas are different with whitespace, that means the original likely has some weird whitespace, so let's correct that, bu we don't need to tell the user.
                 const simplerRoll = Roll.create(part.formula).simplifiedFormula;
                 if (part.formula !== simplerRoll) {
                     part.originalFormula = part.formula;
                     part.formula = simplerRoll;
+
+                    // If the formulas are still different without whitespace, then MathTerms must have been simplifed, so let's tell the user.
+                    if (part.originalFormula.replace(/\s/g, "") !== simplerRoll.replace(/\s/g, "")) {
+                        part.originalFormulaTooltip = true;
+                    }
                 }
             }
 

--- a/src/module/apps/roll-dialog.js
+++ b/src/module/apps/roll-dialog.js
@@ -171,8 +171,10 @@ export default class RollDialog extends Dialog {
                 }
                 part.type = typeString;
 
-                // If it actually was simplified, append the original modififer for use on the tooltip.
-                // If the formulas are different with whitespace, that means the original likely has some weird whitespace, so let's correct that, bu we don't need to tell the user.
+                /* If it actually was simplified, append the original modififer for use on the tooltip.
+                *
+                * If the formulas are different with whitespace, that means the original likely has some weird whitespace, so let's correct that, bu we don't need to tell the user.
+                */
                 const simplerRoll = Roll.create(part.formula).simplifiedFormula;
                 if (part.formula !== simplerRoll) {
                     part.originalFormula = part.formula;

--- a/src/templates/chat/roll-dialog.hbs
+++ b/src/templates/chat/roll-dialog.hbs
@@ -56,7 +56,7 @@
                     <p class="damage-type">
                         <label class="radio">
                             <input class="damageSection" type="radio" name="{{part.group}}" id={{@index}} {{checked part.enabled}}/>{{part.name}}: {{part.formula}} {{part.type}}
-                            {{#if part.originalFormula}}
+                            {{#if part.originalFormulaTooltip}}
                                 <i class="fas fa-info-circle" data-tooltip="{{localize "SFRPG.Rolls.Dialog.SimplifiedFormulaTooltip" formula=part.originalFormula}}"></i>
                             {{/if}}
                         </label>
@@ -65,7 +65,7 @@
                     <p class="damage-type">
                         <label class="checkbox">
                             <input class="damageSection" type="checkbox" name="{{i}}" id={{@index}} {{checked part.enabled}}/>{{part.name}}: {{part.formula}} {{part.type}}
-                            {{#if part.originalFormula}}
+                            {{#if part.originalFormulaTooltip}}
                                 <i class="fas fa-info-circle" data-tooltip="{{localize "SFRPG.Rolls.Dialog.SimplifiedFormulaTooltip" formula=part.originalFormula}}"></i>
                             {{/if}}
                         </label>
@@ -94,7 +94,7 @@
             <a class="modifier-enabled" title="{{modifier.name}}">{{#if modifier.enabled}}<i class="far fa-check-square">{{else}}<i class="far fa-square"></i>{{/if}}</i></a>
             <h4 class="modifier-name">{{modifier.name}}</h4>
             <span class="modifier-modifier">{{modifier.modifier}}
-            {{#if modifier.originalFormula}}
+            {{#if modifier.originalFormulaTooltip}}
                 <i class="fas fa-info-circle" data-tooltip="{{localize "SFRPG.Rolls.Dialog.SimplifiedFormulaTooltip" formula=modifier.originalFormula}}"></i>
             {{/if}}
             </span>


### PR DESCRIPTION
This stops "1d6+ 4" from being shown as being calculated to "1d6 + 4"