### PR TITLE
Add framework for repost buttons on inline buttons

### DIFF
--- a/src/lang/de.json
+++ b/src/lang/de.json
@@ -929,6 +929,7 @@
                     "SenseDependent": "Sense Dependent"
                 }
             },
+            "SendToChat": "Send to chat",
             "TypeError": "{enricherType} parsing failed! Type is invalid."
         },
         "Environment": "Environment",
@@ -1539,11 +1540,14 @@
             "Feat": {
                 "ActionRecharge": "Aufladungsaktion",
                 "Charged": "Aufgeladen",
+                "CombatFeat": "Combat Feat",
                 "FeatureAttack": "Fähigkeitsangriff",
                 "FeatureCategory": "Feature Category",
+                "FeatureDetails": "Feature Details",
                 "FeatureUsage": "Fähigkeitsanwendung",
                 "RechargeOn": "Aufladen durch",
-                "Requirements": "Voraussetzungen"
+                "Requirements": "Voraussetzungen",
+                "SpecialAbilityType": "Special Ability Type"
             },
             "Goods": {
                 "Details": "Goods Details"
@@ -2381,6 +2385,11 @@
         "SortByFilterName": "Name",
         "Space": "Angriffsfläche",
         "Special": "Spezial",
+        "SpecialAbilityTypes": {
+            "Extraordinary": "Extraordinary (Ex)",
+            "SpellLike": "Spell-like Ability (Sp)",
+            "Supernatural": "Supernatural (Su)"
+        },
         "SpecialMaterials": {
             "Abysium": "Abysium",
             "Adamantine": "Adamantine Alloy",

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -929,6 +929,7 @@
                     "SenseDependent": "Sense Dependent"
                 }
             },
+            "SendToChat": "Send to chat",
             "TypeError": "{enricherType} parsing failed! Type is invalid."
         },
         "Environment": "Environment",
@@ -1538,13 +1539,13 @@
             "Feat": {
                 "ActionRecharge": "Action Recharge",
                 "Charged": "Charged",
+                "CombatFeat": "Combat Feat",
                 "FeatureAttack": "Feature Attack",
                 "FeatureCategory": "Feature Category",
                 "FeatureDetails": "Feature Details",
                 "FeatureUsage": "Feature Usage",
                 "RechargeOn": "Recharge On",
                 "Requirements": "Requirements",
-                "CombatFeat": "Combat Feat",
                 "SpecialAbilityType": "Special Ability Type"
             },
             "Goods": {
@@ -2384,9 +2385,9 @@
         "Space": "Space",
         "Special": "Special",
         "SpecialAbilityTypes": {
-          "Extraordinary": "Extraordinary (Ex)",
-          "Supernatural": "Supernatural (Su)",
-          "SpellLike": "Spell-like Ability (Sp)"
+            "Extraordinary": "Extraordinary (Ex)",
+            "SpellLike": "Spell-like Ability (Sp)",
+            "Supernatural": "Supernatural (Su)"
         },
         "SpecialMaterials": {
             "Abysium": "Abysium",

--- a/src/lang/fr.json
+++ b/src/lang/fr.json
@@ -929,6 +929,7 @@
                     "SenseDependent": "Sense Dependent"
                 }
             },
+            "SendToChat": "Send to chat",
             "TypeError": "{enricherType} parsing failed! Type is invalid."
         },
         "Environment": "Environment",
@@ -1539,11 +1540,14 @@
             "Feat": {
                 "ActionRecharge": "Recharge de l'action",
                 "Charged": "Chargé",
+                "CombatFeat": "Combat Feat",
                 "FeatureAttack": "Attaque du trait",
                 "FeatureCategory": "Feature Category",
+                "FeatureDetails": "Feature Details",
                 "FeatureUsage": "Utilisation du trait",
                 "RechargeOn": "Recharge",
-                "Requirements": "Prérequis"
+                "Requirements": "Prérequis",
+                "SpecialAbilityType": "Special Ability Type"
             },
             "Goods": {
                 "Details": "Goods Details"
@@ -2381,6 +2385,11 @@
         "SortByFilterName": "Nom",
         "Space": "Espace",
         "Special": "Spécial",
+        "SpecialAbilityTypes": {
+            "Extraordinary": "Extraordinary (Ex)",
+            "SpellLike": "Spell-like Ability (Sp)",
+            "Supernatural": "Supernatural (Su)"
+        },
         "SpecialMaterials": {
             "Abysium": "Abysium",
             "Adamantine": "Alliage d'adamantine",

--- a/src/lang/it.json
+++ b/src/lang/it.json
@@ -929,6 +929,7 @@
                     "SenseDependent": "Sense Dependent"
                 }
             },
