### PR TITLE
Quick fix for container wealth calculation

### DIFF
--- a/src/module/item/item.js
+++ b/src/module/item/item.js
@@ -438,7 +438,7 @@ export class ItemSFRPG extends Mix(Item).with(ItemActivationMixin, ItemCapacityM
 
         if (this.type === "container") {
             if (this.actor) {
-                const wealthString = new Intl.NumberFormat(game.i18n.lang).format(Math.floor(this.system.itemWealth.contentWealth));
+                const wealthString = new Intl.NumberFormat(game.i18n.lang).format(Math.floor(this.contentWealth));
                 const wealthProperty = game.i18n.format("SFRPG.CharacterSheet.Inventory.ContainedWealth", {wealth: wealthString});
                 props.push({
                     name: wealthProperty,


### PR DESCRIPTION
Fixes the path to a container's contained wealth value. An error was being thrown when containers were clicked to expand, which this corrects.