### PR TITLE
Trait selector update

### DIFF
--- a/src/less/apps.less
+++ b/src/less/apps.less
@@ -223,14 +223,25 @@ img.icon-enricher {
     }
 
     &.app {
-        .trait-list {
-            li input[type="text"] {
-                flex: 0 0 65%;
-                text-align: center;
-            }
-            .energy-resistance .checkbox {
-                flex: 0 0 33%;
-                text-align: left;
+        .trait-selector {
+            max-height: 480px;
+            
+            .trait-list {
+                display: flex;
+                flex-wrap: wrap;
+                justify-content: flex-start;
+
+                li {
+                    flex: 0 0 150px;
+                }
+                /*li input[type="text"] {
+                    flex: 0 0 65%;
+                    text-align: center;
+                }
+                .energy-resistance .checkbox {
+                    flex: 0 0 33%;
+                    text-align: left;
+                }*/
             }
         }
     }

--- a/src/module/apps/trait-selector.js
+++ b/src/module/apps/trait-selector.js
@@ -62,10 +62,7 @@ export class TraitSelectorSFRPG extends FormApplication {
             }
         }
 
-        this.sorters = {
-            text: '',
-            castingtime: 'null'
-        };
+        this.searchTerm = '';
 
         return {
             choices: choices,
@@ -132,6 +129,17 @@ export class TraitSelectorSFRPG extends FormApplication {
         });
     }
 
