### PR TITLE
Return the roll object on DiceSFRPG.d20Rolls

### DIFF
--- a/src/module/apps/roll-dialog.js
+++ b/src/module/apps/roll-dialog.js
@@ -361,7 +361,7 @@ export default class RollDialog extends Dialog {
                     buttons: buttons,
                     default: defaultButton,
                     close: (button, rollMode, bonus, parts) => {
-                        resolve([button, rollMode, bonus, parts]);
+                        resolve({button, rollMode, bonus, parts});
                     }
                 },
                 options: options.dialogOptions || {}

--- a/src/module/dice.js
+++ b/src/module/dice.js
@@ -211,7 +211,7 @@ export class DiceSFRPG {
         const formula = parts.map(partMapper).join(" + ");
 
         const tree = new RollTree(options);
-        return tree.buildRoll(formula, rollContext, async (button, rollMode, finalFormula) => {
+        return await tree.buildRoll(formula, rollContext, async (button, rollMode, finalFormula) => {
             if (button === "cancel") {
                 if (onClose) {
                     onClose(null, null, null);
@@ -312,7 +312,10 @@ export class DiceSFRPG {
             if (errorToThrow) {
                 throw errorToThrow;
             }
+
+            return roll;
         });
+
     }
 
     /**
@@ -564,7 +567,7 @@ export class DiceSFRPG {
 
         const formula = finalParts.join(" + ");
         const tree = new RollTree(options);
-        return tree.buildRoll(formula, rollContext, async (button, rollMode, finalFormula, part) => {
+        return await tree.buildRoll(formula, rollContext, async (button, rollMode, finalFormula, part) => {
             if (button === 'cancel') {
                 if (onClose) {
                     onClose(null, null, null, false);

--- a/src/module/item/item.js
+++ b/src/module/item/item.js
@@ -1692,7 +1692,8 @@ export class ItemSFRPG extends Mix(Item).with(ItemActivationMixin, ItemCapacityM
 
                 for (let currentValue of updates) {
                     if (currentValue.scaling.d3) {
-                        currentValue['system.damage.parts'].forEach(i => {
+                        const parts = currentValue['system.damage.parts'];
+                        for (const i of parts) {
                             if (setting) {
                                 if (isNPC) {
                                     i.formula = npcd3scaling;
@@ -1702,9 +1703,10 @@ export class ItemSFRPG extends Mix(Item).with(ItemActivationMixin, ItemCapacityM
                             } else {
                                 i.formula = "1d3";
                             }
-                        });
+                        }
                     } else if (currentValue.scaling.d6) {
-                        currentValue['system.damage.parts'].forEach(i => {
+                        const parts = currentValue['system.damage.parts'];
+                        for (const i of parts) {
                             if (setting) {
                                 if (isNPC) {
                                     i.formula = npcd6scaling;
@@ -1714,7 +1716,7 @@ export class ItemSFRPG extends Mix(Item).with(ItemActivationMixin, ItemCapacityM
                             } else {
                                 i.formula = "1d6";
                             }
-                        });
+                        }
                     }
 
                     delete currentValue.scaling;
@@ -1740,7 +1742,10 @@ export class ItemSFRPG extends Mix(Item).with(ItemActivationMixin, ItemCapacityM
         if (addedItem.system.scaling?.d3) {
 
             const updates = duplicate(addedItem.system.damage.parts);
-            updates.forEach(i => i.formula = (isNPC) ? npcd3scaling : d3scaling);
+            updates.map(i => {
+                i.formula = (isNPC) ? npcd3scaling : d3scaling;
+                return i;
+            } );
 
             await addedItem.update({"system.damage.parts": updates});
             console.log(`Starfinder | Updated ${addedItem.name} to use the ${ (isNPC) ? 'NPC ' : ""}d3 scaling formula.`);
@@ -1748,7 +1753,10 @@ export class ItemSFRPG extends Mix(Item).with(ItemActivationMixin, ItemCapacityM
         } else if (addedItem.system.scaling?.d6) {
 
             const updates = duplicate(addedItem.system.damage.parts);
-            updates.forEach(i => i.formula = (isNPC) ? npcd6scaling : d6scaling);
+            updates.map(i => {
+                i.formula = (isNPC) ? npcd6scaling : d6scaling;
+                return i;
+            } );
 
             await addedItem.update({"system.damage.parts": updates});
             console.log(`Starfinder | Updated ${addedItem.name} to use the ${ (isNPC) ? "NPC " : ""}d6 scaling formula.`);


### PR DESCRIPTION
This change allows for macros and such to access the result of `actor.rollSkill` or `item.rollAttack` etc.
Also included some optimisations(?) to scaling spell logic