+            "SendToChat": "Send to chat",
             "TypeError": "{enricherType} parsing failed! Type is invalid."
         },
         "Environment": "Environment",
@@ -1539,11 +1540,14 @@
             "Feat": {
                 "ActionRecharge": "Ricarica dell'Azione",
                 "Charged": "Carico",
+                "CombatFeat": "Combat Feat",
                 "FeatureAttack": "Attacco della Capacità",
                 "FeatureCategory": "Feature Category",
+                "FeatureDetails": "Feature Details",
                 "FeatureUsage": "Utilizzo della Capacità",
                 "RechargeOn": "Ricarica",
-                "Requirements": "Prerequisiti"
+                "Requirements": "Prerequisiti",
+                "SpecialAbilityType": "Special Ability Type"
             },
             "Goods": {
                 "Details": "Goods Details"
@@ -2381,6 +2385,11 @@
         "SortByFilterName": "Name",
         "Space": "Spazio",
         "Special": "Speciale",
+        "SpecialAbilityTypes": {
+            "Extraordinary": "Extraordinary (Ex)",
+            "SpellLike": "Spell-like Ability (Sp)",
+            "Supernatural": "Supernatural (Su)"
+        },
         "SpecialMaterials": {
             "Abysium": "Abysium",
             "Adamantine": "Adamantine Alloy",

--- a/src/lang/ja.json
+++ b/src/lang/ja.json
@@ -929,6 +929,7 @@
                     "SenseDependent": "Sense Dependent"
                 }
             },
+            "SendToChat": "Send to chat",
             "TypeError": "{enricherType} parsing failed! Type is invalid."
         },
         "Environment": "Environment",
@@ -1539,11 +1540,14 @@
             "Feat": {
                 "ActionRecharge": "Action Recharge",
                 "Charged": "Charged",
+                "CombatFeat": "Combat Feat",
                 "FeatureAttack": "Feature Attack",
                 "FeatureCategory": "Feature Category",
+                "FeatureDetails": "Feature Details",
                 "FeatureUsage": "Feature Usage",
                 "RechargeOn": "Recharge On",
-                "Requirements": "Requirements"
+                "Requirements": "Requirements",
+                "SpecialAbilityType": "Special Ability Type"
             },
             "Goods": {
                 "Details": "Goods Details"
@@ -2381,6 +2385,11 @@
         "SortByFilterName": "名前",
         "Space": "ｽﾍﾟｰｽ",
         "Special": "特殊",
+        "SpecialAbilityTypes": {
+            "Extraordinary": "Extraordinary (Ex)",
+            "SpellLike": "Spell-like Ability (Sp)",
+            "Supernatural": "Supernatural (Su)"
+        },
         "SpecialMaterials": {
             "Abysium": "Abysium",
             "Adamantine": "Adamantine Alloy",

--- a/src/lang/pt-BR.json
+++ b/src/lang/pt-BR.json
@@ -929,6 +929,7 @@
                     "SenseDependent": "Sense Dependent"
                 }
             },
+            "SendToChat": "Send to chat",
             "TypeError": "{enricherType} parsing failed! Type is invalid."
         },
         "Environment": "Ambiente",
