### PR TITLE
Refactor Modifiers to use DataModels

### DIFF
--- a/src/less/apps.less
+++ b/src/less/apps.less
@@ -813,8 +813,20 @@ aside#tooltip,
     border-image: linear-gradient(180deg, #424242, #333333 25%, #333333 75%, #424242 100%) 1 1;
     font-size: var(--font-size-14);
 
-    // The tooltip always has text-center, so we make text-center left!
+    // The tooltip always has the class `text-center`, so we make `text-center` left!
     &.text-center {
         text-align: left;
+    }
+}
+
+div.modifier-app {
+    fieldset {
+        &:disabled {
+            display: none;
+        }
+
+        border-color: @borderGroove;
+        border-radius: 5px;
+        backdrop-filter: brightness(0.9);
     }
 }

--- a/src/module/actor/actor.js
+++ b/src/module/actor/actor.js
@@ -82,7 +82,10 @@ export class ActorSFRPG extends Mix(Actor).with(ActorConditionsMixin, ActorCrewM
         super.prepareData();
 
         this._ensureHasModifiers(this.system);
-        const modifiers = this.getAllModifiers();
+        const modifiers = this.getAllModifiers(false, false, true);
+
+        // Store all modifiers, from the actor and from items, on the actor in an instantiated state.
+        this.system.allModifiers = modifiers;
 
         // const timedEffects = SFRPGTimedEffect.getAllTimedEffects(this);
         this.system.timedEffects = new Map();

--- a/src/module/actor/mixins/actor-modifiers.js
+++ b/src/module/actor/mixins/actor-modifiers.js
@@ -76,7 +76,7 @@ export const ActorModifiersMixin = (superclass) => class extends superclass {
             damage
         }));
 
