### PR TITLE
Untrained skills update

### DIFF
--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -2557,6 +2557,8 @@
         "SkillTooltipThemeMod": "Theme Modifier: {mod}",
         "SkillTooltipTrainedClassSkill": "Trained Class Skill Modifier: {mod}",
         "SkillTrainedOnly": "Trained Only",
+		"SkillTrained": "Trained",
+		"SkillUntrained": "Untrained",
         "SkillTrainedOnlyDialog": {
             "Content": "{skill} is a trained only skill, but {name} is not trained in that skill. Would you like to roll anyway?",
             "Title": "{skill} is trained only"

--- a/src/less/actors.less
+++ b/src/less/actors.less
@@ -427,6 +427,12 @@
     /* ----------------------------------------- */
     /*  Skills                                   */
     /* ----------------------------------------- */
+	
+	/* If hideUntrained is selected, only show skills that are allowed untrained,
+	 * or trained skills that have at least one rank in it. */
+	ul.skills-list.hideUntrained li.trained-only:not(.trained) {
+		display: none;
+	}
 
     ul.skills-list {
         flex: 0 0 192px;
@@ -439,6 +445,7 @@
         div.centered {
             text-align: center;
         }
+		
 
         li.skill {
             height: 22px;

--- a/src/less/actors.less
+++ b/src/less/actors.less
@@ -430,7 +430,7 @@
 	
 	/* If hideUntrained is selected, only show skills that are allowed untrained,
 	 * or trained skills that have at least one rank in it. */
-	ul.skills-list.hideUntrained li.trained-only:not(.trained) {
+	ul.skills-list.hide-untrained li.skill.trained-only:not(.trained) {
 		display: none;
 	}
 

--- a/src/module/actor/actor.js
+++ b/src/module/actor/actor.js
@@ -622,15 +622,25 @@ export class ActorSFRPG extends Mix(Actor).with(ActorConditionsMixin, ActorCrewM
             ? game.i18n.format("SFRPG.Rolls.Dice.SkillCheckTitleWithProfession", { skill: CONFIG.SFRPG.skills[skillId.substring(0, 3)], profession: skill.subname })
             : game.i18n.format("SFRPG.Rolls.Dice.SkillCheckTitle", { skill: CONFIG.SFRPG.skills[skillId.substring(0, 3)] });
 		
-		const tags = {};
+		const tags = new Array();
 		
 		if (skill.isTrainedOnly) {
-			tags.push({name: "isTrainedOnly", text: game.i18n.format("SFRPG.SkillTrainedOnly")});
+			var t = game.i18n.format("SFRPG.SkillTrainedOnly");
+			tags.push({name: "isTrainedOnly", text: t});
 		}
 		if (skill.ranks) {
-			tags.push({name: "hasRanks", text: game.i18n.format("SFRPG.Items.Proficient")});
+			var t = game.i18n.format("SFRPG.SkillTrained");
+			tags.push({name: "hasRanks", text: t});
 		} else {
-			tags.push({name: "hasRanks", text: game.i18n.format("SFRPG.Items.NotProficient")});
+			var t = game.i18n.format("SFRPG.SkillUntrained");
+			tags.push({name: "hasRanks", text: t});
+		}
+		if (skill.value) {
+			var t = game.i18n.format("SFRPG.Items.Proficient");
+			tags.push({name: "hasProficiency", text: t});
+		} else {
+			var t = game.i18n.format("SFRPG.Items.NotProficient");
+			tags.push({name: "hasProficiency", text: t});
 		}
 		
 

--- a/src/module/actor/actor.js
+++ b/src/module/actor/actor.js
@@ -615,10 +615,24 @@ export class ActorSFRPG extends Mix(Actor).with(ActorConditionsMixin, ActorCrewM
     async rollSkillCheck(skillId, skill, options = {}) {
         const rollContext = RollContext.createActorRollContext(this);
         const parts = [`@skills.${skillId}.mod`];
-
+		
+		
+		
         const title = skillId.includes('pro')
             ? game.i18n.format("SFRPG.Rolls.Dice.SkillCheckTitleWithProfession", { skill: CONFIG.SFRPG.skills[skillId.substring(0, 3)], profession: skill.subname })
             : game.i18n.format("SFRPG.Rolls.Dice.SkillCheckTitle", { skill: CONFIG.SFRPG.skills[skillId.substring(0, 3)] });
+		
+		const tags = {};
+		
+		if (skill.isTrainedOnly) {
+			tags.push({name: "isTrainedOnly", text: game.il8n.format("SFRPG.SkillTrainedOnly")});
+		}
+		if (skill.ranks) {
+			tags.push({name: "hasRanks", text: game.il8n.format("SFRPG.Items.Proficient")});
+		} else {
+			tags.push({name: "hasRanks", text: game.il8n.format("SFRPG.Items.NotProficient")});
+		}
+		
 
         return await DiceSFRPG.d20Roll({
             event: options.event,
@@ -635,7 +649,8 @@ export class ActorSFRPG extends Mix(Actor).with(ActorConditionsMixin, ActorCrewM
             dialogOptions: {
                 left: options.event ? options.event.clientX - 80 : null,
                 top: options.event ? options.event.clientY - 80 : null
-            }
+            },
+			tags: tags
         });
     }
 

--- a/src/module/actor/actor.js
+++ b/src/module/actor/actor.js
@@ -625,12 +625,12 @@ export class ActorSFRPG extends Mix(Actor).with(ActorConditionsMixin, ActorCrewM
 		const tags = {};
 		
 		if (skill.isTrainedOnly) {
-			tags.push({name: "isTrainedOnly", text: game.il8n.format("SFRPG.SkillTrainedOnly")});
+			tags.push({name: "isTrainedOnly", text: game.i18n.format("SFRPG.SkillTrainedOnly")});
 		}
 		if (skill.ranks) {
-			tags.push({name: "hasRanks", text: game.il8n.format("SFRPG.Items.Proficient")});
+			tags.push({name: "hasRanks", text: game.i18n.format("SFRPG.Items.Proficient")});
 		} else {
-			tags.push({name: "hasRanks", text: game.il8n.format("SFRPG.Items.NotProficient")});
+			tags.push({name: "hasRanks", text: game.i18n.format("SFRPG.Items.NotProficient")});
 		}
 		
 

--- a/src/module/actor/sheet/base.js
+++ b/src/module/actor/sheet/base.js
@@ -309,6 +309,9 @@ export class ActorSheetSFRPG extends ActorSheet {
 
         // Effect Toggling
         html.find('.effect-toggle').on('click', this._onToggleEffect.bind(this));
+		
+		// Option Toggling
+		html.find('.option-toggle').on('click', this._onToggleOption.bind(this));
     }
 
     /** @override */
@@ -566,6 +569,32 @@ export class ActorSheetSFRPG extends ActorSheet {
 
         this.actor.system.timedEffects.get(effectUuid)?.toggle();
     }
+	
+	/** 
+	 * Toggles an option on the selected item.
+	 * 
+	 * @param {Event} event The originating click event
+	 */
+	async _onToggleOption(event) {
+		event.preventDefault();
+		const target = $(event.currentTarget);
+		const opt = target.data('optionKey');
+		
+		var options = null;
+		if (this.actor.system.options) {
+			options = duplicate(this.actor.system.options);
+		}
+		if (!options) {
+			options = new Map();
+		}
+		if (!options[opt]) {
+			options[opt] = true;
+		} else {
+			options[opt] = false;
+		}
+		
+		await this.actor.update({["system.options"]: options});
+	}
 
     /**
      * handle cycling whether a skill is a class skill or not

--- a/src/module/dice.js
+++ b/src/module/dice.js
@@ -164,7 +164,7 @@ export class DiceSFRPG {
     * @param {DialogOptions}        data.dialogOptions Modal dialog options
     */
     static async d20Roll({ event = new Event(''), parts, rollContext, title, speaker, flavor, advantage = true, rollOptions = {},
-        critical = 20, fumble = 1, chatMessage = true, onClose, dialogOptions }) {
+		critical = 20, fumble = 1, chatMessage = true, onClose, dialogOptions, tags = {} }) {
 
         flavor = `${title}${(flavor ? " <br> " + flavor : "")}`;
 
@@ -213,7 +213,7 @@ export class DiceSFRPG {
         const formula = parts.map(partMapper).join(" + ");
 
         const tree = new RollTree(options);
-        return await tree.buildRoll(formula, rollContext, async (button, rollMode, unusedFinalFormula, node, rollMods, bonus = null) => {
+        return await tree.buildRoll(formula, rollContext, async (button, rollMode, unusedFinalFormula, node, rollMods, tags, bonus = null) => {
             if (button === "cancel") {
                 if (onClose) {
                     onClose(null, null, null);
@@ -237,7 +237,6 @@ export class DiceSFRPG {
             finalFormula.formula = finalFormula.formula.endsWith("+") ? finalFormula.formula.substring(0, finalFormula.formula.length - 1).trim() : finalFormula.formula;
             const preparedRollExplanation = DiceSFRPG.formatFormula(finalFormula.formula);
 
-            const tags = [];
             if (rollOptions?.actionTarget) {
                 tags.push({ name: "actionTarget", text: game.i18n.format("SFRPG.Items.Action.ActionTarget.Tag", {actionTarget: rollOptions.actionTargetSource[rollOptions.actionTarget]}) });
             }
@@ -280,7 +279,8 @@ export class DiceSFRPG {
                     htmlData: htmlData,
                     rollType: "normal",
                     rollOptions: rollOptions,
-                    rollDices: finalFormula.rollDices
+                    rollDices: finalFormula.rollDices,
+					tags: tags
                 };
 
                 try {
@@ -299,7 +299,8 @@ export class DiceSFRPG {
                     roll: roll,
                     type: CONST.CHAT_MESSAGE_TYPES.ROLL,
                     sound: CONFIG.sounds.dice,
-                    flags: {rollOptions: rollOptions}
+                    flags: {rollOptions: rollOptions},
+					tags: tags
                 };
 
                 messageData.content = await roll.render({ htmlData: htmlData, customTooltip: finalFormula.rollDices });

--- a/src/module/dice.js
+++ b/src/module/dice.js
@@ -164,7 +164,7 @@ export class DiceSFRPG {
     * @param {DialogOptions}        data.dialogOptions Modal dialog options
     */
     static async d20Roll({ event = new Event(''), parts, rollContext, title, speaker, flavor, advantage = true, rollOptions = {},
-		critical = 20, fumble = 1, chatMessage = true, onClose, dialogOptions, tags = {} }) {
+		critical = 20, fumble = 1, chatMessage = true, onClose, dialogOptions, tags = new Array() }) {
 
         flavor = `${title}${(flavor ? " <br> " + flavor : "")}`;
 
@@ -213,7 +213,7 @@ export class DiceSFRPG {
         const formula = parts.map(partMapper).join(" + ");
 
         const tree = new RollTree(options);
-        return await tree.buildRoll(formula, rollContext, async (button, rollMode, unusedFinalFormula, node, rollMods, tags, bonus = null) => {
+        return await tree.buildRoll(formula, rollContext, async (button, rollMode, unusedFinalFormula, node, rollMods, bonus = null) => {
             if (button === "cancel") {
                 if (onClose) {
                     onClose(null, null, null);
@@ -252,16 +252,6 @@ export class DiceSFRPG {
                     d.options.fumble = fumble;
                 }
             }
-
-            // if (flavor) {
-            //     const chatData = {
-            //         type: CONST.CHAT_MESSAGE_TYPES.IC,
-            //         speaker: speaker,
-            //         content: flavor
-            //     };
-
-            //     ChatMessage.create(chatData, { chatBubble: true });
-            // }
 
             const itemContext = rollContext.allContexts['item'];
             const htmlData = [{ name: "rollNotes", value: itemContext?.system?.rollNotes }];

--- a/src/module/rules/actions/actor/calculate-bab-modifier.js
+++ b/src/module/rules/actions/actor/calculate-bab-modifier.js
@@ -36,7 +36,6 @@ export default function(engine) {
         let filteredModifiers = fact.modifiers.filter(mod => {
             return (mod.enabled || mod.modifierType === "formula") && mod.effectType == SFRPGEffectType.BASE_ATTACK_BONUS;
         });
-        filteredModifiers = context.parameters.stackModifiers.process(filteredModifiers, context, {actor: fact.actor});
 
         const bonus = Object.entries(filteredModifiers).reduce((sum, mod) => {
             if (mod[1] === null || mod[1].length < 1) return sum;

--- a/src/module/rules/actions/actor/calculate-base-ability-modifier.js
+++ b/src/module/rules/actions/actor/calculate-base-ability-modifier.js
@@ -39,11 +39,7 @@ export default function(engine) {
 
         for (let [abl, ability] of Object.entries(data.abilities)) {
 
-            const abilityMods = context.parameters.stackModifiers.process(
-                filteredMods.filter(mod => mod.valueAffected === abl || mod.effectType === SFRPGEffectType.ABILITY_MODIFIERS),
-                context,
-                {actor: fact.actor}
-            );
+            const abilityMods = filteredMods.filter(mod => mod.valueAffected === abl || mod.effectType === SFRPGEffectType.ABILITY_MODIFIERS);
 
             let abilityValue = ability.value;
             if (Number.isNaN(Number.parseInt(abilityValue))) {

--- a/src/module/rules/actions/actor/calculate-base-ability-score.js
+++ b/src/module/rules/actions/actor/calculate-base-ability-score.js
@@ -69,14 +69,13 @@ export default function(engine) {
                 }
             }
         }
+		
+		const filterMods = (abl, mod) => { return mod.valueAffected === abl; };
 
         for (let [abl, ability] of Object.entries(data.abilities)) {
 
-            const abilityMods = context.parameters.stackModifiers.process(
-                filteredMods.filter(mod => mod.valueAffected === abl),
-                context,
-                {actor: fact.actor}
-            );
+
+            const abilityMods = filteredMods.filter(mod => filterMods(abl, mod));
 
             let score = ability.base ? ability.base : 10;
             ability.tooltip.push(game.i18n.format("SFRPG.AbilityScoreBaseTooltip", { mod: score.signedString() }));

--- a/src/module/rules/actions/actor/calculate-cmd-modifiers.js
+++ b/src/module/rules/actions/actor/calculate-cmd-modifiers.js
@@ -37,7 +37,7 @@ export default function(engine) {
             return (mod.enabled || mod.modifierType === "formula") && [SFRPGEffectType.CMD].includes(mod.effectType);
         });
 
-        const mods = context.parameters.stackModifiers.process(filteredMods, context, {actor: fact.actor});
+        const mods = filteredMods;
 
         const cmdMod = Object.entries(mods).reduce((prev, curr) => {
             if (curr[1] === null || curr[1].length < 1) return prev;

--- a/src/module/rules/actions/actor/calculate-encumbrance.js
+++ b/src/module/rules/actions/actor/calculate-encumbrance.js
@@ -51,7 +51,6 @@ export default function(engine) {
 		let filteredModifiers = fact.modifiers.filter(mod => {
 			return (mod.enabled || mod.modifierType === "formula") && mod.effectType == SFRPGEffectType.BULK;
 		});
-		filteredModifiers = context.parameters.stackModifiers.process(filteredModifiers, context, {actor: fact.actor});
 		
 		let encumbrance = {
 			value: 0,

--- a/src/module/rules/actions/actor/calculate-encumbrance.js
+++ b/src/module/rules/actions/actor/calculate-encumbrance.js
@@ -2,100 +2,100 @@ import { SFRPGEffectType, SFRPGModifierType, SFRPGModifierTypes } from "../../..
 
 export default function(engine) {
     engine.closures.add("calculateEncumbrance", (fact, context) => {
-        const data = fact.data;
-        const actor = fact.actor;
-        const actorData = actor.system;
+		const data = fact.data;
+		const actor = fact.actor;
+		const actorData = actor.system;
 
-        let tooltip = [];
-        if (data.encumbrance) {
-            tooltip = encumbrance.tooltip;
-        }
+		let tooltip = [];
+		if (data.encumbrance) {
+			tooltip = data.encumbrance.tooltip;
+		}
+		
 
-        const addModifier = (bonus, data, item, localizationKey) => {
-            if (bonus.modifierType === SFRPGModifierType.FORMULA) {
-                if (item.rolledMods) {
-                    item.rolledMods.push({mod: bonus.modifier, bonus: bonus});
-                } else {
-                    item.rolledMods = [{mod: bonus.modifier, bonus: bonus}];
-                }
+		const addModifier = (bonus, data, item, localizationKey) => {
+			if (bonus.modifierType === SFRPGModifierType.FORMULA) {
+				if (item.rolledMods) {
+					item.rolledMods.push({mod: bonus.modifier, bonus: bonus});
+				} else {
+					item.rolledMods = [{mod: bonus.modifier, bonus: bonus}];
+				}
 
-                return 0;
-            }
+				return 0;
+			}
 
-            let computedBonus = 0;
-            try {
-                const roll = Roll.create(bonus.modifier.toString(), data).evaluate({maximize: true});
-                computedBonus = roll.total;
-            } catch {}
+			let computedBonus = 0;
+			try {
+				const roll = Roll.create(bonus.modifier.toString(), data).evaluate({maximize: true});
+				computedBonus = roll.total;
+			} catch {}
 
-            if (computedBonus !== 0 && localizationKey) {
-                item.tooltip.push(game.i18n.format(localizationKey, {
-                    type: game.i18n.format(`SFRPG.ModifierType${bonus.type.capitalize()}`),
-                    mod: computedBonus.signedString(),
-                    source: bonus.name
-                }));
-            }
+			if (computedBonus !== 0 && localizationKey) {
+				item.tooltip.push(game.i18n.format(localizationKey, {
+					type: game.i18n.format(`SFRPG.ModifierType${bonus.type.capitalize()}`),
+					mod: computedBonus.signedString(),
+					source: bonus.name
+				}));
+			}
 
-            return computedBonus;
-        };
+			return computedBonus;
+		};
+		
+		let strength = Number(data.abilities.str.value);
+		let max = Number.isNaN(strength) ? 0 : strength;
+		
+		tooltip.push(game.i18n.format("SFRPG.ActorSheet.Inventory.Encumbrance.EncumbranceBaseTooltip", {
+			base: strength.signedString()
+		}));
+		
+		// Iterate through any modifiers that affect encumbrance
+		let filteredModifiers = fact.modifiers.filter(mod => {
+			return (mod.enabled || mod.modifierType === "formula") && mod.effectType == SFRPGEffectType.BULK;
+		});
+		filteredModifiers = context.parameters.stackModifiers.process(filteredModifiers, context, {actor: fact.actor});
+		
+		let encumbrance = {
+			value: 0,
+			tooltip: tooltip,
+			rolledMods: []
+		};
+		
+		let bonus = Object.entries(filteredModifiers).reduce((sum, mod) => {
+			if (mod[1] === null || mod[1].length < 1) return sum;
 
-        let strength = Number(data.abilities.str.value);
-        let max = Number.isNaN(strength) ? 0 : strength;
+			if ([SFRPGModifierTypes.CIRCUMSTANCE, SFRPGModifierTypes.UNTYPED].includes(mod[0])) {
+				for (const bonus of mod[1]) {
+					sum += addModifier(bonus, data, encumbrance, "SFRPG.ActorSheet.Inventory.Encumbrance.EncumbranceModifierTooltip");
+				}
+			} else {
+				sum += addModifier(mod[1], data, encumbrance, "SFRPG.ActorSheet.Inventory.Encumbrance.EncumbranceModifierTooltip");
+			}
 
-        tooltip.push(game.i18n.format("SFRPG.ActorSheet.Inventory.Encumbrance.EncumbranceBaseTooltip", {
-            base: strength.signedString()
-        }));
+			return sum;
+		}, 0);
+		
+		data.attributes.encumbrance = {
+			max: max + bonus,
+			value: 0,
+			pct: 0,
+			encumbered: false,
+			tooltip: encumbrance.tooltip,
+			rolledMods: encumbrance.rolledMods
+		};
+		
+		const _computeEncumbrance = (totalWeight, actorData) => {
+			const enc = {
+				max: actorData.attributes.encumbrance.max,
+				tooltip: actorData.attributes.encumbrance.tooltip,
+				value: totalWeight
+			};
 
-        // Iterate through any modifiers that affect encumbrance
-        let filteredModifiers = fact.modifiers.filter(mod => {
-            return (mod.enabled || mod.modifierType === "formula") && mod.effectType == SFRPGEffectType.BULK;
-        });
-        filteredModifiers = context.parameters.stackModifiers.process(filteredModifiers, context, {actor: fact.actor});
-
-        let encumbrance = {
-            value: 0,
-            tooltip: tooltip,
-            rolledMods: []
-        };
-
-        let bonus = Object.entries(filteredModifiers).reduce((sum, mod) => {
-            if (mod[1] === null || mod[1].length < 1) return sum;
-
-            if ([SFRPGModifierTypes.CIRCUMSTANCE, SFRPGModifierTypes.UNTYPED].includes(mod[0])) {
-                for (const bonus of mod[1]) {
-                    sum += addModifier(bonus, data, encumbrance, "SFRPG.ActorSheet.Inventory.Encumbrance.EncumbranceModifierTooltip");
-                }
-            } else {
-                sum += addModifier(mod[1], data, encumbrance, "SFRPG.ActorSheet.Inventory.Encumbrance.EncumbranceModifierTooltip");
-            }
-
-            return sum;
-        }, 0);
-
-        data.attributes.encumbrance = {
-            max: max + bonus,
-            value: 0,
-            pct: 0,
-            encumbered: false,
-            tooltip: encumbrance.tooltip,
-            rolledMods: encumbrance.rolledMods
-        };
-
-        const _computeEncumbrance = (totalWeight, actorData) => {
-            const enc = {
-                max: actorData.attributes.encumbrance.max,
-                tooltip: actorData.attributes.encumbrance.tooltip,
-                value: totalWeight
-            };
-
-            enc.pct = Math.min(enc.value * 100 / enc.max, 99);
-            enc.encumbered = enc.pct > 50;
-            return enc;
-        };
-
-        actorData.encumbrance = _computeEncumbrance(actorData.bulk, actorData);
-        data.encumbrance = actorData.encumbrance;
-
-        return fact;
+			enc.pct = Math.min(enc.value * 100 / enc.max, 99);
+			enc.encumbered = enc.pct > 50;
+			return enc;
+		};
+		
+		actorData.encumbrance = _computeEncumbrance(actorData.bulk, actorData);
+		data.encumbrance = actorData.encumbrance;
+		return fact;
     }, { required: ["stackModifiers"], closureParameters: ["stackModifiers"] });
 }

--- a/src/module/rules/actions/actor/calculate-initiative-modifiers.js
+++ b/src/module/rules/actions/actor/calculate-initiative-modifiers.js
@@ -30,7 +30,7 @@ export default function(engine) {
             return (mod.enabled || mod.modifierType === "formula") && [SFRPGEffectType.INITIATIVE].includes(mod.effectType);
         });
 
-        const mods = context.parameters.stackModifiers.process(filteredMods.filter(mod => {
+        const mods = filteredMods.filter(mod => {
             if (mod.modifierType === SFRPGModifierType.FORMULA) {
                 if (init.rolledMods) {
                     init.rolledMods.push({mod: mod.modifier, bonus: mod});
@@ -40,7 +40,7 @@ export default function(engine) {
                 return false;
             }
             else return true;
-        }), context, {actor: fact.actor});
+        });
 
         const mod = Object.entries(mods).reduce((prev, curr) => {
             if (curr[1] === null || curr[1].length < 1) return prev;

--- a/src/module/rules/actions/actor/calculate-movement-speeds.js
+++ b/src/module/rules/actions/actor/calculate-movement-speeds.js
@@ -53,12 +53,10 @@ export default function(engine) {
             let filteredModifiers = fact.modifiers.filter(mod => {
                 return (mod.enabled || mod.modifierType === "formula") && (mod.effectType === SFRPGEffectType.ALL_SPEEDS || (mod.effectType === SFRPGEffectType.SPECIFIC_SPEED && mod.valueAffected === speedKey));
             });
-            filteredModifiers = context.parameters.stackModifiers.process(filteredModifiers, context, {actor: fact.actor});
 
             let filteredMultiplyModifiers = fact.modifiers.filter(mod => {
                 return (mod.enabled || mod.modifierType === "formula") && mod.effectType === SFRPGEffectType.MULTIPLY_ALL_SPEEDS;
             });
-            filteredMultiplyModifiers = context.parameters.stackModifiers.process(filteredMultiplyModifiers, context, {actor: fact.actor});
 
             const bonus = Object.entries(filteredModifiers).reduce((sum, mod) => {
                 if (mod[1] === null || mod[1].length < 1) return sum;

--- a/src/module/rules/actions/actor/calculate-save-modifiers.js
+++ b/src/module/rules/actions/actor/calculate-save-modifiers.js
@@ -56,7 +56,7 @@ export default function(engine) {
         });
 
         fort.rolledMods = null;
-        const fortMods = context.parameters.stackModifiers.process(filteredMods.filter(mod => {
+        const fortMods = filteredMods.filter(mod => {
             if (mod.modifierType === SFRPGModifierType.FORMULA && (mod.effectType === SFRPGEffectType.SAVES || [ "highest", "lowest", "fort" ].includes(mod.valueAffected))) {
                 if (fort.rolledMods) {
                     fort.rolledMods.push({mod: mod.modifier, bonus: mod});
@@ -68,10 +68,10 @@ export default function(engine) {
             if ([ "highest", "lowest", "fort" ].includes(mod.valueAffected)) return true;
             if (mod.effectType === SFRPGEffectType.SAVES) return true;
             return false;
-        }), context, {actor: fact.actor});
+        });
 
         reflex.rolledMods = null;
-        const reflexMods = context.parameters.stackModifiers.process(filteredMods.filter(mod => {
+        const reflexMods = filteredMods.filter(mod => {
             if (mod.modifierType === SFRPGModifierType.FORMULA && (mod.effectType === SFRPGEffectType.SAVES || [ "highest", "lowest", "reflex" ].includes(mod.valueAffected))) {
                 if (reflex.rolledMods) {
                     reflex.rolledMods.push({mod: mod.modifier, bonus: mod});
@@ -83,10 +83,10 @@ export default function(engine) {
             if ([ "highest", "lowest", "reflex" ].includes(mod.valueAffected)) return true;
             if (mod.effectType === SFRPGEffectType.SAVES) return true;
             return false;
-        }), context, {actor: fact.actor});
+        });
 
         will.rolledMods = null;
-        const willMods = context.parameters.stackModifiers.process(filteredMods.filter(mod => {
+        const willMods = filteredMods.filter(mod => {
             if (mod.modifierType === SFRPGModifierType.FORMULA && (mod.effectType === SFRPGEffectType.SAVES || [ "highest", "lowest", "will" ].includes(mod.valueAffected))) {
                 if (will.rolledMods) {
                     will.rolledMods.push({mod: mod.modifier, bonus: mod});
@@ -98,7 +98,7 @@ export default function(engine) {
             if ([ "highest", "lowest", "will" ].includes(mod.valueAffected)) return true;
             if (mod.effectType === SFRPGEffectType.SAVES) return true;
             return false;
-        }), context, {actor: fact.actor});
+        });
 
         let fortMod = Object.entries(fortMods).reduce((sum, mod) => {
             if (mod[1] === null || mod[1].length < 1) return sum;

--- a/src/templates/actors/character-sheet.hbs
+++ b/src/templates/actors/character-sheet.hbs
@@ -134,7 +134,7 @@
             </ul>
 
             {{!-- Skills --}}
-            <ul class="skills-list">
+            <ul class="skills-list {{#if actor.hideUntrained }} hide-untrained {{/if}}">
                 <h3 class="skill-ranks noborder {{#if (greaterThan system.skillpoints.used system.skillpoints.max)}}red{{/if}}" data-tooltip="<strong>{{localize "SFRPG.ActorSheet.Attributes.Skills.SkillRanks"}}</strong><br>@skillpoints.used<br>@skillpoints.total<br><br>{{#each system.skillpoints.tooltip as |tip|}}{{tip}}<br>{{/each}}">
                     {{localize "SFRPG.ActorSheet.Attributes.Skills.SkillRanks"}} ({{system.skillpoints.used}} / {{system.skillpoints.max}})
                 </h3>
@@ -146,7 +146,7 @@
                     <div class="skill-header-mod">{{localize "SFRPG.SkillsHeaderModifier"}}</div>
                 </li>
                 {{#each system.skills as |skill s|}}
-                <li class="skill flexrow {{#if skill.value}}proficient{{/if}}" data-tooltip="<strong>{{skill.label}}</strong>{{#if (or skill.isTrainedOnly skill.hasArmorCheckPenalty)}}<br>(<em>{{#if skill.hasArmorCheckPenalty}}Armor Check Penalty{{/if}}{{#if (and skill.isTrainedOnly skill.hasArmorCheckPenalty)}}; {{/if}}{{#if skill.isTrainedOnly}}Trained Only{{/if}}</em>){{/if}}<br/>Modifier: @skills.{{s}}.mod<br/>Ranks: @skills.{{s}}.ranks<br/><br/>{{#each skill.tooltip as |tip|}}{{tip}}<br>{{/each}}" data-skill="{{s}}">
+                <li class="skill flexrow {{#if skill.value}}proficient{{/if}} {{#if skill.ranks}}trained{{/if}} {{#if skill.isTrainedOnly}}trained-only{{/if}}" data-tooltip="<strong>{{skill.label}}</strong>{{#if (or skill.isTrainedOnly skill.hasArmorCheckPenalty)}}<br>(<em>{{#if skill.hasArmorCheckPenalty}}Armor Check Penalty{{/if}}{{#if (and skill.isTrainedOnly skill.hasArmorCheckPenalty)}}; {{/if}}{{#if skill.isTrainedOnly}}Trained Only{{/if}}</em>){{/if}}<br/>Modifier: @skills.{{s}}.mod<br/>Ranks: @skills.{{s}}.ranks<br/><br/>{{#each skill.tooltip as |tip|}}{{tip}}<br>{{/each}}" data-skill="{{s}}">
                     <input type="hidden" name="system.skills.{{s}}.value" value="{{skill.value}}" data-dtype="Number" />
                     <a class="proficiency-toggle skill-proficiency" title="{{skill.hover}}">{{{skill.icon}}}</a>
                     <a title="Compendium" class="compendium-link" data-skill-id="{{s}}">
@@ -163,6 +163,15 @@
                 </li>
                 {{/each}}
                 <li class="flexcol skills-footer">
+				    <div class="form-group">
+						<input 
+							type="checkbox" id="hideUntrained"
+							name="actor.hideUntrained"
+							value="{{actor.hideUntrained}}"
+							{{checked actor.hideUntrained}}
+							>
+						<label for="hideUntrained">Hide Untrained</label>
+					</div>
                     <div class="form-group">
                         <button id="add-profession" type="button"><i class="fas fa-plus"></i> {{localize "SFRPG.AddProfessionButtonText"}}</button>
                     </div>

--- a/src/templates/actors/character-sheet.hbs
+++ b/src/templates/actors/character-sheet.hbs
@@ -134,7 +134,7 @@
             </ul>
 
             {{!-- Skills --}}
-            <ul class="skills-list {{#if actor.hideUntrained }} hide-untrained {{/if}}">
+            <ul class="skills-list {{#if actor.system.options.hideUntrained }} hide-untrained {{/if}}">
                 <h3 class="skill-ranks noborder {{#if (greaterThan system.skillpoints.used system.skillpoints.max)}}red{{/if}}" data-tooltip="<strong>{{localize "SFRPG.ActorSheet.Attributes.Skills.SkillRanks"}}</strong><br>@skillpoints.used<br>@skillpoints.total<br><br>{{#each system.skillpoints.tooltip as |tip|}}{{tip}}<br>{{/each}}">
                     {{localize "SFRPG.ActorSheet.Attributes.Skills.SkillRanks"}} ({{system.skillpoints.used}} / {{system.skillpoints.max}})
                 </h3>
@@ -164,13 +164,7 @@
                 {{/each}}
                 <li class="flexcol skills-footer">
 				    <div class="form-group">
-						<input 
-							type="checkbox" id="hideUntrained"
-							name="actor.hideUntrained"
-							value="{{actor.hideUntrained}}"
-							{{checked actor.hideUntrained}}
-							>
-						<label for="hideUntrained">Hide Untrained</label>
+						<a class="option-toggle" data-option-key="hideUntrained">{{#if actor.system.options.hideUntrained}}<i class="far fa-check-square">{{else}}<i class="far fa-square">{{/if}}</i> Hide Untrained</a>
 					</div>
                     <div class="form-group">
                         <button id="add-profession" type="button"><i class="fas fa-plus"></i> {{localize "SFRPG.AddProfessionButtonText"}}</button>


### PR DESCRIPTION
resolves #676 
A new option has been added to below the Skills called "Hide Untrained." Checking this option will hide all skills that cannot be used Untrained, if they do not have at least one rank in them.

Here's how it looks in the various ways (I use the Dark UI Module on my personal server).

![Hide Untrained](https://github.com/foundryvtt-starfinder/foundryvtt-starfinder/assets/49252077/2cb0b702-221b-449c-b81d-65ccd90654e2)
![Hide Untrained - Show All One](https://github.com/foundryvtt-starfinder/foundryvtt-starfinder/assets/49252077/12473c53-68b9-42fd-9ec9-eeb3c5124e45)
![Hide Untrained - Show None One](https://github.com/foundryvtt-starfinder/foundryvtt-starfinder/assets/49252077/79d0767a-48bb-4c42-8de6-a6963daa95ad)

A huge infinite loop bug was found while fixing another bug that I found. Basically, the entire calculate folder was calling for the entire calculation stack to be processed, leading to an infinite loop. The entire system was causing a StackOverflowException, being discarded, and then it just... went as normal. However, the entire process was filling up memory if you were in Inspect Element, causing the entire Inspect Element UI to crash. So, I removed the entire stack calling the recalculation of the stack in the various .js files.