+    async filterTraits(li) {
+        let ct = 0;
+        li.hide();
+
+        for (const trait of li) {
+            if (this.searchTerm === '') {
+                $(trait).show();
+            }
+        }
+    }
+
     async filterItems(li) {
         let counter = 0;
         li.hide();
@@ -155,7 +163,8 @@ export class TraitSelectorSFRPG extends FormApplication {
             for (const string of strings) {
                 if (string.indexOf(':') === -1) {
                     console.log($(element).find('.trait'));
-                    if ($(element).find('.trait')[0].innerHTML.toLowerCase().indexOf(string.toLowerCase().trim()) === -1) {
+                    console.log($(element).find('.trait').prevObject[0].innerHTML);
+                    if ($(element).find('.trait').prevObject[0].innerHTML.toLowerCase().indexOf(string.toLowerCase().trim()) === -1) {
                         return false;
                     }
                 } else {
@@ -207,10 +216,11 @@ export class TraitSelectorSFRPG extends FormApplication {
 
         // activating or deactivating filters
         html.on('change paste', 'input[name=textFilter]', ev => {
-            console.log(this);
-            this.sorters.text = ev.target.value;
-            this.filterItems(html.find('li'));
+            this.searchTerm = ev.target.value;
+            this.filterTraits(html.find('li'));
         });
+
+        // on Enter key press, filter based on search
 
     }
 }

--- a/src/module/apps/trait-selector.js
+++ b/src/module/apps/trait-selector.js
@@ -13,7 +13,6 @@ export class TraitSelectorSFRPG extends FormApplication {
         options.template = "systems/sfrpg/templates/apps/trait-selector.hbs";
         options.width = 480;
         options.height = "auto";
-        console.log(options);
 
         return options;
     }
@@ -33,6 +32,7 @@ export class TraitSelectorSFRPG extends FormApplication {
      * @returns {Object}
      */
     getData() {
+        console.log(this);
         const attr = getProperty(this.object, this.attribute);
         if (typeof attr.value === "string") attr.value = this.constructor._backCompat(attr.value, this.options.choices);
 
@@ -61,6 +61,11 @@ export class TraitSelectorSFRPG extends FormApplication {
                 }
             }
         }
+
+        this.sorters = {
+            text: '',
+            castingtime: 'null'
+        };
 
         return {
             choices: choices,
@@ -149,7 +154,8 @@ export class TraitSelectorSFRPG extends FormApplication {
 
             for (const string of strings) {
                 if (string.indexOf(':') === -1) {
-                    if ($(element).find('.item-name a')[0].innerHTML.toLowerCase().indexOf(string.toLowerCase().trim()) === -1) {
+                    console.log($(element).find('.trait'));
+                    if ($(element).find('.trait')[0].innerHTML.toLowerCase().indexOf(string.toLowerCase().trim()) === -1) {
                         return false;
                     }
                 } else {
@@ -201,6 +207,7 @@ export class TraitSelectorSFRPG extends FormApplication {
 
         // activating or deactivating filters
         html.on('change paste', 'input[name=textFilter]', ev => {
+            console.log(this);
             this.sorters.text = ev.target.value;
             this.filterItems(html.find('li'));
         });

--- a/src/templates/apps/trait-selector.hbs
+++ b/src/templates/apps/trait-selector.hbs
@@ -1,5 +1,15 @@
-<form autocomplete="off" onsubmit="event.preventDefault();">
-    <ol class="trait-list">
+<form class="trait-selector" autocomplete="off" onsubmit="event.preventDefault();">
+
+    {{!-- Search Bar --}}
+    <div class="sortcontainer" id="tagfilter">
+        <input class="" name="textFilter" type="text" value="" data-dtype="String" placeholder="{{localize "SFRPG.Browsers.ItemBrowser.BrowserSearchPlaceholder"}}" data-tooltip="{{localize "SFRPG.Browsers.ItemBrowser.BrowserSearchTitle"}}"/>
+        <div class="hint" style="display:none;">
+            {{{localize "SFRPG.Browsers.ItemBrowser.SearchHint"}}}
+        </div>
+    </div>
+
+    {{!-- Trait List --}}
+    <ul class="trait-list">
     {{#unless isEnergyResistance}}
         {{#each choices as |choice key|}}
         <li>
@@ -21,10 +31,14 @@
         </li>
         {{/each}}
     {{/unless}}
-    </ol>
+    </ul>
+
+    {{!-- Special Traits --}}
     <div class="form-group stacked">
         <label>Special</label>
         <input type="text" name="custom" value="{{custom}}" data-dtype="String"/>
     </div>
+
+    {{!-- Save and Exit Button --}}
     <button type="submit" name="submit" value="1"><i class="far fa-save"></i> Update Actor</button>
 </form>

--- a/src/templates/apps/trait-selector.hbs
+++ b/src/templates/apps/trait-selector.hbs
@@ -2,7 +2,7 @@
 
     {{!-- Search Bar --}}
     <div class="sortcontainer" id="tagfilter">
-        <input class="" name="textFilter" type="text" value="" data-dtype="String" placeholder="{{localize "SFRPG.Browsers.ItemBrowser.BrowserSearchPlaceholder"}}" data-tooltip="{{localize "SFRPG.Browsers.ItemBrowser.BrowserSearchTitle"}}"/>
+        <input class="" name="textFilter" type="text" value="" data-dtype="String" placeholder="{{localize "SFRPG.Browsers.ItemBrowser.BrowserSearchPlaceholder"}}"/>
         <div class="hint" style="display:none;">
             {{{localize "SFRPG.Browsers.ItemBrowser.SearchHint"}}}
         </div>
@@ -12,7 +12,7 @@
     <ul class="trait-list">
     {{#unless isEnergyResistance}}
         {{#each choices as |choice key|}}
-        <li>
+        <li class="trait">
             <label class="checkbox">
                 <input type="checkbox" name="{{key}}" data-dtype="Boolean" {{checked choice.chosen}}>
                 {{choice.label}}

--- a/src/templates/apps/trait-selector.hbs
+++ b/src/templates/apps/trait-selector.hbs
@@ -21,7 +21,7 @@
         {{/each}}
     {{else}}
         {{#each choices as |choice key|}}
-        <li class="flexrow energy-resistance">
+        <li class="flexrow energy-resistance trait">
             <label class="checkbox">
                 <input type="checkbox" name="er.{{key}}.0" data-dtype="Boolean" {{checked choice.chosen}}>
                 {{choice.label}}


### PR DESCRIPTION
This PR updates the trait selector app.

### New/Modified Features List
- [x] Restrict the maximum height of the trait selector
- [x] Draw traits in 3 columns instead of one
- [x] Add a text search/filter field
- [ ] Set up weapon properties to use this trait selector
- [ ] Update visual styling to look nicer

### Stretch Goal
- [ ] Set selected (checked) weapon properties to include a text field that can be edited (e.g. to indicate something like Explode (5ft))
- [ ] Backend data structure updates to enable this
- [ ] Migration script to not kill everyone's world actors