-        await this.update({["system.modifiers"]: modifiers});
+        await this.update({"system.modifiers": modifiers});
     }
 
     /**
@@ -114,8 +114,8 @@ export const ActorModifiersMixin = (superclass) => class extends superclass {
         if (!invalidate && this.system.modifiers) return this.system.allModifiers;
 
         this.system.modifiers = this.system.modifiers.map(mod => {
-            mod.container = {actorUuid: this.uuid, itemUuid: null};
-            return new SFRPGModifier({...mod, id: mod._id}, { includeContainer: true });
+            const container = {actorUuid: this.uuid, itemUuid: null};
+            return new SFRPGModifier({...mod, container});
         }, this);
 
         const allModifiers = this.system.modifiers.filter(mod => (!ignoreTemporary || mod.subtab === "permanent"));
@@ -125,8 +125,8 @@ export const ActorModifiersMixin = (superclass) => class extends superclass {
 
             // Create each modifier as an SFRPGModifier instance first on the item data.
             const itemModifiers = itemData.modifiers = itemData.modifiers.map(mod => {
-                mod.container = {actorUuid: this.uuid, itemUuid: item.uuid};
-                return new SFRPGModifier({...mod, id: mod._id}, { includeContainer: true });
+                const container = {actorUuid: this.uuid, itemUuid: item.uuid};
+                return new SFRPGModifier({...mod, container});
             }, this);
 
             let modifiersToPush = [];

--- a/src/module/actor/mixins/actor-modifiers.js
+++ b/src/module/actor/mixins/actor-modifiers.js
@@ -52,7 +52,9 @@ export const ActorModifiersMixin = (superclass) => class extends superclass {
         source = "",
         notes = "",
         condition = "",
-        id = null
+        id = null,
+        limitTo = "",
+        damage = null
     } = {}) {
         const data = this._ensureHasModifiers(duplicate(this.system));
         const modifiers = data.modifiers;
@@ -69,7 +71,9 @@ export const ActorModifiersMixin = (superclass) => class extends superclass {
             notes,
             subtab,
             condition,
-            id
+            id,
+            limitTo,
+            damage
         }));
 
         await this.update({["system.modifiers"]: modifiers});
@@ -92,7 +96,7 @@ export const ActorModifiersMixin = (superclass) => class extends superclass {
      * @param {String} id The id for the modifier to edit
      */
     editModifier(id) {
-        const modifiers = duplicate(this.system.modifiers);
+        const modifiers = this.system.modifiers;
         const modifier = modifiers.find(mod => mod._id === id);
 
         new SFRPGModifierApplication(modifier, this).render(true);
@@ -103,21 +107,29 @@ export const ActorModifiersMixin = (superclass) => class extends superclass {
      *
      * @param {Boolean} ignoreTemporary Should we ignore temporary modifiers? Defaults to false.
      * @param {Boolean} ignoreEquipment Should we ignore equipment modifiers? Defaults to false.
+     * @param {Boolean} invalidate Whether to ignore `this.system.allModifiers` and generate all modifiers anew.
+     * @returns {SFRPGModifier[]}
      */
-    getAllModifiers(ignoreTemporary = false, ignoreEquipment = false) {
-        let allModifiers = this.system.modifiers.filter(mod => {
-            return (!ignoreTemporary || mod.subtab === "permanent");
-        });
+    getAllModifiers(ignoreTemporary = false, ignoreEquipment = false, invalidate = false) {
+        if (!invalidate && this.system.modifiers) return this.system.allModifiers;
 
-        for (const actorModifier of allModifiers) {
-            actorModifier.container = {actorId: this.id, itemId: null};
-        }
+        this.system.modifiers = this.system.modifiers.map(mod => {
+            mod.container = {actorUuid: this.uuid, itemUuid: null};
+            return new SFRPGModifier({...mod, id: mod._id}, { includeContainer: true });
+        }, this);
+
+        const allModifiers = this.system.modifiers.filter(mod => (!ignoreTemporary || mod.subtab === "permanent"));
 
         for (const item of this.items) {
             const itemData = item.system;
-            const itemModifiers = itemData.modifiers;
 
-            let modifiersToConcat = [];
+            // Create each modifier as an SFRPGModifier instance first on the item data.
+            const itemModifiers = itemData.modifiers = itemData.modifiers.map(mod => {
+                mod.container = {actorUuid: this.uuid, itemUuid: item.uuid};
+                return new SFRPGModifier({...mod, id: mod._id}, { includeContainer: true });
+            }, this);
+
+            let modifiersToPush = [];
             switch (item.type) {
             // Armor upgrades are only valid if they are slotted into an equipped armor
                 case "upgrade":
@@ -125,7 +137,7 @@ export const ActorModifiersMixin = (superclass) => class extends superclass {
                     if (!ignoreEquipment) {
                         const container = getItemContainer(this.items, item);
                         if (container && container.type === "equipment" && container.system.equipped) {
-                            modifiersToConcat = itemModifiers;
+                            modifiersToPush = itemModifiers;
                         }
                     }
                     break;
@@ -138,7 +150,7 @@ export const ActorModifiersMixin = (superclass) => class extends superclass {
                     if (!ignoreEquipment) {
                         const container = getItemContainer(this.items, item);
                         if (container && container.type === "weapon" && container.system.equipped) {
-                            modifiersToConcat = itemModifiers;
+                            modifiersToPush = itemModifiers;
                         }
                     }
                     break;
@@ -147,7 +159,7 @@ export const ActorModifiersMixin = (superclass) => class extends superclass {
                 // Feats are only active when they are passive, or activated
                 case "feat":
                     if (itemData.activation?.type === "" || itemData.isActive) {
-                        modifiersToConcat = itemModifiers;
+                        modifiersToPush = itemModifiers;
                     }
                     break;
 
@@ -156,34 +168,26 @@ export const ActorModifiersMixin = (superclass) => class extends superclass {
                 case "shield":
                 case "weapon":
                     if (!ignoreEquipment && itemData.equipped) {
-                        modifiersToConcat = itemModifiers;
+                        modifiersToPush = itemModifiers;
                     }
                     break;
 
                 case "actorResource":
                     if (itemData.enabled && itemData.type && itemData.subType && (itemData.base || itemData.base === 0)) {
-                        modifiersToConcat = itemModifiers;
+                        modifiersToPush = itemModifiers;
                     }
                     break;
 
                 // Everything else
                 default:
                     if (!itemData.equippable || itemData.equipped) {
-                        modifiersToConcat = itemModifiers;
+                        modifiersToPush = itemModifiers;
                     }
                     break;
             }
 
-            if (modifiersToConcat && modifiersToConcat.length > 0) {
-                for (const itemModifier of modifiersToConcat) {
-                    itemModifier.container = {actorId: this.id, itemId: item.id};
-                    if (this.token) {
-                        itemModifier.container.tokenId = this.token?.id;
-                        itemModifier.container.sceneId = this.token?.parent?.id;
-                    }
-                }
-
-                allModifiers = allModifiers.concat(modifiersToConcat);
+            if (modifiersToPush.length > 0) {
+                allModifiers.push(...modifiersToPush);
             }
         }
         return allModifiers;

--- a/src/module/apps/modifier-app.js
+++ b/src/module/apps/modifier-app.js
@@ -1,4 +1,3 @@
-import SFRPGModifier from "../modifiers/modifier.js";
 import { SFRPGEffectType } from "../modifiers/types.js";
 
 /**
@@ -313,7 +312,7 @@ export default class SFRPGModifierApplication extends FormApplication {
     }
 
     async _updateModifierData(formData) {
-        const modifiers = duplicate(this.target.system.modifiers);
+        const modifiers = this.target.system.modifiers;
         const index = modifiers.findIndex(mod => mod._id === this.modifier._id);
         const modifier = modifiers[index];
 
@@ -329,8 +328,9 @@ export default class SFRPGModifierApplication extends FormApplication {
             modifier.max = 0;
         }
 
-        const newModifier = new SFRPGModifier(mergeObject(modifier, formData));
-        modifiers[index] = newModifier;
+        const merged = mergeObject(modifier, formData);
+        modifier.updateSource(merged);
+        modifiers[index] = modifier;
 
         return this.target.update({ "system.modifiers": modifiers });
     }

--- a/src/module/apps/modifier-app.js
+++ b/src/module/apps/modifier-app.js
@@ -316,7 +316,7 @@ export default class SFRPGModifierApplication extends FormApplication {
         const index = modifiers.findIndex(mod => mod._id === this.modifier._id);
         const modifier = modifiers[index];
 
-        const formula = formData["modifier"];
+        const formula = String(formData["modifier"] || "0");
         if (formula) {
             try {
                 const roll = Roll.create(formula, this.owningActor?.system || this.target.system);

--- a/src/module/apps/modifier-app.js
+++ b/src/module/apps/modifier-app.js
@@ -1,3 +1,4 @@
+import SFRPGModifier from "../modifiers/modifier.js";
 import { SFRPGEffectType } from "../modifiers/types.js";
 
 /**
@@ -12,7 +13,7 @@ export default class SFRPGModifierApplication extends FormApplication {
     constructor(modifier, target, options = {}, owningActor = null) {
         super(modifier, options);
 
-        this.actor = target;
+        this.target = target;
         this.owningActor = owningActor;
     }
 
@@ -70,12 +71,12 @@ export default class SFRPGModifierApplication extends FormApplication {
      */
     getData() {
         const data = {
-            isOwner: this.actor.isOwner,
+            isOwner: this.target.isOwner,
             modifier: this.modifier,
-            limited: this.actor.limited,
+            limited: this.target.limited,
             options: this.options,
             editable: this.isEditable,
-            cssClass: this.actor.isOwner ? "editable" : "locked",
+            cssClass: this.target.isOwner ? "editable" : "locked",
             config: CONFIG.SFRPG
         };
 
@@ -92,10 +93,10 @@ export default class SFRPGModifierApplication extends FormApplication {
         html.find(".modifier-modifier-type select").change(event => {
             const modifierType = event.currentTarget.value;
 
-            const damageSectionDetails = $("section.damage-section-details");
+            const damageSectionDetails = $("fieldset.damage-section-details");
 
-            if (modifierType !== "damageSection") damageSectionDetails.hide();
-            else damageSectionDetails.show();
+            if (modifierType !== "damageSection") damageSectionDetails.prop("disabled", true);
+            else damageSectionDetails.prop("disabled", false);
 
             this.setPosition({ height: "auto" });
         });
@@ -110,15 +111,15 @@ export default class SFRPGModifierApplication extends FormApplication {
             const damageSectionType = $("option[value='damageSection']");
 
             if (!(this.damageEffectTypes.includes(effectType))) {
-                $("section.damage-section-details").hide(); // Damage section details
+                $("fieldset.damage-section-details").prop("disabled", true); // Damage section details
                 damageSectionType.hide(); // Damage section modifier type
             } else {
                 damageSectionType.show();
             }
 
             // Hide limit to setting if modifier doesn't affect an item
-            if (!(this.limitToTypes.includes(effectType))) $("div.modifier-limit-to").hide();
-            else $("div.modifier-limit-to").show();
+            if (!(this.limitToTypes.includes(effectType))) $("fieldset.modifier-limit-to").prop("disabled", true);
+            else $("fieldset.modifier-limit-to").prop("disabled", false);
 
             if (oldValue === SFRPGEffectType.ACTOR_RESOURCE || effectType === SFRPGEffectType.ACTOR_RESOURCE) {
                 const modifierDialog = this;
@@ -251,11 +252,11 @@ export default class SFRPGModifierApplication extends FormApplication {
         const valueAffectedElement = this.element.find(".modifier-value-affected select");
         const modifierTypeElement = this.element.find(".modifier-modifier-type select");
 
-        if (modifierTypeElement.val() === "damageSection") $("section.damage-section-details").show();
+        if (modifierTypeElement.val() === "damageSection") $("fieldset.damage-section-details").prop("disabled", false);
         if (this.damageEffectTypes.includes(effectType)) $("option[value='damageSection']").show();
 
-        if (!(this.limitToTypes.includes(effectType))) $("div.modifier-limit-to").hide();
-        else $("div.modifier-limit-to").show();
+        if (!(this.limitToTypes.includes(effectType))) $("fieldset.modifier-limit-to").prop("disabled", true);
+        else $("fieldset.modifier-limit-to").prop("disabled", false);
 
         switch (effectType) {
             case SFRPGEffectType.ABILITY_SKILLS:
@@ -312,13 +313,14 @@ export default class SFRPGModifierApplication extends FormApplication {
     }
 
     async _updateModifierData(formData) {
-        const modifiers = duplicate(this.actor.system.modifiers);
-        const modifier = modifiers.find(mod => mod._id === this.modifier._id);
+        const modifiers = duplicate(this.target.system.modifiers);
+        const index = modifiers.findIndex(mod => mod._id === this.modifier._id);
+        const modifier = modifiers[index];
 
         const formula = formData["modifier"];
         if (formula) {
             try {
-                const roll = Roll.create(formula, this.owningActor?.system || this.actor.system);
+                const roll = Roll.create(formula, this.owningActor?.system || this.target.system);
                 modifier.max = await roll.evaluate({ maximize: true }).total;
             } catch (err) {
                 ui.notifications.error(err);
@@ -327,8 +329,9 @@ export default class SFRPGModifierApplication extends FormApplication {
             modifier.max = 0;
         }
 
-        mergeObject(modifier, formData);
+        const newModifier = new SFRPGModifier(mergeObject(modifier, formData));
+        modifiers[index] = newModifier;
 
-        return this.actor.update({ "system.modifiers": modifiers });
+        return this.target.update({ "system.modifiers": modifiers });
     }
 }

--- a/src/module/apps/roll-dialog.js
+++ b/src/module/apps/roll-dialog.js
@@ -222,7 +222,7 @@ export default class RollDialog extends Dialog {
             const container = modifier.container;
             const actor = await fromUuid(container.actorUuid);
             if (container.itemUuid) {
-                const item = container.itemId ? actor.items.get(container.itemUuid) : null;
+                const item = container.itemUuid ? actor.items.get(fromUuidSync(container.itemUuid)._id) : null;
 
                 // Update modifier by ID in item
                 const containerModifiers = item.system.modifiers;

--- a/src/module/apps/roll-dialog.js
+++ b/src/module/apps/roll-dialog.js
@@ -218,11 +218,11 @@ export default class RollDialog extends Dialog {
         this.render(false);
 
         if (modifier._id) {
-            // Update container
+            // Update owner
             const owner = modifier.primaryOwner;
             if (!owner) return; // Will be undefined if using a global attack modifier
 
-            // Update modifier by ID in actor
+            // Update modifier by ID in owner
             const ownerModifiers = owner.system.modifiers;
             const modifierToUpdate = ownerModifiers.find(x => x._id === modifier._id);
             if (!modifierToUpdate) return; // God help us!

--- a/src/module/apps/roll-dialog.js
+++ b/src/module/apps/roll-dialog.js
@@ -210,15 +210,6 @@ export default class RollDialog extends Dialog {
         this.rollMode = event.target.value;
     }
 
-    _getActorForContainer(container) {
-        if (container.tokenId) {
-            const scene = game.scenes.get(container.sceneId);
-            const token = scene.tokens.get(container.tokenId);
-            return token.actor;
-        }
-        return game.actors.get(container.actorId);
-    }
-
     async _toggleModifierEnabled(event) {
         const modifierIndex = $(event.currentTarget).data('modifierIndex');
         const modifier = this.availableModifiers[modifierIndex];
@@ -229,18 +220,18 @@ export default class RollDialog extends Dialog {
         if (modifier._id) {
             // Update container
             const container = modifier.container;
-            const actor = this._getActorForContainer(container);
-            if (container.itemId) {
-                const item = container.itemId ? await actor.items.get(container.itemId) : null;
+            const actor = await fromUuid(container.actorUuid);
+            if (container.itemUuid) {
+                const item = container.itemId ? actor.items.get(container.itemUuid) : null;
 
                 // Update modifier by ID in item
-                const containerModifiers = duplicate(item.system.modifiers);
+                const containerModifiers = item.system.modifiers;
                 const modifierToUpdate = containerModifiers.find(x => x._id === modifier._id);
                 modifierToUpdate.enabled = modifier.enabled;
                 await item.update({ "system.modifiers": containerModifiers });
             } else {
                 // Update modifier by ID in actor
-                const containerModifiers = duplicate(actor.system.modifiers);
+                const containerModifiers = actor.system.modifiers;
                 const modifierToUpdate = containerModifiers.find(x => x._id === modifier._id);
                 modifierToUpdate.enabled = modifier.enabled;
                 await actor.update({ "system.modifiers": containerModifiers });

--- a/src/module/apps/roll-dialog.js
+++ b/src/module/apps/roll-dialog.js
@@ -219,23 +219,16 @@ export default class RollDialog extends Dialog {
 
         if (modifier._id) {
             // Update container
-            const container = modifier.container;
-            const actor = await fromUuid(container.actorUuid);
-            if (container.itemUuid) {
-                const item = container.itemUuid ? actor.items.get(fromUuidSync(container.itemUuid)._id) : null;
+            const owner = modifier.primaryOwner;
+            if (!owner) return; // Will be undefined if using a global attack modifier
 
-                // Update modifier by ID in item
-                const containerModifiers = item.system.modifiers;
-                const modifierToUpdate = containerModifiers.find(x => x._id === modifier._id);
-                modifierToUpdate.enabled = modifier.enabled;
-                await item.update({ "system.modifiers": containerModifiers });
-            } else {
-                // Update modifier by ID in actor
-                const containerModifiers = actor.system.modifiers;
-                const modifierToUpdate = containerModifiers.find(x => x._id === modifier._id);
-                modifierToUpdate.enabled = modifier.enabled;
-                await actor.update({ "system.modifiers": containerModifiers });
-            }
+            // Update modifier by ID in actor
+            const ownerModifiers = owner.system.modifiers;
+            const modifierToUpdate = ownerModifiers.find(x => x._id === modifier._id);
+            if (!modifierToUpdate) return; // God help us!
+            modifierToUpdate.enabled = modifier.enabled;
+            await owner.update({ "system.modifiers": ownerModifiers });
+
         }
     }
 

--- a/src/module/canvas/ability-template.js
+++ b/src/module/canvas/ability-template.js
@@ -1,6 +1,6 @@
 import { MeasuredTemplateSFRPG } from "./template-overrides.js";
 /**
- * A helper class to provide a preview interface for placable templates
+ * A helper class to provide a preview interface for placeable templates
  *
  * @augments MeasuredTemplateSFRPG
  */

--- a/src/module/item/item.js
+++ b/src/module/item/item.js
@@ -911,9 +911,9 @@ export class ItemSFRPG extends Mix(Item).with(ItemActivationMixin, ItemCapacityM
 
         /** Add Container Values to globalAttackRollModifiers */
         for (let addModsI = 0; addModsI < additionalModifiers.length; addModsI++) {
-            additionalModifiers[addModsI].container = {
+            additionalModifiers[addModsI].bonus.container = {
                 actorUuid: this.actor.uuid,
-                itemUuid: itemData.uuid
+                itemUuid: this.uuid
             };
         }
 

--- a/src/module/item/item.js
+++ b/src/module/item/item.js
@@ -906,16 +906,12 @@ export class ItemSFRPG extends Mix(Item).with(ItemActivationMixin, ItemCapacityM
 
         const rollContext = RollContext.createItemRollContext(this, this.actor, {itemData: itemData});
 
-        /** Create additional modifiers. */
-        const additionalModifiers = deepClone(SFRPG.globalAttackRollModifiers);
-
-        /** Add Container Values to globalAttackRollModifiers */
-        for (let addModsI = 0; addModsI < additionalModifiers.length; addModsI++) {
-            additionalModifiers[addModsI].bonus.container = {
-                actorUuid: this.actor.uuid,
-                itemUuid: this.uuid
-            };
-        }
+        /** Create global attack modifiers. */
+        const additionalModifiers = deepClone(SFRPG.globalAttackRollModifiers).map(mod => {
+            const container = {actorUuid: this.actor.uuid, itemUuid: this.uuid};
+            const modInstance = {bonus: new SFRPGModifier({...mod.bonus, container})};
+            return modInstance;
+        });
 
         /** Apply bonus rolled mods from relevant attack roll formula modifiers. */
         for (const rolledMod of rolledMods) {

--- a/src/module/item/item.js
+++ b/src/module/item/item.js
@@ -912,8 +912,8 @@ export class ItemSFRPG extends Mix(Item).with(ItemActivationMixin, ItemCapacityM
         /** Add Container Values to globalAttackRollModifiers */
         for (let addModsI = 0; addModsI < additionalModifiers.length; addModsI++) {
             additionalModifiers[addModsI].container = {
-                actorId: this.actor.id,
-                itemId: itemData.id
+                actorUuid: this.actor.uuid,
+                itemUuid: itemData.uuid
             };
         }
 
@@ -971,9 +971,9 @@ export class ItemSFRPG extends Mix(Item).with(ItemActivationMixin, ItemCapacityM
             // Remove inactive constant and damage section mods. Keep all situational mods, regardless of status.
             if (!mod.enabled && mod.modifierType !== SFRPGModifierType.FORMULA) return false;
 
-            if (mod.limitTo === "parent" && mod.container.itemId !== this.id) return false;
+            if (mod.limitTo === "parent" && mod.container.itemUuid !== this.uuid) return false;
             if (mod.limitTo === "container") {
-                const parentItem = getItemContainer(this.actor.items, this.actor.items.get(mod.container.itemId));
+                const parentItem = getItemContainer(this.actor.items, fromUuidSync(mod.container.itemUuid));
                 if (parentItem?.id !== this.id) return false;
             }
 
@@ -1340,9 +1340,9 @@ export class ItemSFRPG extends Mix(Item).with(ItemActivationMixin, ItemCapacityM
                 return false;
             }
 
-            if (mod.limitTo === "parent" && mod.container.itemId !== this.id) return false;
+            if (mod.limitTo === "parent" && mod.container.itemUuid !== this.uuid) return false;
             if (mod.limitTo === "container") {
-                const parentItem = getItemContainer(this.actor.items, this.actor.items.get(mod.container.itemId));
+                const parentItem = getItemContainer(this.actor.items, fromUuidSync(mod.container.itemUuid));
                 if (parentItem?.id !== this.id) return false;
             }
 
@@ -1840,7 +1840,9 @@ export class ItemSFRPG extends Mix(Item).with(ItemActivationMixin, ItemCapacityM
         source = "",
         notes = "",
         condition = "",
-        id = null
+        id = null,
+        limitTo = "",
+        damage = null
     } = {}) {
         const data = this._ensureHasModifiers(duplicate(this.system));
         const modifiers = data.modifiers;
@@ -1857,7 +1859,9 @@ export class ItemSFRPG extends Mix(Item).with(ItemActivationMixin, ItemCapacityM
             notes,
             subtab,
             condition,
-            id
+            id,
+            limitTo,
+            damage
         }));
 
         console.log("Adding a modifier to the item");

--- a/src/module/modifiers/modifier.js
+++ b/src/module/modifiers/modifier.js
@@ -26,11 +26,11 @@ export default class SFRPGModifier extends foundry.abstract.DataModel {
         super(data, options);
     }
 
-    _configure(options) {
+    _initializeSource(source, options = {}) {
         // Create a random id, or set the specific one if provided.
-        this._source._id ||= this._source.id || generateUUID();
+        source._id ||= source.id || generateUUID();
 
-        return super._configure(options);
+        return super._initializeSource(source, (options = {}));
     }
 
     // Slight hack to keep modifiers on the database or exported to JSON minimal and clean.
@@ -67,28 +67,66 @@ export default class SFRPGModifier extends foundry.abstract.DataModel {
         const fields = foundry.data.fields;
         return {
             _id: new fields.StringField({ initial: "", required: true, readonly: false }),
-            name: new fields.StringField({ initial: "New Modifier", required: false, blank: false }),
-            modifier: new fields.StringField({ initial: "0", required: true }),
+            name: new fields.StringField({
+                initial: "New Modifier",
+                required: false,
+                blank: false,
+                label: "SFRPG.ModifierNameLabel",
+                hint: "SFRPG.ModifierNameTooltip"
+            }),
+            modifier: new fields.StringField({
+                initial: "0",
+                required: true,
+                label: "SFRPG.ModifierModifierLabel",
+                hint: "SFRPG.ModifierModifierTooltip"
+            }),
             max: new fields.NumberField({ initial: 0, integer: true, required: false }),
             type: new fields.StringField({
                 initial: SFRPGModifierTypes.UNTYPED,
                 required: false,
-                choices: Object.values(SFRPGModifierTypes)
+                choices: Object.values(SFRPGModifierTypes),
+                label: "SFRPG.ModifierTypeLabel",
+                hint: "SFRPG.ModifierTypeTooltip"
             }),
             modifierType: new fields.StringField({
                 initial: SFRPGModifierType.CONSTANT,
                 required: true,
-                choices: Object.values(SFRPGModifierType).concat("damageSection")
+                choices: Object.values(SFRPGModifierType).concat("damageSection"),
+                label: "SFRPG.ModifierModifierTypeLabel",
+                hint: "SFRPG.ModifierModifierTypeTooltip"
             }),
             effectType: new fields.StringField({
                 initial: SFRPGEffectType.SKILL,
                 required: true,
-                choices: Object.values(SFRPGEffectType)
+                choices: Object.values(SFRPGEffectType),
+                label: "SFRPG.ModifierEffectTypeLabel",
+                hint: "SFRPG.ModifierEffectTypeTooltip"
             }),
-            valueAffected: new fields.StringField({ initial: "", required: false, blank: true }),
-            enabled: new fields.BooleanField({ initial: false, required: false }),
-            source: new fields.StringField({ initial: "", required: false }),
-            notes: new fields.HTMLField({ initial: "", required: false }),
+            valueAffected: new fields.StringField({
+                initial: "",
+                required: false,
+                blank: true,
+                label: "SFRPG.ModifierValueAffectedLabel",
+                hint: "SFRPG.ModifierValueAffectedTooltip"
+            }),
+            enabled: new fields.BooleanField({
+                initial: false,
+                required: false,
+                label: "SFRPG.ModifierEnabledLabel",
+                hint: "SFRPG.ModifierEnabledTooltip"
+            }),
+            source: new fields.StringField({
+                initial: "",
+                required: false,
+                label: "SFRPG.ModifierSourceLabel",
+                hint: "SFRPG.ModifierSourceTooltip"
+            }),
+            notes: new fields.HTMLField({
+                initial: "",
+                required: false,
+                label: "SFRPG.ModifierNotesLabel",
+                hint: "SFRPG.ModifierNotesTooltip"
+            }),
             subtab: new fields.StringField({
                 initial: "misc",
                 required: false,
@@ -105,7 +143,12 @@ export default class SFRPGModifier extends foundry.abstract.DataModel {
             ),
             damage: new fields.SchemaField(
                 {
-                    damageGroup: new fields.NumberField({ initial: null, required: false, nullable: true, integer: true }),
+                    damageGroup: new fields.NumberField({
+                        initial: null,
+                        required: false,
+                        nullable: true,
+                        integer: true
+                    }),
                     damageTypes: new fields.SchemaField(
                         [
                             ...Object.keys(CONFIG.SFRPG.energyDamageTypes),
@@ -124,7 +167,9 @@ export default class SFRPGModifier extends foundry.abstract.DataModel {
                 required: false,
                 nullable: true,
                 blank: true,
-                choices: ["", "parent", "container"]
+                choices: ["", "parent", "container"],
+                label: "SFRPG.ModifierLimitToLabel",
+                hint: "SFRPG.ModifierLimitToTooltip"
             })
         };
     }

--- a/src/module/modifiers/modifier.js
+++ b/src/module/modifiers/modifier.js
@@ -5,18 +5,24 @@ import { SFRPGEffectType, SFRPGModifierType, SFRPGModifierTypes } from "./types.
  * A data object that hold information about a specific modifier.
  *
  * @param {Object}        data               The data for the modifier.
- * @param {String}        data.name          The name for the modifier. Only useful for identifiying the modifier.
+ * @param {String}        data.name          The name for the modifier. Only useful for identifying the modifier.
  * @param {Number|String} data.modifier      The value to modify with. This can be either a constant number or a Roll formula.
  * @param {String}        data.type          The modifier type. This is used to determine if a modifier stacks or not.
- * @param {String}        data.modifierType  Determines if this modifer is a constant value (+2) or a roll formula (1d4).
+ * @param {String}        data.modifierType  Determines if this modifier is a constant value (+2) or a roll formula (1d4).
  * @param {String}        data.effectType    The category of things that might be modified by this value.
  * @param {String}        data.valueAffected The specific statistic being affected.
  * @param {Boolean}       data.enabled       Is this modifier enabled or not.
  * @param {String}        data.source        Where does this modifier come from? An item, or an ability?
- * @param {String}        data.notes         Any notes that are useful for this modifer.
+ * @param {String}        data.notes         Any notes that are useful for this modifier.
  * @param {String}        data.subtab        What subtab should this appear on in the character sheet?
  * @param {String}        data.condition     The condition, if any, that this modifier is associated with.
  * @param {String|null}   data.id            Override a random id with a specific one.
+ * @param {Object|null}   data.container     The UUIDs of the actor and item, if applicable, the modifier is owned by.
+ * @param {Object|null}   data.damage        If this modifier is a damage section modifier, the damage type and group
+ * @param {String}        data.limitTo       If this modifier is on an item, should the modifier affect only that item?
+ *
+ * @param {Object}        options            Options to configure this modifier
+ * @param {Boolean}       includeContainer   Whether the this modifier should include container information. True during data prep.
  */
 export default class SFRPGModifier {
     constructor({
@@ -31,7 +37,12 @@ export default class SFRPGModifier {
         notes = "",
         subtab = "misc",
         condition = "",
-        id = null
+        id = null,
+        container = null,
+        damage = null,
+        limitTo = ""
+    } = {}, {
+        includeContainer = false
     } = {}) {
         this.name = name;
         this.modifier = modifier;
@@ -45,9 +56,34 @@ export default class SFRPGModifier {
         this.condition = condition;
         this.subtab = subtab;
 
-        let roll = Roll.create(modifier.toString()).evaluate({maximize: true});
+        if (damage) this.damage = damage;
+        if (limitTo) this.limitTo = limitTo;
+        if (includeContainer && container) this.container = container;
+
+        const roll = Roll.create(modifier.toString()).evaluate({maximize: true});
         this.max = roll.total;
 
         this._id = id ?? generateUUID();
     }
+
+    get actor() {
+        return fromUuidSync(this.container.actorUuid);
+    }
+
+    get item() {
+        return fromUuidSync(this.container.itemUuid);
+    }
+
+    get token() {
+        return fromUuidSync(this.container.tokenUuid);
+    }
+
+    get primaryOwner() {
+        return this.item || this.actor;
+    }
+
+    get hasDamageSection() {
+        return (this.damage && Object.values(this.damage.damageTypes).some(type => !!type)) || false;
+    }
+
 }

--- a/src/module/rules/closures/stack-modifiers.js
+++ b/src/module/rules/closures/stack-modifiers.js
@@ -20,7 +20,7 @@ export default class StackModifiers extends Closure {
         const modifiers = mods;
         for (let modifiersI = 0; modifiersI < modifiers.length; modifiersI++) {
             const modifier = modifiers[modifiersI];
-            const actor = game.actors.get(modifier.container?.actorId) || options.actor;
+            const actor = fromUuidSync(modifier.container?.actorUuid) || options.actor;
             const formula = String(modifier.modifier);
 
             if (formula && (modifier.modifierType === SFRPGModifierType.CONSTANT)) {
@@ -34,7 +34,7 @@ export default class StackModifiers extends Closure {
                         modifier.max = 0;
                     }
                 } catch (error) {
-                    console.warn(`Could not calculate modifier: ${modifier.name} for actor with ID: ${modifier.container.actorId}. Setting to zero. ${error}`);
+                    console.warn(`Could not calculate modifier: ${modifier.name} for actor with ID: ${modifier.container.actorUuid}. Setting to zero. ${error}`);
                     modifier.max = 0;
                 }
             } else {
@@ -59,7 +59,7 @@ export default class StackModifiers extends Closure {
         if (modifiers.length > 0) {
             for (let modifiersI = 0; modifiersI < modifiers.length; modifiersI++) {
                 const modifier = modifiers[modifiersI];
-                const actor = game.actors.get(modifier.container?.actorId) || options.actor;
+                const actor = await fromUuid(modifier.container?.actorUuid) || options.actor;
                 const formula = String(modifier.modifier);
 
                 if (formula) {

--- a/src/templates/apps/modifier-app.hbs
+++ b/src/templates/apps/modifier-app.hbs
@@ -112,7 +112,7 @@
             </select>
         {{/if}}
     </div>
-    <div class="form-group modifier-limit-to" style="display: none">
+    <fieldset class="form-group modifier-limit-to" disabled=true>
         <label for="limitTo">{{localize "SFRPG.ModifierLimitToLabel"}}</label>
         <select name="limitTo" data-tooltip="{{localize "SFRPG.ModifierLimitToTooltip"}}">
             {{#select modifier.limitTo}}
@@ -121,7 +121,7 @@
                 <option value="container">{{localize "SFRPG.ModifierLimitToContainer"}}</option>
             {{/select}}
         </select>
-    </div>
+    </fieldset>
     <div class="form-group modifier-modifier-type">
         <label for="modifierType">{{localize "SFRPG.ModifierModifierTypeLabel"}}</label>
         <select name="modifierType" data-tooltip="{{localize "SFRPG.ModifierModifierTypeTooltip"}}">
@@ -133,10 +133,10 @@
             {{/select}}
         </select>
     </div>
-    <section class="damage-section-details" style="display: none">
+    <fieldset class="damage-section-details" disabled=true>
         <div class="damage-part-formula form-group">
             <label>{{ localize "SFRPG.Damage.Types.DamageGroup" group=""}}</label>
-            <input type="number" name="damageGroup" value="{{lookup modifier "damageGroup"}}" data-dtype="Number" data-tooltip="
+            <input type="number" name="damage.damageGroup" value="{{lookup modifier "damage.damageGroup"}}" data-dtype="Number" data-tooltip="
                 <strong>{{ localize 'SFRPG.Damage.Types.DamageGroup' group=''}}</strong>
                 <br>
                 <p>{{ localize 'SFRPG.Damage.Types.DamageGroupTooltip'}}</p>" />
@@ -146,7 +146,7 @@
                 <label>{{localize "SFRPG.Damage.EnergyDamage"}}</label>
                 {{#each config.energyDamageTypes as |name type|}}
                     <label class="checkbox">
-                        <input type="checkbox" name="damageTypes.{{type}}" {{checked (lookup ../modifier.damageTypes
+                        <input type="checkbox" name="damage.damageTypes.{{type}}" {{checked (lookup ../modifier.damage.damageTypes
                             type)}} />{{name}}
                     </label>
                 {{/each}}
@@ -155,7 +155,7 @@
                 <label>{{localize "SFRPG.Damage.KineticDamage"}}</label>
                 {{#each config.kineticDamageTypes as |name type|}}
                     <label class="checkbox">
-                        <input type="checkbox" name="damageTypes.{{type}}" {{checked (lookup ../modifier.damageTypes
+                        <input type="checkbox" name="damage.damageTypes.{{type}}" {{checked (lookup ../modifier.damage.damageTypes
                             type)}} />{{name}}
                     </label>
                 {{/each}}
@@ -163,12 +163,12 @@
             <div class="form-group form-group-stacked">
                 <label>{{localize "SFRPG.HealingTypesHealing"}}</label>
                 <label class="checkbox">
-                    <input type="checkbox" name="damageTypes.healing" {{checked (lookup
-                        modifier.damageTypes "healing" )}} />{{localize "SFRPG.HealingTypesHealing"}}
+                    <input type="checkbox" name="damage.damageTypes.healing" {{checked (lookup
+                        modifier.damage.damageTypes "healing" )}} />{{localize "SFRPG.HealingTypesHealing"}}
                 </label>
             </div>
         </div>
-    </section>
+    </fieldset>
     <div class="form-group modifier-source">
         <label for="source">{{localize "SFRPG.ModifierSourceLabel"}}</label>
         <input type="text" name="source" value="{{modifier.source}}" data-tooltip="{{localize "SFRPG.ModifierSourceTooltip"}}">

--- a/src/templates/apps/modifier-app.hbs
+++ b/src/templates/apps/modifier-app.hbs
@@ -136,7 +136,7 @@
     <fieldset class="damage-section-details" disabled=true>
         <div class="damage-part-formula form-group">
             <label>{{ localize "SFRPG.Damage.Types.DamageGroup" group=""}}</label>
-            <input type="number" name="damage.damageGroup" value="{{lookup modifier "damage.damageGroup"}}" data-dtype="Number" data-tooltip="
+            <input type="number" name="damage.damageGroup" value="{{modifier.damage.damageGroup}}" data-dtype="Number" data-tooltip="
                 <strong>{{ localize 'SFRPG.Damage.Types.DamageGroup' group=''}}</strong>
                 <br>
                 <p>{{ localize 'SFRPG.Damage.Types.DamageGroupTooltip'}}</p>" />


### PR DESCRIPTION
-Ensure modifiers don't save damage sections or limit to if not applicable by refactoring to fieldsets
-Refactor getAllModifiers to use push, and to return a cached version if possible 
-Migrate modifier containers to UUIDs, and ensure they are not saved to DBs 
-Refactor modifiers to be stored in memory as SFRPGModifier class instances