### PR TITLE
Pictures, and minor fix on disintegration lash and Metabolic Stability

### DIFF
--- a/src/items/class-features/entropic_pool_(su).json
+++ b/src/items/class-features/entropic_pool_(su).json
@@ -2,7 +2,7 @@
   "_id": "1HVLxal9WXqtMiCg",
   "name": "Entropic Pool (Su)",
   "type": "actorResource",
-  "img": "icons/svg/item-bag.svg",
+  "img": "icons/magic/unholy/strike-body-explode-disintegrate.webp",
   "system": {
     "type": "vanguard",
     "abilityMods": {
@@ -52,6 +52,7 @@
       "mode": "immediate"
     },
     "source": "COM pg. 50",
+    "stage": "early",
     "subType": "entropicPool"
   }
 }

--- a/src/items/class-features/exergy.json
+++ b/src/items/class-features/exergy.json
@@ -2,13 +2,14 @@
   "_id": "NsxuKKOs4oqxwngX",
   "name": "Exergy",
   "type": "feat",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "icons/skills/melee/maneuver-greatsword-yellow.webp",
   "system": {
     "type": "",
     "ability": null,
     "abilityMods": {
       "parts": []
     },
+    "actionTarget": "",
     "actionType": "",
     "activation": {
       "type": "",
@@ -30,20 +31,63 @@
     "damage": {
       "parts": []
     },
+    "damageNotes": "",
     "description": {
       "chat": "",
+      "gmnotes": "",
+      "short": "",
       "unidentified": "",
       "value": "<p>&gt;@UUID[Compendium.sfrpg.class-features.wq8dRJYQ58VZQuZU]{First Vanguard Aspect}</p>\n<p>You embody the total amount of potential work the energy in a system can perform when accessed by entropy.</p>\n<p>@UUID[Compendium.sfrpg.class-features.Ib9Lkj71QWj7akKg]{Exergy Insight (Ex)} You gain @UUID[Compendium.sfrpg.feats.0Pq35gvSI2JlD682]{Improved Combat Maneuver (trip)} as a bonus feat and a +2 insight bonus to Intimidate checks.</p>\n<p>@UUID[Compendium.sfrpg.class-features.uIC3dnxRBosrQ9DC]{Exergy Embodiment (Ex)} Once per combat, when you make two or more attacks in the same turn, you can gain 1 Entropy Point without taking any additional action.</p>\n<p>@UUID[Compendium.sfrpg.class-features.cw3pEFiZ07czkWZN]{Exergy Catalyst (Su)} Each foe within 30 feet must attempt a Fortitude saving throw. On a failed save, a creature takes an additional 1d6 damage per 2 vanguard levels from the next damaging attack that hits it within the next minute.</p>\n<p><em>Improved</em>: The additional damage is 1d6 per vanguard level.</p>\n<p>@UUID[Compendium.sfrpg.class-features.RrmY1Bs7MttrKhbx]{Exergy Finale (Su)} When you hit a foe with your entropic strike and the attack roll is a natural 18 or 19 (meaning the d20 shows an 18 or 19), you can apply one critical hit effect of that attack to your target, but you do not double the damage. This critical hit effect is treated as a critical hit for purposes of abilities that affect critical hits. If you roll a natural 20, the normal critical hit rules apply instead.</p>"
     },
-    "descriptors": [],
+    "descriptors": {
+      "acid": false,
+      "air": false,
+      "calling": false,
+      "chaotic": false,
+      "charm": false,
+      "cold": false,
+      "compulsion": false,
+      "creation": false,
+      "curse": false,
+      "darkness": false,
+      "death": false,
+      "disease": false,
+      "earth": false,
+      "electricity": false,
+      "emotion": false,
+      "evil": false,
+      "fear": false,
+      "fire": false,
+      "force": false,
+      "good": false,
+      "healing": false,
+      "language-dependent": false,
+      "lawful": false,
+      "light": false,
+      "mind-affecting": false,
+      "pain": false,
+      "poison": false,
+      "polymorph": false,
+      "radiation": false,
+      "scrying": false,
+      "sense-dependent": false,
+      "shadow": false,
+      "sonic": false,
+      "summoning": false,
+      "teleportation": false,
+      "water": false
+    },
     "details": {
-      "category": "classFeature"
+      "category": "classFeature",
+      "combat": false,
+      "specialAbilityType": ""
     },
     "duration": {
       "units": "",
       "value": null
     },
     "formula": "",
+    "isActive": null,
     "modifiers": [],
     "range": {
       "additional": "",
@@ -56,6 +100,7 @@
       "value": null
     },
     "requirements": "2nd Level",
+    "rollNotes": "",
     "save": {
       "type": "",
       "dc": null,

--- a/src/items/class-features/exergy_insight_(ex).json
+++ b/src/items/class-features/exergy_insight_(ex).json
@@ -2,13 +2,14 @@
   "_id": "Ib9Lkj71QWj7akKg",
   "name": "Exergy Insight (Ex)",
   "type": "feat",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "icons/skills/melee/strike-sword-gray.webp",
   "system": {
     "type": "",
     "ability": null,
     "abilityMods": {
       "parts": []
     },
+    "actionTarget": "",
     "actionType": "",
     "activation": {
       "type": "",
@@ -30,14 +31,55 @@
     "damage": {
       "parts": []
     },
+    "damageNotes": "",
     "description": {
       "chat": "",
+      "gmnotes": "",
+      "short": "",
       "unidentified": "",
       "value": "<p>&gt;@UUID[Compendium.sfrpg.class-features.NsxuKKOs4oqxwngX]{Exergy}</p>\n<p>You gain @UUID[Compendium.sfrpg.feats.0Pq35gvSI2JlD682]{Improved Combat Maneuver (trip)} as a bonus feat and a +2 insight bonus to Intimidate checks.</p>"
     },
-    "descriptors": [],
+    "descriptors": {
+      "acid": false,
+      "air": false,
+      "calling": false,
+      "chaotic": false,
+      "charm": false,
+      "cold": false,
+      "compulsion": false,
+      "creation": false,
+      "curse": false,
+      "darkness": false,
+      "death": false,
+      "disease": false,
+      "earth": false,
+      "electricity": false,
+      "emotion": false,
+      "evil": false,
+      "fear": false,
+      "fire": false,
+      "force": false,
+      "good": false,
+      "healing": false,
+      "language-dependent": false,
+      "lawful": false,
+      "light": false,
+      "mind-affecting": false,
+      "pain": false,
+      "poison": false,
+      "polymorph": false,
+      "radiation": false,
+      "scrying": false,
+      "sense-dependent": false,
+      "shadow": false,
+      "sonic": false,
+      "summoning": false,
+      "teleportation": false,
+      "water": false
+    },
     "details": {
       "category": "classFeature",
+      "combat": false,
       "specialAbilityType": "ex"
     },
     "duration": {
@@ -45,6 +87,7 @@
       "value": null
     },
     "formula": "",
+    "isActive": null,
     "modifiers": [
       {
         "_id": "c5e3c7af-ace2-4a0e-a2ed-ea5157b8c367",
@@ -73,6 +116,7 @@
       "value": null
     },
     "requirements": "Aspect Insight",
+    "rollNotes": "",
     "save": {
       "type": "",
       "dc": null,

--- a/src/items/class-features/metabolic_stability_(ex).json
+++ b/src/items/class-features/metabolic_stability_(ex).json
@@ -2,13 +2,14 @@
   "_id": "vEYD9O1trlqlIPQO",
   "name": "Metabolic Stability (Ex)",
   "type": "feat",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "icons/creatures/abilities/wolf-heads-swirl-purple.webp",
   "system": {
     "type": "",
     "ability": null,
     "abilityMods": {
       "parts": []
     },
+    "actionTarget": "",
     "actionType": "",
     "activation": {
       "type": "",
@@ -30,14 +31,55 @@
     "damage": {
       "parts": []
     },
+    "damageNotes": "",
     "description": {
       "chat": "",
+      "gmnotes": "",
+      "short": "",
       "unidentified": "",
-      "value": "<p>&gt;@UUID[Compendium.sfrpg.class-features.Dysu4F8licjEb2FY]{Vanguard Discipline}</p>\n<p>Your control of the chemical processes in your own body gives you significant vigor. You gain Diehard as a bonus feat.</p>"
+      "value": "<p>&gt;@UUID[Compendium.sfrpg.class-features.Dysu4F8licjEb2FY]{Vanguard Discipline}</p>\n<p>Your control of the chemical processes in your own body gives you significant vigor. You gain @UUID[Compendium.sfrpg.feats.4WOgAfmOTll6oqGo]{Diehard} as a bonus feat.</p>"
     },
-    "descriptors": [],
+    "descriptors": {
+      "acid": false,
+      "air": false,
+      "calling": false,
+      "chaotic": false,
+      "charm": false,
+      "cold": false,
+      "compulsion": false,
+      "creation": false,
+      "curse": false,
+      "darkness": false,
+      "death": false,
+      "disease": false,
+      "earth": false,
+      "electricity": false,
+      "emotion": false,
+      "evil": false,
+      "fear": false,
+      "fire": false,
+      "force": false,
+      "good": false,
+      "healing": false,
+      "language-dependent": false,
+      "lawful": false,
+      "light": false,
+      "mind-affecting": false,
+      "pain": false,
+      "poison": false,
+      "polymorph": false,
+      "radiation": false,
+      "scrying": false,
+      "sense-dependent": false,
+      "shadow": false,
+      "sonic": false,
+      "summoning": false,
+      "teleportation": false,
+      "water": false
+    },
     "details": {
       "category": "classFeature",
+      "combat": false,
       "specialAbilityType": "ex"
     },
     "duration": {
@@ -45,6 +87,7 @@
       "value": null
     },
     "formula": "",
+    "isActive": null,
     "modifiers": [],
     "range": {
       "additional": "",
@@ -57,6 +100,7 @@
       "value": null
     },
     "requirements": "2nd Level",
+    "rollNotes": "",
     "save": {
       "type": "",
       "dc": null,

--- a/src/items/class-features/mitigate_(ex).json
+++ b/src/items/class-features/mitigate_(ex).json
@@ -2,13 +2,14 @@
   "_id": "5bNbood0KKzBbKyv",
   "name": "Mitigate (Ex)",
   "type": "feat",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "icons/magic/control/silhouette-hold-beam-blue.webp",
   "system": {
     "type": "",
     "ability": null,
     "abilityMods": {
       "parts": []
     },
+    "actionTarget": "",
     "actionType": "",
     "activation": {
       "type": "reaction",
@@ -30,14 +31,55 @@
     "damage": {
       "parts": []
     },
+    "damageNotes": "",
     "description": {
       "chat": "",
+      "gmnotes": "",
+      "short": "",
       "unidentified": "",
       "value": "<p>&gt;@UUID[Compendium.sfrpg.classes.WDvGdJ5mMpAD9cWQ]{Vanguard}</p>\n<p>You can control how you are affected by damage or effects that alter damage. As a reaction when you take damage, you can spend 1 Entropy Point to reduce the damage you take by an amount equal to your vanguard level (to a minimum of 0 damage). If you do, you can’t gain any Entropy Points from that attack.</p>\n<p>Additionally, as a swift action, you can remove any DR or energy resistance you have, or the AC benefit of any ability or spell that increases your AC. If the effect granting DR or energy resistance has a duration, this ends the effect entirely for you. If you end an AC benefit, that AC benefit is ended for the duration of the effect. If the ability does not normally have a duration, you suspend the listed benefits until the beginning of your next turn. Additionally, whenever you first come under the effect of an ability or spell that grants you DR, energy resistance, or a bonus to AC, you can waive that benefit of the effect.</p>"
     },
-    "descriptors": [],
+    "descriptors": {
+      "acid": false,
+      "air": false,
+      "calling": false,
+      "chaotic": false,
+      "charm": false,
+      "cold": false,
+      "compulsion": false,
+      "creation": false,
+      "curse": false,
+      "darkness": false,
+      "death": false,
+      "disease": false,
+      "earth": false,
+      "electricity": false,
+      "emotion": false,
+      "evil": false,
+      "fear": false,
+      "fire": false,
+      "force": false,
+      "good": false,
+      "healing": false,
+      "language-dependent": false,
+      "lawful": false,
+      "light": false,
+      "mind-affecting": false,
+      "pain": false,
+      "poison": false,
+      "polymorph": false,
+      "radiation": false,
+      "scrying": false,
+      "sense-dependent": false,
+      "shadow": false,
+      "sonic": false,
+      "summoning": false,
+      "teleportation": false,
+      "water": false
+    },
     "details": {
       "category": "classFeature",
+      "combat": false,
       "specialAbilityType": "ex"
     },
     "duration": {
@@ -45,6 +87,7 @@
       "value": ""
     },
     "formula": "",
+    "isActive": null,
     "modifiers": [],
     "range": {
       "additional": "",
@@ -57,6 +100,7 @@
       "value": null
     },
     "requirements": "2nd Level",
+    "rollNotes": "",
     "save": {
       "type": "",
       "dc": null,

--- a/src/items/class-features/reactive_(ex).json
+++ b/src/items/class-features/reactive_(ex).json
@@ -2,13 +2,14 @@
   "_id": "avUIfY50kR6ZwAv5",
   "name": "Reactive (Ex)",
   "type": "feat",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "icons/magic/movement/abstract-ribbons-red-orange.webp",
   "system": {
     "type": "",
     "ability": null,
     "abilityMods": {
       "parts": []
     },
+    "actionTarget": "",
     "actionType": "",
     "activation": {
       "type": "",
@@ -30,14 +31,55 @@
     "damage": {
       "parts": []
     },
+    "damageNotes": "",
     "description": {
       "chat": "",
+      "gmnotes": "",
+      "short": "",
       "unidentified": "",
       "value": "<p>&gt;@UUID[Compendium.sfrpg.classes.WDvGdJ5mMpAD9cWQ]{Vanguard}</p>\n<p>Once per day, you can take an additional reaction during a single round, though you can still take only one reaction per triggering event. You can take a reaction before the first time you act in a combat, but not in a surprise round in which you are unable to act.</p>\n<p>At 9th level and again at 15th level, you can use this ability one additional time per day, though you can never use this ability to take more than two reactions in a round or one per triggering event.</p>"
     },
-    "descriptors": [],
+    "descriptors": {
+      "acid": false,
+      "air": false,
+      "calling": false,
+      "chaotic": false,
+      "charm": false,
+      "cold": false,
+      "compulsion": false,
+      "creation": false,
+      "curse": false,
+      "darkness": false,
+      "death": false,
+      "disease": false,
+      "earth": false,
+      "electricity": false,
+      "emotion": false,
+      "evil": false,
+      "fear": false,
+      "fire": false,
+      "force": false,
+      "good": false,
+      "healing": false,
+      "language-dependent": false,
+      "lawful": false,
+      "light": false,
+      "mind-affecting": false,
+      "pain": false,
+      "poison": false,
+      "polymorph": false,
+      "radiation": false,
+      "scrying": false,
+      "sense-dependent": false,
+      "shadow": false,
+      "sonic": false,
+      "summoning": false,
+      "teleportation": false,
+      "water": false
+    },
     "details": {
       "category": "classFeature",
+      "combat": false,
       "specialAbilityType": "ex"
     },
     "duration": {
@@ -45,6 +87,7 @@
       "value": null
     },
     "formula": "",
+    "isActive": null,
     "modifiers": [],
     "range": {
       "additional": "",
@@ -57,6 +100,7 @@
       "value": null
     },
     "requirements": "3rd Level",
+    "rollNotes": "",
     "save": {
       "type": "",
       "dc": null,

--- a/src/items/equipment/disintegration_lash_decimator.json
+++ b/src/items/equipment/disintegration_lash_decimator.json
@@ -2,7 +2,7 @@
   "_id": "COZFwSlbmu5pT3jc",
   "name": "Disintegration lash, decimator",
   "type": "weapon",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "icons/weapons/misc/whip-red-yellow.webp",
   "system": {
     "type": "",
     "ability": "str",
@@ -16,6 +16,7 @@
       "condition": "",
       "cost": null
     },
+    "ammunitionType": "charge",
     "area": {
       "effect": "",
       "shape": "",
@@ -50,6 +51,7 @@
     "chatFlavor": "",
     "container": {
       "contents": [],
+      "includeContentsInWealthCalculation": true,
       "isOpen": true,
       "storage": [
         {
@@ -92,16 +94,28 @@
     "damage": {
       "parts": [
         {
+          "name": "",
           "formula": "1d10 + @abilities.str.mod",
-          "operator": "",
+          "group": null,
           "types": {
-            "acid": true
+            "acid": true,
+            "bludgeoning": false,
+            "cold": false,
+            "electricity": false,
+            "fire": false,
+            "healing": false,
+            "piercing": false,
+            "slashing": false,
+            "sonic": false
           }
         }
       ]
     },
+    "damageNotes": "",
     "description": {
       "chat": "",
+      "gmnotes": "",
+      "short": "",
       "unidentified": "",
       "value": "<p>A disintegration lash is a marvel of bioengineering—a technological living organism that feeds on matter by breaking it down with its own high-energy proton-decoupling field. The result is a black, snakelike lash crackling with red-tinged energy, making this a weapon commonly wielded by those looking to intimidate their foes. Disintegration lashes are designated in the standard method for disintegrator weapons: liquidator, decimator, executioner, and eradicator.</p>"
     },
@@ -110,6 +124,7 @@
       "units": "",
       "value": ""
     },
+    "equippable": false,
     "equipped": false,
     "formula": "",
     "identified": true,
@@ -132,6 +147,7 @@
       "breach": false,
       "breakdown": false,
       "bright": false,
+      "buttressing": false,
       "cluster": false,
       "conceal": false,
       "deconstruct": false,
@@ -150,15 +166,18 @@
       "force": false,
       "freeHands": false,
       "fueled": false,
+      "gearArray": false,
       "grapple": false,
       "gravitation": false,
       "guided": false,
       "harrying": false,
       "holyWater": false,
       "hybrid": false,
+      "hydrodynamic": false,
       "ignite": false,
       "indirect": false,
       "injection": false,
+      "instrumental": false,
       "integrated": false,
       "line": false,
       "living": true,
@@ -176,6 +195,7 @@
       "polymorphic": false,
       "powered": true,
       "professional": false,
+      "propel": false,
       "punchGun": false,
       "qreload": false,
       "radioactive": false,
@@ -184,7 +204,9 @@
       "regrowth": false,
       "relic": false,
       "reposition": false,
+      "scramble": false,
       "shape": false,
+      "shatter": false,
       "shells": false,
       "shield": false,
       "sniper": false,
@@ -197,6 +219,7 @@
       "thought": false,
       "throttle": false,
       "thrown": false,
+      "thruster": false,
       "trip": false,
       "two": false,
       "unbalancing": false,
@@ -206,19 +229,41 @@
       "wideLine": false
     },
     "quantity": 1,
+    "quantityPerPack": 1,
     "range": {
       "additional": "",
       "per": "",
       "units": "ft",
       "value": 10
     },
+    "rollNotes": "",
     "save": {
       "type": "",
       "dc": "",
       "descriptor": "negate"
     },
+    "skillCheck": {
+      "type": "",
+      "dc": ""
+    },
     "source": "AR pg. 10",
     "special": "",
+    "specialMaterials": {
+      "abysium": false,
+      "adamantine": false,
+      "coldiron": false,
+      "diatha": false,
+      "djezet": false,
+      "horacalcum": false,
+      "inubrix": false,
+      "khefak": false,
+      "noqual": false,
+      "nyblantine": false,
+      "purplecores": false,
+      "siccatite": false,
+      "silver": false,
+      "voidglass": false
+    },
     "target": {
       "type": "",
       "value": ""

--- a/src/items/equipment/disintegration_lash_eradicator.json
+++ b/src/items/equipment/disintegration_lash_eradicator.json
@@ -2,7 +2,7 @@
   "_id": "h6ugumhUrs4V0Fht",
   "name": "Disintegration lash, eradicator",
   "type": "weapon",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "icons/weapons/misc/whip-red-yellow.webp",
   "system": {
     "type": "",
     "ability": "str",
@@ -16,6 +16,7 @@
       "condition": "",
       "cost": null
     },
+    "ammunitionType": "charge",
     "area": {
       "effect": "",
       "shape": "",
@@ -50,6 +51,7 @@
     "chatFlavor": "",
     "container": {
       "contents": [],
+      "includeContentsInWealthCalculation": true,
       "isOpen": true,
       "storage": [
         {
@@ -92,16 +94,28 @@
     "damage": {
       "parts": [
         {
+          "name": "",
           "formula": "4d20 + @abilities.str.mod",
-          "operator": "",
+          "group": null,
           "types": {
-            "acid": true
+            "acid": true,
+            "bludgeoning": false,
+            "cold": false,
+            "electricity": false,
+            "fire": false,
+            "healing": false,
+            "piercing": false,
+            "slashing": false,
+            "sonic": false
           }
         }
       ]
     },
+    "damageNotes": "",
     "description": {
       "chat": "",
+      "gmnotes": "",
+      "short": "",
       "unidentified": "",
       "value": "<p>A disintegration lash is a marvel of bioengineering—a technological living organism that feeds on matter by breaking it down with its own high-energy proton-decoupling field. The result is a black, snakelike lash crackling with red-tinged energy, making this a weapon commonly wielded by those looking to intimidate their foes. Disintegration lashes are designated in the standard method for disintegrator weapons: liquidator, decimator, executioner, and eradicator.</p>"
     },
@@ -110,6 +124,7 @@
       "units": "",
       "value": ""
     },
+    "equippable": false,
     "equipped": false,
     "formula": "",
     "identified": true,
@@ -132,6 +147,7 @@
       "breach": false,
       "breakdown": false,
       "bright": false,
+      "buttressing": false,
       "cluster": false,
       "conceal": false,
       "deconstruct": false,
@@ -150,15 +166,18 @@
       "force": false,
       "freeHands": false,
       "fueled": false,
+      "gearArray": false,
       "grapple": false,
       "gravitation": false,
       "guided": false,
       "harrying": false,
       "holyWater": false,
       "hybrid": false,
+      "hydrodynamic": false,
       "ignite": false,
       "indirect": false,
       "injection": false,
+      "instrumental": false,
       "integrated": false,
       "line": false,
       "living": true,
@@ -176,6 +195,7 @@
       "polymorphic": false,
       "powered": true,
       "professional": false,
+      "propel": false,
       "punchGun": false,
       "qreload": false,
       "radioactive": false,
@@ -184,7 +204,9 @@
       "regrowth": false,
       "relic": false,
       "reposition": false,
+      "scramble": false,
       "shape": false,
+      "shatter": false,
       "shells": false,
       "shield": false,
       "sniper": false,
@@ -197,6 +219,7 @@
       "thought": false,
       "throttle": false,
       "thrown": false,
+      "thruster": false,
       "trip": false,
       "two": false,
       "unbalancing": false,
@@ -206,19 +229,41 @@
       "wideLine": false
     },
     "quantity": 1,
+    "quantityPerPack": 1,
     "range": {
       "additional": "",
       "per": "",
       "units": "ft",
       "value": 10
     },
+    "rollNotes": "",
     "save": {
       "type": "",
       "dc": "",
       "descriptor": "negate"
     },
+    "skillCheck": {
+      "type": "",
+      "dc": ""
+    },
     "source": "AR pg. 10",
     "special": "",
+    "specialMaterials": {
+      "abysium": false,
+      "adamantine": false,
+      "coldiron": false,
+      "diatha": false,
+      "djezet": false,
+      "horacalcum": false,
+      "inubrix": false,
+      "khefak": false,
+      "noqual": false,
+      "nyblantine": false,
+      "purplecores": false,
+      "siccatite": false,
+      "silver": false,
+      "voidglass": false
+    },
     "target": {
       "type": "",
       "value": ""

--- a/src/items/equipment/disintegration_lash_executioner.json
+++ b/src/items/equipment/disintegration_lash_executioner.json
@@ -2,7 +2,7 @@
   "_id": "csJB6G2AUgnRhU2C",
   "name": "Disintegration lash, executioner",
   "type": "weapon",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "icons/weapons/misc/whip-red-yellow.webp",
   "system": {
     "type": "",
     "ability": "str",
@@ -16,6 +16,7 @@
       "condition": "",
       "cost": null
     },
+    "ammunitionType": "charge",
     "area": {
       "effect": "",
       "shape": "",
@@ -50,6 +51,7 @@
     "chatFlavor": "",
     "container": {
       "contents": [],
+      "includeContentsInWealthCalculation": true,
       "isOpen": true,
       "storage": [
         {
@@ -92,16 +94,28 @@
     "damage": {
       "parts": [
         {
+          "name": "",
           "formula": "2d20 + @abilities.str.mod",
-          "operator": "",
+          "group": null,
           "types": {
-            "acid": true
+            "acid": true,
+            "bludgeoning": false,
+            "cold": false,
+            "electricity": false,
+            "fire": false,
+            "healing": false,
+            "piercing": false,
+            "slashing": false,
+            "sonic": false
           }
         }
       ]
     },
+    "damageNotes": "",
     "description": {
       "chat": "",
+      "gmnotes": "",
+      "short": "",
       "unidentified": "",
       "value": "<p>A disintegration lash is a marvel of bioengineering—a technological living organism that feeds on matter by breaking it down with its own high-energy proton-decoupling field. The result is a black, snakelike lash crackling with red-tinged energy, making this a weapon commonly wielded by those looking to intimidate their foes. Disintegration lashes are designated in the standard method for disintegrator weapons: liquidator, decimator, executioner, and eradicator.</p>"
     },
@@ -110,6 +124,7 @@
       "units": "",
       "value": ""
     },
+    "equippable": false,
     "equipped": false,
     "formula": "",
     "identified": true,
@@ -132,6 +147,7 @@
       "breach": false,
       "breakdown": false,
       "bright": false,
+      "buttressing": false,
       "cluster": false,
       "conceal": false,
       "deconstruct": false,
@@ -150,15 +166,18 @@
       "force": false,
       "freeHands": false,
       "fueled": false,
+      "gearArray": false,
       "grapple": false,
       "gravitation": false,
       "guided": false,
       "harrying": false,
       "holyWater": false,
       "hybrid": false,
+      "hydrodynamic": false,
       "ignite": false,
       "indirect": false,
       "injection": false,
+      "instrumental": false,
       "integrated": false,
       "line": false,
       "living": true,
@@ -176,6 +195,7 @@
       "polymorphic": false,
       "powered": true,
       "professional": false,
+      "propel": false,
       "punchGun": false,
       "qreload": false,
       "radioactive": false,
@@ -184,7 +204,9 @@
       "regrowth": false,
       "relic": false,
       "reposition": false,
+      "scramble": false,
       "shape": false,
+      "shatter": false,
       "shells": false,
       "shield": false,
       "sniper": false,
@@ -197,6 +219,7 @@
       "thought": false,
       "throttle": false,
       "thrown": false,
+      "thruster": false,
       "trip": false,
       "two": false,
       "unbalancing": false,
@@ -206,19 +229,41 @@
       "wideLine": false
     },
     "quantity": 1,
+    "quantityPerPack": 1,
     "range": {
       "additional": "",
       "per": "",
       "units": "ft",
       "value": 10
     },
+    "rollNotes": "",
     "save": {
       "type": "",
       "dc": "",
       "descriptor": "negate"
     },
+    "skillCheck": {
+      "type": "",
+      "dc": ""
+    },
     "source": "AR pg. 10",
     "special": "",
+    "specialMaterials": {
+      "abysium": false,
+      "adamantine": false,
+      "coldiron": false,
+      "diatha": false,
+      "djezet": false,
+      "horacalcum": false,
+      "inubrix": false,
+      "khefak": false,
+      "noqual": false,
+      "nyblantine": false,
+      "purplecores": false,
+      "siccatite": false,
+      "silver": false,
+      "voidglass": false
+    },
     "target": {
       "type": "",
       "value": ""

--- a/src/items/equipment/disintegration_lash_liquidator.json
+++ b/src/items/equipment/disintegration_lash_liquidator.json
@@ -2,7 +2,7 @@
   "_id": "pcSmuTD42jh8G9A2",
   "name": "Disintegration lash, liquidator",
   "type": "weapon",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "icons/weapons/misc/whip-red-yellow.webp",
   "system": {
     "type": "",
     "ability": "str",
@@ -16,6 +16,7 @@
       "condition": "",
       "cost": null
     },
+    "ammunitionType": "charge",
     "area": {
       "effect": "",
       "shape": "",
@@ -50,6 +51,7 @@
     "chatFlavor": "",
     "container": {
       "contents": [],
+      "includeContentsInWealthCalculation": true,
       "isOpen": true,
       "storage": [
         {
@@ -92,16 +94,28 @@
     "damage": {
       "parts": [
         {
+          "name": "",
           "formula": "1d6 + @abilities.str.mod",
-          "operator": "",
+          "group": null,
           "types": {
-            "acid": true
+            "acid": true,
+            "bludgeoning": false,
+            "cold": false,
+            "electricity": false,
+            "fire": false,
+            "healing": false,
+            "piercing": false,
+            "slashing": false,
+            "sonic": false
           }
         }
       ]
     },
+    "damageNotes": "",
     "description": {
       "chat": "",
+      "gmnotes": "",
+      "short": "",
       "unidentified": "",
       "value": "<p>A disintegration lash is a marvel of bioengineering—a technological living organism that feeds on matter by breaking it down with its own high-energy proton-decoupling field. The result is a black, snakelike lash crackling with red-tinged energy, making this a weapon commonly wielded by those looking to intimidate their foes. Disintegration lashes are designated in the standard method for disintegrator weapons: liquidator, decimator, executioner, and eradicator.</p>"
     },
@@ -110,6 +124,7 @@
       "units": "",
       "value": ""
     },
+    "equippable": false,
     "equipped": false,
     "formula": "",
     "identified": true,
@@ -132,6 +147,7 @@
       "breach": false,
       "breakdown": false,
       "bright": false,
+      "buttressing": false,
       "cluster": false,
       "conceal": false,
       "deconstruct": false,
@@ -150,15 +166,18 @@
       "force": false,
       "freeHands": false,
       "fueled": false,
+      "gearArray": false,
       "grapple": false,
       "gravitation": false,
       "guided": false,
       "harrying": false,
       "holyWater": false,
       "hybrid": false,
+      "hydrodynamic": false,
       "ignite": false,
       "indirect": false,
       "injection": false,
+      "instrumental": false,
       "integrated": false,
       "line": false,
       "living": true,
@@ -176,6 +195,7 @@
       "polymorphic": false,
       "powered": true,
       "professional": false,
+      "propel": false,
       "punchGun": false,
       "qreload": false,
       "radioactive": false,
@@ -184,7 +204,9 @@
       "regrowth": false,
       "relic": false,
       "reposition": false,
+      "scramble": false,
       "shape": false,
+      "shatter": false,
       "shells": false,
       "shield": false,
       "sniper": false,
@@ -197,6 +219,7 @@
       "thought": false,
       "throttle": false,
       "thrown": false,
+      "thruster": false,
       "trip": false,
       "two": false,
       "unbalancing": false,
@@ -206,19 +229,41 @@
       "wideLine": false
     },
     "quantity": 1,
+    "quantityPerPack": 1,
     "range": {
       "additional": "",
       "per": "",
       "units": "ft",
       "value": 10
     },
+    "rollNotes": "",
     "save": {
       "type": "",
       "dc": "",
       "descriptor": "negate"
     },
+    "skillCheck": {
+      "type": "",
+      "dc": ""
+    },
     "source": "AR pg. 10",
     "special": "",
+    "specialMaterials": {
+      "abysium": false,
+      "adamantine": false,
+      "coldiron": false,
+      "diatha": false,
+      "djezet": false,
+      "horacalcum": false,
+      "inubrix": false,
+      "khefak": false,
+      "noqual": false,
+      "nyblantine": false,
+      "purplecores": false,
+      "siccatite": false,
+      "silver": false,
+      "voidglass": false
+    },
     "target": {
       "type": "",
       "value": ""

--- a/src/items/racial-features/stony_plates.json
+++ b/src/items/racial-features/stony_plates.json
@@ -2,7 +2,7 @@
   "_id": "d1Wjor8GNeHAuzU0",
   "name": "Stony Plates",
   "type": "feat",
-  "img": "icons/svg/mystery-man.svg",
+  "img": "icons/commodities/biological/shell-ribbed-grey.webp",
   "system": {
     "type": "",
     "ability": null,
@@ -67,16 +67,20 @@
       "mind-affecting": false,
       "pain": false,
       "poison": false,
+      "polymorph": false,
       "radiation": false,
       "scrying": false,
       "sense-dependent": false,
       "shadow": false,
+      "sonic": false,
       "summoning": false,
       "teleportation": false,
       "water": false
     },
     "details": {
-      "category": "speciesFeature"
+      "category": "speciesFeature",
+      "combat": false,
+      "specialAbilityType": ""
     },
     "duration": {
       "units": "",


### PR DESCRIPTION
Added pictures to: Entropic Pool, Exergy, Exergy Insight, Metabolic Stability, Mitigate, Reactive and Stony Plates.
Fixed ammunition on disintegration lash and added picture to them as well.
Linked Diehard feat on Metabolic Stability's description.