@@ -1539,11 +1540,14 @@
             "Feat": {
                 "ActionRecharge": "Ação Recarga",
                 "Charged": "Carga",
+                "CombatFeat": "Combat Feat",
                 "FeatureAttack": "Talento Ataque",
                 "FeatureCategory": "Feature Category",
+                "FeatureDetails": "Feature Details",
                 "FeatureUsage": "Talento Uso",
                 "RechargeOn": "Recarga Ativa",
-                "Requirements": "Requerimentos"
+                "Requirements": "Requerimentos",
+                "SpecialAbilityType": "Special Ability Type"
             },
             "Goods": {
                 "Details": "Goods Details"
@@ -2381,6 +2385,11 @@
         "SortByFilterName": "Nome",
         "Space": "Espaço",
         "Special": "Especial",
+        "SpecialAbilityTypes": {
+            "Extraordinary": "Extraordinary (Ex)",
+            "SpellLike": "Spell-like Ability (Sp)",
+            "Supernatural": "Supernatural (Su)"
+        },
         "SpecialMaterials": {
             "Abysium": "Abysium",
             "Adamantine": "Adamantine Alloy",

--- a/src/less/apps.less
+++ b/src/less/apps.less
@@ -76,12 +76,10 @@ a.enriched-link {
             margin-left: 2px;
             text-shadow: none;
 
-
             &:hover {
                 color: var(--color-shadow-primary);
                 text-shadow: 0px 0px 2px black;
                 transition: inherit;
-
             }
         }
     }

--- a/src/less/apps.less
+++ b/src/less/apps.less
@@ -58,10 +58,32 @@ a.enriched-link {
     white-space: nowrap;
     word-break: break-all;
     line-height: 1.6em;
+    transition: text-shadow .15s ease-in-out,
+        background-color .15s ease-in-out,
+        border .15s ease-in-out,
+        color .15s ease-in-out,
+        box-shadow .15s ease-in-out;
 
     i {
         color: var(--color-text-dark-inactive);
         margin-right: 0.25em;
+
+        &.repost {
+            border-left: 1px solid var(--color-border-dark-tertiary);
+            background: #FFF9;
+            padding: 2px;
+            margin-right: -4px;
+            margin-left: 2px;
+            text-shadow: none;
+
+
+            &:hover {
+                color: var(--color-shadow-primary);
+                text-shadow: 0px 0px 2px black;
+                transition: inherit;
+
+            }
+        }
     }
 }
 

--- a/src/module/system/enrichers/base.js
+++ b/src/module/system/enrichers/base.js
@@ -146,7 +146,7 @@ export default class BaseEnricher {
 
         a.innerText = this.name;
 
-        if (this._hasRepost) a = this.addRepost(a);
+        if (this.#_hasRepost) a = this.addRepost(a);
 
         return a;
     }
@@ -159,10 +159,12 @@ export default class BaseEnricher {
 
     /**
      * Should this enricher have a repost button appended to created elements?
-     * Create both a publically accessable static variable and an internal instance one.
+     * Create both a publicly accessible static variable and an internal instance one.
+     * @type {Boolean}
      */
     static hasRepost = false;
-    _hasRepost = this.constructor.hasRepost;
+    /** @type {Boolean} */
+    #_hasRepost = this.constructor.hasRepost;
 
     /**
      * Take an anchor element and append a repost button
@@ -180,7 +182,7 @@ export default class BaseEnricher {
     }
 
     /**
-     * `this` is the instance of the class fished out of CONFIG, so we can access instance variables.
+     * Handle repost button click, sending a chat message of the current target to chat.
      * @param {Event} event
      * @returns Create a chat message
      */

--- a/src/module/system/enrichers/base.js
+++ b/src/module/system/enrichers/base.js
@@ -20,6 +20,12 @@ export default class BaseEnricher {
         this.enricher = this.enricherFunc.bind(this);
     }
 
+    /** --------
+    |           |
+    |  Getters  |
+    |           |
+    ----------*/
+
     /**
      * The RegExp to capture the text.
      * @returns {RegExp}
@@ -51,6 +57,12 @@ export default class BaseEnricher {
     get icons() {
         throw new Error("This method must be implemented on subclasses of BaseEnricher.");
     }
+
+    /** -------------------
+    |                      |
+    |  Element Generation  |
+    |                      |
+    ----------------------*/
 
     /**
      * Transform the Regex match array into an enriched element, performing validation.
@@ -124,7 +136,7 @@ export default class BaseEnricher {
      * @returns {HTMLAnchorElement}
      */
     createElement() {
-        const a = document.createElement("a");
+        let a = document.createElement("a");
 
         a.dataset.action = this.enricherType;
         a.dataset.type = this.args.type;
@@ -134,8 +146,55 @@ export default class BaseEnricher {
 
         a.innerText = this.name;
 
+        if (this._hasRepost) a = this.addRepost(a);
+
         return a;
     }
+
+    /** -------
+    |          |
+    |  Repost  |
+    |          |
+    -----------*/
+
+    /**
+     * Should this enricher have a repost button appended to created elements?
+     * Create both a publically accessable static variable and an internal instance one.
+     */
+    static hasRepost = false;
+    _hasRepost = this.constructor.hasRepost;
+
+    /**
+     * Take an anchor element and append a repost button
+     * @param {HTMLAnchorElement} a The original anchor
+     * @returns The inputted Anchor, with a repost button appended
+     */
+    addRepost(a) {
+        let repost = document.createElement("i");
+        repost.classList.add("fas", "fa-comment-alt", "repost");
+        repost.dataset.tooltip = "SFRPG.Enrichers.SendToChat";
+
+        a.append(repost);
+
+        return a;
+    }
+
+    /**
+     * `this` is the instance of the class fished out of CONFIG, so we can access instance variables.
+     * @param {Event} event
+     * @returns Create a chat message
+     */
+    static repostListener(event) {
+        event.stopPropagation();
+
+        return ChatMessage.create({content: event.currentTarget.parentElement.outerHTML});
+    }
+
+    /** ---------
+    |            |
+    |  Listener  |
+    |            |
+    ------------*/
 
     /**
      * Whether the enricher has an event listener.
@@ -146,17 +205,18 @@ export default class BaseEnricher {
     /**
      * A callback function to run when the element is clicked.
      * @param {Event} event The DOM event that triggers the listener
-     * @returns {*}
+     * @returns {void}
      */
     static listener(event) {}
 
+    /**
+     * Add Event listeners to the DOM body at startup.
+     */
     static addListeners() {
         const body = $("body");
+        body.on("click", `i.repost`, this.repostListener);
         for (const [action, cls] of Object.entries(CONFIG.SFRPG.enricherTypes)) {
-            if (!cls.hasListener) continue;
-            const enricherListener = cls.listener;
-
-            body.on("click", `a[data-action="${action}"]`, enricherListener);
+            if (cls.hasListener) body.on("click", `a[data-action="${action}"]`, cls.listener);
         }
     }
 }

--- a/src/module/system/enrichers/browser.js
+++ b/src/module/system/enrichers/browser.js
@@ -19,10 +19,10 @@ export default class BrowserEnricher extends BaseEnricher {
 
     /**
      * @override
-     * Override to use angle brackets so any JSON doesn't interfere with closing brackets
+     * Override to use normal brackets so any JSON doesn't interfere with closing brackets
      */
     get regex() {
-        return new RegExp(`(@${this.enricherType})<([^>]+)>(?:{([^}]+)})?`, "gm");
+        return new RegExp(`(@${this.enricherType})\\(([^>]+)\\)(?:{([^}]+)})?`, "gm");
     }
 
     /** @inheritdoc */
@@ -53,7 +53,7 @@ export default class BrowserEnricher extends BaseEnricher {
 
         if (this.args.filters) a.dataset.filters = JSON.stringify(this.args.filters);
 
-        a.innerHTML = `<i class="fas ${this.icons[this.args.type]}"></i>${this.name}`;
+        a.innerHTML = `<i class="fas ${this.icons[this.args.type]}"></i>${a.innerHTML}`;
 
         return a;
 

--- a/src/module/system/enrichers/check.js
+++ b/src/module/system/enrichers/check.js
@@ -90,12 +90,13 @@ export default class CheckEnricher extends BaseEnricher {
 
         if (this.args.dc) a.dataset.dc = parseInt(this.args.dc);
 
-        a.innerHTML = `<i class="fas ${this.icons[this.args.type]}"></i>${this.name}`;
+        a.innerHTML = `<i class="fas ${this.icons[this.args.type]}"></i>${a.innerHTML}`;
 
         return a;
 
     }
 
+    static hasRepost = true;
     static hasListener = true;
 
     static listener(event) {

--- a/src/sfrpg.js
+++ b/src/sfrpg.js
@@ -249,6 +249,10 @@ Hooks.once('init', async function() {
     console.log("Starfinder | [READY] Preloading handlebar templates");
     preloadHandlebarsTemplates();
 
+    console.log("Starfinder | [READY] Setting up inline buttons");
+    CONFIG.TextEditor.enrichers.push(new BrowserEnricher(), new IconEnricher(), new CheckEnricher());
+    BaseEnricher.addListeners();
+
     const finishTime = (new Date()).getTime();
     console.log(`Starfinder | [INIT] Done (operation took ${finishTime - initTime} ms)`);
 });
@@ -401,10 +405,6 @@ Hooks.once("ready", async () => {
 
     console.log("Starfinder | [READY] Applying artwork from modules to compendiums");
     registerCompendiumArt();
-
-    console.log("Starfinder | [READY] Setting up inline buttons");
-    CONFIG.TextEditor.enrichers.push(new BrowserEnricher(), new IconEnricher(), new CheckEnricher());
-    BaseEnricher.addListeners();
 
     if (game.user.isGM) {
         const currentSchema = game.settings.get('sfrpg', 'worldSchemaVersion') ?? 0;


### PR DESCRIPTION
***BREAKING***: `@Browser` now uses `()` instead of `<>` since the latter gets eaten in chat messages. It can be worked around by including spaces or `\` but ultimately that's bad UX so we should rip off this band-aid now.