### PR TITLE
Supply roll data to HTML enrichment, and refactor item chat data

### DIFF
--- a/src/module/actor/actor.js
+++ b/src/module/actor/actor.js
@@ -834,12 +834,18 @@ export class ActorSFRPG extends Mix(Actor).with(ActorConditionsMixin, ActorCrewM
 
                 flavor += `<p><strong>${game.i18n.format("SFRPG.Rolls.StarshipActions.Chat.DC")}: </strong>${dcRoll.roll.total}</p>`;
             } else {
-                flavor += `<p><strong>${game.i18n.format("SFRPG.Rolls.StarshipActions.Chat.DC")}: </strong>${await TextEditor.enrichHTML(dc.value, {async: true})}</p>`;
+                flavor += `<p><strong>${game.i18n.format("SFRPG.Rolls.StarshipActions.Chat.DC")}: </strong>${await TextEditor.enrichHTML(dc.value, {
+                    async: true,
+                    rollData: this.getRollData() ?? {}
+                })}</p>`;
             }
         }
 
         flavor += `<p><strong>${game.i18n.format("SFRPG.Rolls.StarshipActions.Chat.NormalEffect")}: </strong>`;
-        flavor += await TextEditor.enrichHTML(selectedFormula.effectNormal || actionEntry.system.effectNormal, {async: true});
+        flavor += await TextEditor.enrichHTML(selectedFormula.effectNormal || actionEntry.system.effectNormal, {
+            async: true,
+            rollData: this.getRollData() ?? {}
+        });
         flavor += "</p>";
 
         if (actionEntry.system.effectCritical) {
@@ -847,7 +853,10 @@ export class ActorSFRPG extends Mix(Actor).with(ActorConditionsMixin, ActorCrewM
             if (critEffectDisplayState !== 'never') {
                 if (critEffectDisplayState === 'always' || rollResult.roll.dice[0].values[0] === 20) {
                     flavor += `<p><strong>${game.i18n.format("SFRPG.Rolls.StarshipActions.Chat.CriticalEffect")}: </strong>`;
-                    flavor += await TextEditor.enrichHTML(selectedFormula.effectCritical || actionEntry.system.effectCritical, {async: true});
+                    flavor += await TextEditor.enrichHTML(selectedFormula.effectCritical || actionEntry.system.effectCritical, {
+                        async: true,
+                        rollData: this.getRollData() ?? {}
+                    });
                     flavor += "</p>";
                 }
             }

--- a/src/module/actor/sheet/base.js
+++ b/src/module/actor/sheet/base.js
@@ -161,8 +161,17 @@ export class ActorSheetSFRPG extends ActorSheet {
         this._prepareItems(data);
 
         // Enrich text editors. The below are used for character, drone and npc(2). Other types use editors defined in their class.
-        data.enrichedBiography = await TextEditor.enrichHTML(this.object.system.details.biography.value, {async: true});
-        data.enrichedGMNotes = await TextEditor.enrichHTML(this.object.system.details.biography.gmNotes, {async: true});
+        const secrets = this.actor.isOwner;
+        data.enrichedBiography = await TextEditor.enrichHTML(this.actor.system.details.biography.value, {
+            async: true,
+            rollData: this.actor.getRollData() ?? {},
+            secrets
+        });
+        data.enrichedGMNotes = await TextEditor.enrichHTML(this.actor.system.details.biography.gmNotes, {
+            async: true,
+            rollData: this.actor.getRollData() ?? {},
+            secrets
+        });
 
         return data;
     }
@@ -856,15 +865,15 @@ export class ActorSheetSFRPG extends ActorSheet {
      */
     async _onItemSummary(event) {
         event.preventDefault();
-        let li = $(event.currentTarget).parents('.item'),
-            item = this.actor.items.get(li.data('item-id')),
-            chatData = await item.getChatData({ secrets: this.actor.isOwner, rollData: this.actor.system });
+        const li = $(event.currentTarget).parents('.item');
+        const item = this.actor.items.get(li.data('item-id'));
+        const chatData = await item.getChatData();
 
         if (li.hasClass('expanded')) {
             let summary = li.children('.item-summary');
             summary.slideUp(200, () => summary.remove());
         } else {
-            const desiredDescription = await TextEditor.enrichHTML(chatData.description.short || chatData.description.value, {async: true});
+            const desiredDescription = chatData.description.short || chatData.description.value;
             let div = $(`<div class="item-summary">${desiredDescription}</div>`);
             Hooks.callAll("renderItemSummary", this, div, {}); // Event listeners need to be added to this HTML.
 

--- a/src/module/actor/sheet/hazard.js
+++ b/src/module/actor/sheet/hazard.js
@@ -26,7 +26,8 @@ export class ActorSheetSFRPGHazard extends ActorSheetSFRPG {
         // Enrich text editors
         data.enrichedDescription = await TextEditor.enrichHTML(this.actor.system.details.description.value, {
             async: true,
-            rollData: this.actor.getRollData() ?? {}
+            rollData: this.actor.getRollData() ?? {},
+            secrets: this.actor.isOwner
         });
 
         return data;

--- a/src/module/actor/sheet/hazard.js
+++ b/src/module/actor/sheet/hazard.js
@@ -24,7 +24,10 @@ export class ActorSheetSFRPGHazard extends ActorSheetSFRPG {
         const data = await super.getData();
 
         // Enrich text editors
-        data.enrichedDescription = await TextEditor.enrichHTML(this.object.system.details.description.value, {async: true});
+        data.enrichedDescription = await TextEditor.enrichHTML(this.actor.system.details.description.value, {
+            async: true,
+            rollData: this.actor.getRollData() ?? {}
+        });
 
         return data;
     }

--- a/src/module/actor/sheet/starship.js
+++ b/src/module/actor/sheet/starship.js
@@ -680,7 +680,9 @@ export class ActorSheetSFRPGStarship extends ActorSheetSFRPG {
             summary.slideUp(200, () => summary.remove());
         } else {
             const desiredDescription = await TextEditor.enrichHTML(content || chatData.description.value, {
-                async: true, rollData: this.actor.getRollData() ?? {}
+                async: true,
+                rollData: this.actor.getRollData() ?? {},
+                secrets: this.actor.isOwner
             });
             let div = $(`<div class="item-summary">${desiredDescription}</div>`);
             Hooks.callAll("renderItemSummary", this, div, {});

--- a/src/module/actor/sheet/starship.js
+++ b/src/module/actor/sheet/starship.js
@@ -42,7 +42,10 @@ export class ActorSheetSFRPGStarship extends ActorSheetSFRPG {
         this._getCrewData(data);
 
         // Encrich text editors
-        data.enrichedDescription = await TextEditor.enrichHTML(this.object.system.details.notes, {async: true});
+        data.enrichedDescription = await TextEditor.enrichHTML(this.actor.system.details.notes, {
+            async: true,
+            rollData: this.actor.getRollData() ?? {}
+        });
 
         return data;
     }
@@ -665,7 +668,7 @@ export class ActorSheetSFRPGStarship extends ActorSheetSFRPG {
 
         const doc = index.find(i => i.name === (li.prevObject[0].innerHTML));
         const item = await pack.getDocument(doc._id);
-        const chatData = await item.getChatData({ secrets: this.actor.isOwner, rollData: this.actor.system });
+        const chatData = await item.getChatData();
 
         let content = `<p><strong>${game.i18n.localize("SFRPG.StarshipSheet.Actions.Tooltips.NormalEffect")}:</strong> ${chatData.effectNormal}</p>`;
         if (chatData.effectCritical) {
@@ -676,7 +679,9 @@ export class ActorSheetSFRPGStarship extends ActorSheetSFRPG {
             let summary = li.children('.item-summary');
             summary.slideUp(200, () => summary.remove());
         } else {
-            const desiredDescription = await TextEditor.enrichHTML(content || chatData.description.value, {async: true});
+            const desiredDescription = await TextEditor.enrichHTML(content || chatData.description.value, {
+                async: true, rollData: this.actor.getRollData() ?? {}
+            });
             let div = $(`<div class="item-summary">${desiredDescription}</div>`);
             Hooks.callAll("renderItemSummary", this, div, {});
 

--- a/src/module/actor/sheet/vehicle.js
+++ b/src/module/actor/sheet/vehicle.js
@@ -35,7 +35,8 @@ export class ActorSheetSFRPGVehicle extends ActorSheetSFRPG {
         // Encrich text editors
         data.enrichedDescription = await TextEditor.enrichHTML(this.actor.system.details.description.value, {
             async: true,
-            rollData: this.actor.getRollData() ?? {}
+            rollData: this.actor.getRollData() ?? {},
+            secrets: this.actor.isOwner
         });
 
         return data;

--- a/src/module/actor/sheet/vehicle.js
+++ b/src/module/actor/sheet/vehicle.js
@@ -33,7 +33,10 @@ export class ActorSheetSFRPGVehicle extends ActorSheetSFRPG {
         this._getHangarBayData(data);
 
         // Encrich text editors
-        data.enrichedDescription = await TextEditor.enrichHTML(this.object.system.details.description.value, {async: true});
+        data.enrichedDescription = await TextEditor.enrichHTML(this.actor.system.details.description.value, {
+            async: true,
+            rollData: this.actor.getRollData() ?? {}
+        });
 
         return data;
     }
@@ -318,7 +321,7 @@ export class ActorSheetSFRPGVehicle extends ActorSheetSFRPG {
 
             if (oldRole) {
                 const originalRole = crew[oldRole];
-                originalRole.actorIds = originalRole.actorIds.filter(x => x != actorId);
+                originalRole.actorIds = originalRole.actorIds.filter(x => x !== actorId);
             }
 
             await this.actor.update({

--- a/src/module/apps/item-collection-sheet.js
+++ b/src/module/apps/item-collection-sheet.js
@@ -202,7 +202,7 @@ export class ItemCollectionSheet extends DocumentSheet {
         let li = $(event.currentTarget).parents('.item');
         let itemId = li.attr("data-item-id");
         const item = this.itemCollection.flags.sfrpg.itemCollection.items.find(x => x._id === itemId);
-        let chatData = await this.getChatData(item, { secrets: true, rollData: item.system });
+        let chatData = await this.getChatData(item, { secrets: true, rollData: item });
 
         if (li.hasClass('expanded')) {
             let summary = li.children('.item-summary');
@@ -296,6 +296,7 @@ export class ItemCollectionSheet extends DocumentSheet {
         const labels = itemData.labels || {};
 
         htmlOptions.async = true;
+        htmlOptions.rollData ||= (this.actor.getRollData() ?? {});
 
         // Rich text description
         data.system.description.value = await TextEditor.enrichHTML(data.system.description.value, htmlOptions);

--- a/src/module/item/item.js
+++ b/src/module/item/item.js
@@ -211,8 +211,6 @@ export class ItemSFRPG extends Mix(Item).with(ItemActivationMixin, ItemCapacityM
      * @return {Promise}
      */
     async roll() {
-        let htmlOptions = { secrets: this.actor?.isOwner || true, rollData: this };
-        htmlOptions.rollData.owner = this.actor?.system;
 
         // Basic template rendering data
         const token = this.actor.token;
@@ -220,7 +218,7 @@ export class ItemSFRPG extends Mix(Item).with(ItemActivationMixin, ItemCapacityM
             actor: this.actor,
             tokenId: token ? `${token.parent.id}.${token.id}` : null,
             item: this,
-            system: await this.getChatData(htmlOptions),
+            system: await this.getChatData(),
             labels: this.labels,
             hasAttack: this.hasAttack,
             hasDamage: this.hasDamage,
@@ -345,14 +343,29 @@ export class ItemSFRPG extends Mix(Item).with(ItemActivationMixin, ItemCapacityM
     /*  Chat Cards                                  */
     /* -------------------------------------------- */
 
-    async getChatData(htmlOptions) {
+    /**
+     * Prepare this item's description, and chat message properties.
+     * @returns {Object} An object containing the item's rollData (including its owners), and chat message properties.
+     */
+    async getChatData() {
         const data = duplicate(this.system);
         const labels = this.labels;
 
-        htmlOptions.async = true;
+        const async = true;
+        const secrets = this.isOwner;
+        const rollData = RollContext.createItemRollContext(this, this.actor).getRollData();
 
         // Rich text description
-        data.description.value = await TextEditor.enrichHTML(data.description.value, htmlOptions);
+        if (data.description.short) data.description.short = await TextEditor.enrichHTML(data.description.short, {
+            async,
+            secrets,
+            rollData
+        });
+        data.description.value = await TextEditor.enrichHTML(data.description.value, {
+            async,
+            secrets,
+            rollData
+        });
 
         // Item type specific properties
         const props = [];
@@ -816,7 +829,11 @@ export class ItemSFRPG extends Mix(Item).with(ItemActivationMixin, ItemCapacityM
             parts: parts,
             rollContext: rollContext,
             title: title,
-            flavor: await TextEditor.enrichHTML(this.system?.chatFlavor, {async: true}),
+            flavor: await TextEditor.enrichHTML(this.system?.chatFlavor, {
+                async: true,
+                rollData: this.actor.getRollData() ?? {},
+                secrets: this.isOwner
+            }),
             speaker: ChatMessage.getSpeaker({ actor: this.actor }),
             critical: critThreshold,
             chatMessage: options.chatMessage,
@@ -1154,7 +1171,11 @@ export class ItemSFRPG extends Mix(Item).with(ItemActivationMixin, ItemCapacityM
             criticalData: itemData.critical,
             rollContext: rollContext,
             title: title,
-            flavor: (await TextEditor.enrichHTML(options?.flavorOverride, {async: true}) ?? await TextEditor.enrichHTML(itemData.chatFlavor, {async: true})) || null,
+            flavor: await TextEditor.enrichHTML(options?.flavorOverride || itemData.chatFlavor, {
+                async: true,
+                rollData: this.actor.getRollData() ?? {},
+                secrets: this.isOwner
+            }) || null,
             speaker: ChatMessage.getSpeaker({ actor: this.actor }),
             chatMessage: options.chatMessage,
             dialogOptions: {

--- a/src/module/item/sheet.js
+++ b/src/module/item/sheet.js
@@ -1,4 +1,5 @@
 import { SFRPG } from "../config.js";
+import RollContext from "../rolls/rollcontext.js";
 
 const itemSizeArmorClassModifier = {
     "fine": 8,
@@ -186,9 +187,24 @@ export class ItemSheetSFRPG extends ItemSheet {
         data.hasCapacity = this.item.hasCapacity();
 
         // Enrich text editors
-        data.enrichedDescription = await TextEditor.enrichHTML(this.object.system?.description?.value, {async: true});
-        data.enrichedShortDescription = await TextEditor.enrichHTML(this.object.system?.description?.short, {async: true});
-        data.enrichedGMNotes = await TextEditor.enrichHTML(this.object.system?.description?.gmNotes, {async: true});
+        const rollData = RollContext.createItemRollContext(this.item, this.actor).getRollData();
+        const secrets = this.item.isOwner;
+
+        data.enrichedDescription = await TextEditor.enrichHTML(this.item.system?.description?.value, {
+            async: true,
+            rollData: rollData ?? {},
+            secrets
+        });
+        data.enrichedShortDescription = await TextEditor.enrichHTML(this.item.system?.description?.short, {
+            async: true,
+            rollData: rollData ?? {},
+            secrets
+        });
+        data.enrichedGMNotes = await TextEditor.enrichHTML(this.item.system?.description?.gmNotes, {
+            async: true,
+            rollData: rollData ?? {},
+            secrets
+        });
 
         return data;
     }
@@ -334,7 +350,7 @@ export class ItemSheetSFRPG extends ItemSheet {
                 props.push(game.i18n.localize("SFRPG.VehicleAttackSheet.Details.IgnoresHardness") + " " + item.ignoresHardness);
             }
         } else if (item.type === "vehicleSystem") {
-            if (item.senses &&  item.senses.usedForSenses == true) {
+            if (item.senses && item.senses.usedForSenses) {
                 // We deliminate the senses by `,` and present each sense as a separate property
                 let sensesDeliminated = item.senses.senses.split(",");
                 for (let index = 0; index < sensesDeliminated.length; index++) {
@@ -414,18 +430,18 @@ export class ItemSheetSFRPG extends ItemSheet {
             if (!arr[i]) arr[i] = { name: "", formula: "", types: {}, group: null };
 
             switch (key) {
-            case 'name':
-                arr[i].name = entry[1];
-                break;
-            case 'formula':
-                arr[i].formula = entry[1];
-                break;
-            case 'types':
-                if (type) arr[i].types[type] = entry[1];
-                break;
-            case 'group':
-                arr[i].group = entry[1];
-                break;
+                case 'name':
+                    arr[i].name = entry[1];
+                    break;
+                case 'formula':
+                    arr[i].formula = entry[1];
+                    break;
+                case 'types':
+                    if (type) arr[i].types[type] = entry[1];
+                    break;
+                case 'group':
+                    arr[i].group = entry[1];
+                    break;
             }
 
             return arr;
@@ -438,12 +454,12 @@ export class ItemSheetSFRPG extends ItemSheet {
             if (!arr[i]) arr[i] = { formula: "", types: {}, operator: "" };
 
             switch (key) {
-            case 'formula':
-                arr[i].formula = entry[1];
-                break;
-            case 'types':
-                if (type) arr[i].types[type] = entry[1];
-                break;
+                case 'formula':
+                    arr[i].formula = entry[1];
+                    break;
+                case 'types':
+                    if (type) arr[i].types[type] = entry[1];
+                    break;
             }
 
             return arr;


### PR DESCRIPTION
I'm amazed no one noticed inline values like [[@details.level.value]] haven't worked consistently since the start of V10