### PR TITLE
Fix Recursion Bug in rules

### DIFF
--- a/src/module/rules/actions/actor/calculate-ability-check-modifiers.js
+++ b/src/module/rules/actions/actor/calculate-ability-check-modifiers.js
@@ -12,7 +12,7 @@ export default function(engine) {
                 item.calculatedMods = [{mod: bonus.modifier, bonus: bonus}];
             }
 
-            let computedBonus = bonus.max || 0;
+            const computedBonus = bonus.max || 0;
 
             if (computedBonus !== 0 && localizationKey) {
                 item.tooltip.push(game.i18n.format(localizationKey, {
@@ -28,21 +28,21 @@ export default function(engine) {
         const filteredMods = modifiers.filter(mod => {
             return (mod.enabled || mod.modifierType === "formula") && [SFRPGEffectType.ABILITY_CHECK, SFRPGEffectType.ABILITY_CHECKS].includes(mod.effectType);
         });
-		
-		const getFilteredAbilities = (abl, ability, mod) => {
-			if (mod.modifierType === SFRPGModifierType.FORMULA) {
-				if (ability.rolledMods) {
-					ability.rolledMods.push({mod: mod.modifier, bonus: mod});
-				} else {
-					ability.rolledMods = [{mod: mod.modifier, bonus: mod}];
-				}
-				return false;
-			}
-			return mod.valueAffected === abl || mod.effectType === SFRPGEffectType.ABILITY_CHECKS;
-		};
 
-        for (let [abl, ability] of Object.entries(data.abilities)) {
-			var filteredAbilityCheckMods = filteredMods.filter(mod => getFilteredAbilities(abl, ability, mod));
+        const getFilteredAbilities = (abl, ability, mod) => {
+            if (mod.modifierType === SFRPGModifierType.FORMULA) {
+                if (ability.rolledMods) {
+                    ability.rolledMods.push({mod: mod.modifier, bonus: mod});
+                } else {
+                    ability.rolledMods = [{mod: mod.modifier, bonus: mod}];
+                }
+                return false;
+            }
+            return mod.valueAffected === abl || mod.effectType === SFRPGEffectType.ABILITY_CHECKS;
+        };
+
+        for (const [abl, ability] of Object.entries(data.abilities)) {
+            const filteredAbilityCheckMods = filteredMods.filter(mod => getFilteredAbilities(abl, ability, mod));
 
             // this is done because the normal tooltip will be changed later on and we need this one as a "base" for dice rolls.
             ability.rollTooltip = [ ...ability.tooltip ];

--- a/src/module/rules/actions/actor/calculate-armor-modifiers.js
+++ b/src/module/rules/actions/actor/calculate-armor-modifiers.js
@@ -38,14 +38,14 @@ export default function(engine) {
             return computedBonus;
         };
 
-        let armorMods = modifiers.filter(mod => {
+        const armorMods = modifiers.filter(mod => {
             return (mod.enabled || mod.modifierType === "formula") && [SFRPGEffectType.AC].includes(mod.effectType);
         });
 
-        let eacMods = context.parameters.stackModifiers.process(armorMods.filter(mod => ["eac", "both"].includes(mod.valueAffected)), context, {actor: fact.actor});
-        let kacMods = context.parameters.stackModifiers.process(armorMods.filter(mod => ["kac", "both"].includes(mod.valueAffected)), context, {actor: fact.actor});
+        const eacMods = context.parameters.stackModifiers.process(armorMods.filter(mod => ["eac", "both"].includes(mod.valueAffected)), context, {actor: fact.actor});
+        const kacMods = context.parameters.stackModifiers.process(armorMods.filter(mod => ["kac", "both"].includes(mod.valueAffected)), context, {actor: fact.actor});
 
-        let eacMod = Object.entries(eacMods).reduce((sum, curr) => {
+        const eacMod = Object.entries(eacMods).reduce((sum, curr) => {
             if (curr[1] === null || curr[1].length < 1) return sum;
 
             if ([SFRPGModifierTypes.CIRCUMSTANCE, SFRPGModifierTypes.UNTYPED].includes(curr[0])) {
@@ -59,7 +59,7 @@ export default function(engine) {
             return sum;
         }, 0);
 
-        let kacMod = Object.entries(kacMods).reduce((sum, curr) => {
+        const kacMod = Object.entries(kacMods).reduce((sum, curr) => {
             if (curr[1] === null || curr[1].length < 1) return sum;
 
             if ([SFRPGModifierTypes.CIRCUMSTANCE, SFRPGModifierTypes.UNTYPED].includes(curr[0])) {

--- a/src/module/rules/actions/actor/calculate-bab-modifier.js
+++ b/src/module/rules/actions/actor/calculate-bab-modifier.js
@@ -33,7 +33,7 @@ export default function(engine) {
         };
 
         // Iterate through any modifiers that affect BAB
-        let filteredModifiers = fact.modifiers.filter(mod => {
+        const filteredModifiers = fact.modifiers.filter(mod => {
             return (mod.enabled || mod.modifierType === "formula") && mod.effectType == SFRPGEffectType.BASE_ATTACK_BONUS;
         });
 

--- a/src/module/rules/actions/actor/calculate-bab-modifier.js
+++ b/src/module/rules/actions/actor/calculate-bab-modifier.js
@@ -36,7 +36,6 @@ export default function(engine) {
         let filteredModifiers = fact.modifiers.filter(mod => {
             return (mod.enabled || mod.modifierType === "formula") && mod.effectType == SFRPGEffectType.BASE_ATTACK_BONUS;
         });
-        filteredModifiers = context.parameters.stackModifiers.process(filteredModifiers, context, {actor: fact.actor});
 
         const bonus = Object.entries(filteredModifiers).reduce((sum, mod) => {
             if (mod[1] === null || mod[1].length < 1) return sum;

--- a/src/module/rules/actions/actor/calculate-base-ability-modifier.js
+++ b/src/module/rules/actions/actor/calculate-base-ability-modifier.js
@@ -37,7 +37,7 @@ export default function(engine) {
             return (mod.enabled || mod.modifierType === "formula") && [SFRPGEffectType.ABILITY_MODIFIER, SFRPGEffectType.ABILITY_MODIFIERS].includes(mod.effectType);
         });
 
-        for (let [abl, ability] of Object.entries(data.abilities)) {
+        for (const [abl, ability] of Object.entries(data.abilities)) {
 
             const abilityMods = filteredMods.filter(mod => mod.valueAffected === abl || mod.effectType === SFRPGEffectType.ABILITY_MODIFIERS);
 
@@ -49,7 +49,7 @@ export default function(engine) {
             const base = Math.floor((abilityValue - 10) / 2);
             ability.modifierTooltip.push(game.i18n.format("SFRPG.AbilityModifierBase", { mod: base.signedString() }));
 
-            let mod = Object.entries(abilityMods).reduce((sum, mod) => {
+            const mod = Object.entries(abilityMods).reduce((sum, mod) => {
                 if (mod[1] === null || mod[1].length < 1) return sum;
 
                 if ([SFRPGModifierTypes.CIRCUMSTANCE, SFRPGModifierTypes.UNTYPED].includes(mod[0])) {
@@ -66,7 +66,7 @@ export default function(engine) {
             let abilityModifier = base + mod;
 
             if (ability.damage) {
-                let damage = -Math.floor(Math.abs(ability.damage) / 2);
+                const damage = -Math.floor(Math.abs(ability.damage) / 2);
                 abilityModifier += damage;
                 ability.modifierTooltip.push(game.i18n.format("SFRPG.AbilityDamageTooltip", { mod: damage.signedString() }));
             }

--- a/src/module/rules/actions/actor/calculate-base-ability-modifier.js
+++ b/src/module/rules/actions/actor/calculate-base-ability-modifier.js
@@ -39,11 +39,7 @@ export default function(engine) {
 
         for (let [abl, ability] of Object.entries(data.abilities)) {
 
-            const abilityMods = context.parameters.stackModifiers.process(
-                filteredMods.filter(mod => mod.valueAffected === abl || mod.effectType === SFRPGEffectType.ABILITY_MODIFIERS),
-                context,
-                {actor: fact.actor}
-            );
+            const abilityMods = filteredMods.filter(mod => mod.valueAffected === abl || mod.effectType === SFRPGEffectType.ABILITY_MODIFIERS);
 
             let abilityValue = ability.value;
             if (Number.isNaN(Number.parseInt(abilityValue))) {

--- a/src/module/rules/actions/actor/calculate-base-ability-score.js
+++ b/src/module/rules/actions/actor/calculate-base-ability-score.js
@@ -69,14 +69,13 @@ export default function(engine) {
                 }
             }
         }
+		
+		const filterMods = (abl, mod) => { return mod.valueAffected === abl; };
 
         for (let [abl, ability] of Object.entries(data.abilities)) {
 
-            const abilityMods = context.parameters.stackModifiers.process(
-                filteredMods.filter(mod => mod.valueAffected === abl),
-                context,
-                {actor: fact.actor}
-            );
+
+            const abilityMods = filteredMods.filter(mod => filterMods(abl, mod));
 
             let score = ability.base ? ability.base : 10;
             ability.tooltip.push(game.i18n.format("SFRPG.AbilityScoreBaseTooltip", { mod: score.signedString() }));

--- a/src/module/rules/actions/actor/calculate-base-ability-score.js
+++ b/src/module/rules/actions/actor/calculate-base-ability-score.js
@@ -41,25 +41,25 @@ export default function(engine) {
             return (mod.enabled || mod.modifierType === "formula") && [SFRPGEffectType.ABILITY_SCORE].includes(mod.effectType);
         });
 
-        let themeMod = {};
+        const themeMod = {};
         if (themeData?.abilityMod) {
             themeMod[themeData.abilityMod.ability] = themeData.abilityMod.mod;
         }
 
-        let racesMod = {};
-        for (let race of races) {
+        const racesMod = {};
+        for (const race of races) {
             const raceData = race.system;
-            for (let raceMod of raceData.abilityMods.parts) {
+            for (const raceMod of raceData.abilityMods.parts) {
                 racesMod[raceMod[1]] = racesMod[raceMod[1]] !== undefined ? racesMod[raceMod[1]] + raceMod[0] : raceMod[0];
             }
         }
 
-        let abilityScoreIncreasesMod = {};
+        const abilityScoreIncreasesMod = {};
         const asis = fact.asis?.filter(x => x.type === "asi") || [];
-        for (let asi of asis) {
+        for (const asi of asis) {
             const asiData = asi.system;
 
-            for (let ability of Object.keys(SFRPG.abilities)) {
+            for (const ability of Object.keys(SFRPG.abilities)) {
                 if (asiData.abilities[ability]) {
                     if (!(ability in abilityScoreIncreasesMod)) {
                         abilityScoreIncreasesMod[ability] = 1;
@@ -69,11 +69,10 @@ export default function(engine) {
                 }
             }
         }
-		
-		const filterMods = (abl, mod) => { return mod.valueAffected === abl; };
 
-        for (let [abl, ability] of Object.entries(data.abilities)) {
+        const filterMods = (abl, mod) => { return mod.valueAffected === abl; };
 
+        for (const [abl, ability] of Object.entries(data.abilities)) {
 
             const abilityMods = filteredMods.filter(mod => filterMods(abl, mod));
 
@@ -107,18 +106,18 @@ export default function(engine) {
             }
 
             if (ability.userPenalty) {
-                let userPenalty = -Math.abs(ability.userPenalty);
+                const userPenalty = -Math.abs(ability.userPenalty);
                 score += userPenalty;
                 ability.tooltip.push(game.i18n.format("SFRPG.AbilityPenaltyTooltip", { mod: userPenalty.signedString() }));
             }
 
             if (ability.drain) {
-                let drain = -Math.abs(ability.drain);
+                const drain = -Math.abs(ability.drain);
                 score += drain;
                 ability.tooltip.push(game.i18n.format("SFRPG.AbilityDrainTooltip", { mod: drain.signedString() }));
             }
 
-            let bonus = Object.entries(abilityMods).reduce((sum, mod) => {
+            const bonus = Object.entries(abilityMods).reduce((sum, mod) => {
                 if (mod[1] === null || mod[1].length < 1) return sum;
 
                 if ([SFRPGModifierTypes.CIRCUMSTANCE, SFRPGModifierTypes.UNTYPED].includes(mod[0])) {

--- a/src/module/rules/actions/actor/calculate-cmd-modifiers.js
+++ b/src/module/rules/actions/actor/calculate-cmd-modifiers.js
@@ -37,7 +37,7 @@ export default function(engine) {
             return (mod.enabled || mod.modifierType === "formula") && [SFRPGEffectType.CMD].includes(mod.effectType);
         });
 
-        const mods = context.parameters.stackModifiers.process(filteredMods, context, {actor: fact.actor});
+        const mods = filteredMods;
 
         const cmdMod = Object.entries(mods).reduce((prev, curr) => {
             if (curr[1] === null || curr[1].length < 1) return prev;

--- a/src/module/rules/actions/actor/calculate-encumbrance.js
+++ b/src/module/rules/actions/actor/calculate-encumbrance.js
@@ -2,100 +2,99 @@ import { SFRPGEffectType, SFRPGModifierType, SFRPGModifierTypes } from "../../..
 
 export default function(engine) {
     engine.closures.add("calculateEncumbrance", (fact, context) => {
-        const data = fact.data;
-        const actor = fact.actor;
-        const actorData = actor.system;
+		const data = fact.data;
+		const actor = fact.actor;
+		const actorData = actor.system;
 
-        let tooltip = [];
-        if (data.encumbrance) {
-            tooltip = encumbrance.tooltip;
-        }
+		let tooltip = [];
+		if (data.encumbrance) {
+			tooltip = data.encumbrance.tooltip;
+		}
+		
 
-        const addModifier = (bonus, data, item, localizationKey) => {
-            if (bonus.modifierType === SFRPGModifierType.FORMULA) {
-                if (item.rolledMods) {
-                    item.rolledMods.push({mod: bonus.modifier, bonus: bonus});
-                } else {
-                    item.rolledMods = [{mod: bonus.modifier, bonus: bonus}];
-                }
+		const addModifier = (bonus, data, item, localizationKey) => {
+			if (bonus.modifierType === SFRPGModifierType.FORMULA) {
+				if (item.rolledMods) {
+					item.rolledMods.push({mod: bonus.modifier, bonus: bonus});
+				} else {
+					item.rolledMods = [{mod: bonus.modifier, bonus: bonus}];
+				}
 
-                return 0;
-            }
+				return 0;
+			}
 
-            let computedBonus = 0;
-            try {
-                const roll = Roll.create(bonus.modifier.toString(), data).evaluate({maximize: true});
-                computedBonus = roll.total;
-            } catch {}
+			let computedBonus = 0;
+			try {
+				const roll = Roll.create(bonus.modifier.toString(), data).evaluate({maximize: true});
+				computedBonus = roll.total;
+			} catch {}
 
-            if (computedBonus !== 0 && localizationKey) {
-                item.tooltip.push(game.i18n.format(localizationKey, {
-                    type: game.i18n.format(`SFRPG.ModifierType${bonus.type.capitalize()}`),
-                    mod: computedBonus.signedString(),
-                    source: bonus.name
-                }));
-            }
+			if (computedBonus !== 0 && localizationKey) {
+				item.tooltip.push(game.i18n.format(localizationKey, {
+					type: game.i18n.format(`SFRPG.ModifierType${bonus.type.capitalize()}`),
+					mod: computedBonus.signedString(),
+					source: bonus.name
+				}));
+			}
 
-            return computedBonus;
-        };
+			return computedBonus;
+		};
+		
+		let strength = Number(data.abilities.str.value);
+		let max = Number.isNaN(strength) ? 0 : strength;
+		
+		tooltip.push(game.i18n.format("SFRPG.ActorSheet.Inventory.Encumbrance.EncumbranceBaseTooltip", {
+			base: strength.signedString()
+		}));
+		
+		// Iterate through any modifiers that affect encumbrance
+		let filteredModifiers = fact.modifiers.filter(mod => {
+			return (mod.enabled || mod.modifierType === "formula") && mod.effectType == SFRPGEffectType.BULK;
+		});
+		
+		let encumbrance = {
+			value: 0,
+			tooltip: tooltip,
+			rolledMods: []
+		};
+		
+		let bonus = Object.entries(filteredModifiers).reduce((sum, mod) => {
+			if (mod[1] === null || mod[1].length < 1) return sum;
 
-        let strength = Number(data.abilities.str.value);
-        let max = Number.isNaN(strength) ? 0 : strength;
+			if ([SFRPGModifierTypes.CIRCUMSTANCE, SFRPGModifierTypes.UNTYPED].includes(mod[0])) {
+				for (const bonus of mod[1]) {
+					sum += addModifier(bonus, data, encumbrance, "SFRPG.ActorSheet.Inventory.Encumbrance.EncumbranceModifierTooltip");
+				}
+			} else {
+				sum += addModifier(mod[1], data, encumbrance, "SFRPG.ActorSheet.Inventory.Encumbrance.EncumbranceModifierTooltip");
+			}
 
-        tooltip.push(game.i18n.format("SFRPG.ActorSheet.Inventory.Encumbrance.EncumbranceBaseTooltip", {
-            base: strength.signedString()
-        }));
+			return sum;
+		}, 0);
+		
+		data.attributes.encumbrance = {
+			max: max + bonus,
+			value: 0,
+			pct: 0,
+			encumbered: false,
+			tooltip: encumbrance.tooltip,
+			rolledMods: encumbrance.rolledMods
+		};
+		
+		const _computeEncumbrance = (totalWeight, actorData) => {
+			const enc = {
+				max: actorData.attributes.encumbrance.max,
+				tooltip: actorData.attributes.encumbrance.tooltip,
+				value: totalWeight
+			};
 
-        // Iterate through any modifiers that affect encumbrance
-        let filteredModifiers = fact.modifiers.filter(mod => {
-            return (mod.enabled || mod.modifierType === "formula") && mod.effectType == SFRPGEffectType.BULK;
-        });
-        filteredModifiers = context.parameters.stackModifiers.process(filteredModifiers, context, {actor: fact.actor});
-
-        let encumbrance = {
-            value: 0,
-            tooltip: tooltip,
-            rolledMods: []
-        };
-
-        let bonus = Object.entries(filteredModifiers).reduce((sum, mod) => {
-            if (mod[1] === null || mod[1].length < 1) return sum;
-
-            if ([SFRPGModifierTypes.CIRCUMSTANCE, SFRPGModifierTypes.UNTYPED].includes(mod[0])) {
-                for (const bonus of mod[1]) {
-                    sum += addModifier(bonus, data, encumbrance, "SFRPG.ActorSheet.Inventory.Encumbrance.EncumbranceModifierTooltip");
-                }
-            } else {
-                sum += addModifier(mod[1], data, encumbrance, "SFRPG.ActorSheet.Inventory.Encumbrance.EncumbranceModifierTooltip");
-            }
-
-            return sum;
-        }, 0);
-
-        data.attributes.encumbrance = {
-            max: max + bonus,
-            value: 0,
-            pct: 0,
-            encumbered: false,
-            tooltip: encumbrance.tooltip,
-            rolledMods: encumbrance.rolledMods
-        };
-
-        const _computeEncumbrance = (totalWeight, actorData) => {
-            const enc = {
-                max: actorData.attributes.encumbrance.max,
-                tooltip: actorData.attributes.encumbrance.tooltip,
-                value: totalWeight
-            };
-
-            enc.pct = Math.min(enc.value * 100 / enc.max, 99);
-            enc.encumbered = enc.pct > 50;
-            return enc;
-        };
-
-        actorData.encumbrance = _computeEncumbrance(actorData.bulk, actorData);
-        data.encumbrance = actorData.encumbrance;
-
-        return fact;
+			enc.pct = Math.min(enc.value * 100 / enc.max, 99);
+			enc.encumbered = enc.pct > 50;
+			return enc;
+		};
+		
+		actorData.encumbrance = _computeEncumbrance(actorData.bulk, actorData);
+		data.encumbrance = actorData.encumbrance;
+		return fact;
     }, { required: ["stackModifiers"], closureParameters: ["stackModifiers"] });
 }

--- a/src/module/rules/actions/actor/calculate-encumbrance.js
+++ b/src/module/rules/actions/actor/calculate-encumbrance.js
@@ -2,99 +2,98 @@ import { SFRPGEffectType, SFRPGModifierType, SFRPGModifierTypes } from "../../..
 
 export default function(engine) {
     engine.closures.add("calculateEncumbrance", (fact, context) => {
-		const data = fact.data;
-		const actor = fact.actor;
-		const actorData = actor.system;
+        const data = fact.data;
+        const actor = fact.actor;
+        const actorData = actor.system;
 
-		let tooltip = [];
-		if (data.encumbrance) {
-			tooltip = data.encumbrance.tooltip;
-		}
-		
+        let tooltip = [];
+        if (data.encumbrance) {
+            tooltip = data.encumbrance.tooltip;
+        }
 
-		const addModifier = (bonus, data, item, localizationKey) => {
-			if (bonus.modifierType === SFRPGModifierType.FORMULA) {
-				if (item.rolledMods) {
-					item.rolledMods.push({mod: bonus.modifier, bonus: bonus});
-				} else {
-					item.rolledMods = [{mod: bonus.modifier, bonus: bonus}];
-				}
+        const addModifier = (bonus, data, item, localizationKey) => {
+            if (bonus.modifierType === SFRPGModifierType.FORMULA) {
+                if (item.rolledMods) {
+                    item.rolledMods.push({mod: bonus.modifier, bonus: bonus});
+                } else {
+                    item.rolledMods = [{mod: bonus.modifier, bonus: bonus}];
+                }
 
-				return 0;
-			}
+                return 0;
+            }
 
-			let computedBonus = 0;
-			try {
-				const roll = Roll.create(bonus.modifier.toString(), data).evaluate({maximize: true});
-				computedBonus = roll.total;
-			} catch {}
+            let computedBonus = 0;
+            try {
+                const roll = Roll.create(bonus.modifier.toString(), data).evaluate({maximize: true});
+                computedBonus = roll.total;
+            } catch {}
 
-			if (computedBonus !== 0 && localizationKey) {
-				item.tooltip.push(game.i18n.format(localizationKey, {
-					type: game.i18n.format(`SFRPG.ModifierType${bonus.type.capitalize()}`),
-					mod: computedBonus.signedString(),
-					source: bonus.name
-				}));
-			}
+            if (computedBonus !== 0 && localizationKey) {
+                item.tooltip.push(game.i18n.format(localizationKey, {
+                    type: game.i18n.format(`SFRPG.ModifierType${bonus.type.capitalize()}`),
+                    mod: computedBonus.signedString(),
+                    source: bonus.name
+                }));
+            }
 
-			return computedBonus;
-		};
-		
-		let strength = Number(data.abilities.str.value);
-		let max = Number.isNaN(strength) ? 0 : strength;
-		
-		tooltip.push(game.i18n.format("SFRPG.ActorSheet.Inventory.Encumbrance.EncumbranceBaseTooltip", {
-			base: strength.signedString()
-		}));
-		
-		// Iterate through any modifiers that affect encumbrance
-		let filteredModifiers = fact.modifiers.filter(mod => {
-			return (mod.enabled || mod.modifierType === "formula") && mod.effectType == SFRPGEffectType.BULK;
-		});
-		
-		let encumbrance = {
-			value: 0,
-			tooltip: tooltip,
-			rolledMods: []
-		};
-		
-		let bonus = Object.entries(filteredModifiers).reduce((sum, mod) => {
-			if (mod[1] === null || mod[1].length < 1) return sum;
+            return computedBonus;
+        };
 
-			if ([SFRPGModifierTypes.CIRCUMSTANCE, SFRPGModifierTypes.UNTYPED].includes(mod[0])) {
-				for (const bonus of mod[1]) {
-					sum += addModifier(bonus, data, encumbrance, "SFRPG.ActorSheet.Inventory.Encumbrance.EncumbranceModifierTooltip");
-				}
-			} else {
-				sum += addModifier(mod[1], data, encumbrance, "SFRPG.ActorSheet.Inventory.Encumbrance.EncumbranceModifierTooltip");
-			}
+        const strength = Number(data.abilities.str.value);
+        const max = Number.isNaN(strength) ? 0 : strength;
 
-			return sum;
-		}, 0);
-		
-		data.attributes.encumbrance = {
-			max: max + bonus,
-			value: 0,
-			pct: 0,
-			encumbered: false,
-			tooltip: encumbrance.tooltip,
-			rolledMods: encumbrance.rolledMods
-		};
-		
-		const _computeEncumbrance = (totalWeight, actorData) => {
-			const enc = {
-				max: actorData.attributes.encumbrance.max,
-				tooltip: actorData.attributes.encumbrance.tooltip,
-				value: totalWeight
-			};
+        tooltip.push(game.i18n.format("SFRPG.ActorSheet.Inventory.Encumbrance.EncumbranceBaseTooltip", {
+            base: strength.signedString()
+        }));
 
-			enc.pct = Math.min(enc.value * 100 / enc.max, 99);
-			enc.encumbered = enc.pct > 50;
-			return enc;
-		};
-		
-		actorData.encumbrance = _computeEncumbrance(actorData.bulk, actorData);
-		data.encumbrance = actorData.encumbrance;
-		return fact;
+        // Iterate through any modifiers that affect encumbrance
+        const filteredModifiers = fact.modifiers.filter(mod => {
+            return (mod.enabled || mod.modifierType === "formula") && mod.effectType == SFRPGEffectType.BULK;
+        });
+
+        const encumbrance = {
+            value: 0,
+            tooltip: tooltip,
+            rolledMods: []
+        };
+
+        const bonus = Object.entries(filteredModifiers).reduce((sum, mod) => {
+            if (mod[1] === null || mod[1].length < 1) return sum;
+
+            if ([SFRPGModifierTypes.CIRCUMSTANCE, SFRPGModifierTypes.UNTYPED].includes(mod[0])) {
+                for (const bonus of mod[1]) {
+                    sum += addModifier(bonus, data, encumbrance, "SFRPG.ActorSheet.Inventory.Encumbrance.EncumbranceModifierTooltip");
+                }
+            } else {
+                sum += addModifier(mod[1], data, encumbrance, "SFRPG.ActorSheet.Inventory.Encumbrance.EncumbranceModifierTooltip");
+            }
+
+            return sum;
+        }, 0);
+
+        data.attributes.encumbrance = {
+            max: max + bonus,
+            value: 0,
+            pct: 0,
+            encumbered: false,
+            tooltip: encumbrance.tooltip,
+            rolledMods: encumbrance.rolledMods
+        };
+
+        const _computeEncumbrance = (totalWeight, actorData) => {
+            const enc = {
+                max: actorData.attributes.encumbrance.max,
+                tooltip: actorData.attributes.encumbrance.tooltip,
+                value: totalWeight
+            };
+
+            enc.pct = Math.min(enc.value * 100 / enc.max, 99);
+            enc.encumbered = enc.pct > 50;
+            return enc;
+        };
+
+        actorData.encumbrance = _computeEncumbrance(actorData.bulk, actorData);
+        data.encumbrance = actorData.encumbrance;
+        return fact;
     }, { required: ["stackModifiers"], closureParameters: ["stackModifiers"] });
 }

--- a/src/module/rules/actions/actor/calculate-initiative-modifiers.js
+++ b/src/module/rules/actions/actor/calculate-initiative-modifiers.js
@@ -30,7 +30,7 @@ export default function(engine) {
             return (mod.enabled || mod.modifierType === "formula") && [SFRPGEffectType.INITIATIVE].includes(mod.effectType);
         });
 
-        const mods = context.parameters.stackModifiers.process(filteredMods.filter(mod => {
+        const mods = filteredMods.filter(mod => {
             if (mod.modifierType === SFRPGModifierType.FORMULA) {
                 if (init.rolledMods) {
                     init.rolledMods.push({mod: mod.modifier, bonus: mod});
@@ -40,7 +40,7 @@ export default function(engine) {
                 return false;
             }
             else return true;
-        }), context, {actor: fact.actor});
+        });
 
         const mod = Object.entries(mods).reduce((prev, curr) => {
             if (curr[1] === null || curr[1].length < 1) return prev;

--- a/src/module/rules/actions/actor/calculate-initiative-modifiers.js
+++ b/src/module/rules/actions/actor/calculate-initiative-modifiers.js
@@ -13,7 +13,7 @@ export default function(engine) {
                 item.calculatedMods = [{mod: bonus.modifier, bonus: bonus}];
             }
 
-            let computedBonus = bonus.max || 0;
+            const computedBonus = bonus.max || 0;
 
             if (computedBonus !== 0 && localizationKey) {
                 item.tooltip.push(game.i18n.format(localizationKey, {

--- a/src/module/rules/actions/actor/calculate-movement-speeds.js
+++ b/src/module/rules/actions/actor/calculate-movement-speeds.js
@@ -50,11 +50,11 @@ export default function(engine) {
 
             const baseValue = Number(data.attributes.speed[speedKey].base);
 
-            let filteredModifiers = fact.modifiers.filter(mod => {
+            const filteredModifiers = fact.modifiers.filter(mod => {
                 return (mod.enabled || mod.modifierType === "formula") && (mod.effectType === SFRPGEffectType.ALL_SPEEDS || (mod.effectType === SFRPGEffectType.SPECIFIC_SPEED && mod.valueAffected === speedKey));
             });
 
-            let filteredMultiplyModifiers = fact.modifiers.filter(mod => {
+            const filteredMultiplyModifiers = fact.modifiers.filter(mod => {
                 return (mod.enabled || mod.modifierType === "formula") && mod.effectType === SFRPGEffectType.MULTIPLY_ALL_SPEEDS;
             });
 

--- a/src/module/rules/actions/actor/calculate-movement-speeds.js
+++ b/src/module/rules/actions/actor/calculate-movement-speeds.js
@@ -53,12 +53,10 @@ export default function(engine) {
             let filteredModifiers = fact.modifiers.filter(mod => {
                 return (mod.enabled || mod.modifierType === "formula") && (mod.effectType === SFRPGEffectType.ALL_SPEEDS || (mod.effectType === SFRPGEffectType.SPECIFIC_SPEED && mod.valueAffected === speedKey));
             });
-            filteredModifiers = context.parameters.stackModifiers.process(filteredModifiers, context, {actor: fact.actor});
 
             let filteredMultiplyModifiers = fact.modifiers.filter(mod => {
                 return (mod.enabled || mod.modifierType === "formula") && mod.effectType === SFRPGEffectType.MULTIPLY_ALL_SPEEDS;
             });
-            filteredMultiplyModifiers = context.parameters.stackModifiers.process(filteredMultiplyModifiers, context, {actor: fact.actor});
 
             const bonus = Object.entries(filteredModifiers).reduce((sum, mod) => {
                 if (mod[1] === null || mod[1].length < 1) return sum;

--- a/src/module/rules/actions/actor/calculate-save-modifiers.js
+++ b/src/module/rules/actions/actor/calculate-save-modifiers.js
@@ -24,19 +24,19 @@ export default function(engine) {
 
             let saveMod = 0;
             switch (bonus.valueAffected) {
-            case "highest":
-                if (item.bonus === highest.bonus) {
+                case "highest":
+                    if (item.bonus === highest.bonus) {
+                        saveMod = computedBonus;
+                    }
+                    break;
+                case "lowest":
+                    if (item.bonus === lowest.bonus) {
+                        saveMod = computedBonus;
+                    }
+                    break;
+                default:
                     saveMod = computedBonus;
-                }
-                break;
-            case "lowest":
-                if (item.bonus === lowest.bonus) {
-                    saveMod = computedBonus;
-                }
-                break;
-            default:
-                saveMod = computedBonus;
-                break;
+                    break;
             }
             computedBonus = saveMod;
 
@@ -100,7 +100,7 @@ export default function(engine) {
             return false;
         });
 
-        let fortMod = Object.entries(fortMods).reduce((sum, mod) => {
+        const fortMod = Object.entries(fortMods).reduce((sum, mod) => {
             if (mod[1] === null || mod[1].length < 1) return sum;
 
             if ([SFRPGModifierTypes.CIRCUMSTANCE, SFRPGModifierTypes.UNTYPED].includes(mod[0])) {
@@ -114,7 +114,7 @@ export default function(engine) {
             return sum;
         }, 0);
 
-        let reflexMod = Object.entries(reflexMods).reduce((sum, mod) => {
+        const reflexMod = Object.entries(reflexMods).reduce((sum, mod) => {
             if (mod[1] === null || mod[1].length < 1) return sum;
 
             if ([SFRPGModifierTypes.CIRCUMSTANCE, SFRPGModifierTypes.UNTYPED].includes(mod[0])) {
@@ -128,7 +128,7 @@ export default function(engine) {
             return sum;
         }, 0);
 
-        let willMod = Object.entries(willMods).reduce((sum, mod) => {
+        const willMod = Object.entries(willMods).reduce((sum, mod) => {
             if (mod[1] === null || mod[1].length < 1) return sum;
 
             if ([SFRPGModifierTypes.CIRCUMSTANCE, SFRPGModifierTypes.UNTYPED].includes(mod[0])) {

--- a/src/module/rules/actions/actor/calculate-save-modifiers.js
+++ b/src/module/rules/actions/actor/calculate-save-modifiers.js
@@ -56,7 +56,7 @@ export default function(engine) {
         });
 
         fort.rolledMods = null;
-        const fortMods = context.parameters.stackModifiers.process(filteredMods.filter(mod => {
+        const fortMods = filteredMods.filter(mod => {
             if (mod.modifierType === SFRPGModifierType.FORMULA && (mod.effectType === SFRPGEffectType.SAVES || [ "highest", "lowest", "fort" ].includes(mod.valueAffected))) {
                 if (fort.rolledMods) {
                     fort.rolledMods.push({mod: mod.modifier, bonus: mod});
@@ -68,10 +68,10 @@ export default function(engine) {
             if ([ "highest", "lowest", "fort" ].includes(mod.valueAffected)) return true;
             if (mod.effectType === SFRPGEffectType.SAVES) return true;
             return false;
-        }), context, {actor: fact.actor});
+        });
 
         reflex.rolledMods = null;
-        const reflexMods = context.parameters.stackModifiers.process(filteredMods.filter(mod => {
+        const reflexMods = filteredMods.filter(mod => {
             if (mod.modifierType === SFRPGModifierType.FORMULA && (mod.effectType === SFRPGEffectType.SAVES || [ "highest", "lowest", "reflex" ].includes(mod.valueAffected))) {
                 if (reflex.rolledMods) {
                     reflex.rolledMods.push({mod: mod.modifier, bonus: mod});
@@ -83,10 +83,10 @@ export default function(engine) {
             if ([ "highest", "lowest", "reflex" ].includes(mod.valueAffected)) return true;
             if (mod.effectType === SFRPGEffectType.SAVES) return true;
             return false;
-        }), context, {actor: fact.actor});
+        });
 
         will.rolledMods = null;
-        const willMods = context.parameters.stackModifiers.process(filteredMods.filter(mod => {
+        const willMods = filteredMods.filter(mod => {
             if (mod.modifierType === SFRPGModifierType.FORMULA && (mod.effectType === SFRPGEffectType.SAVES || [ "highest", "lowest", "will" ].includes(mod.valueAffected))) {
                 if (will.rolledMods) {
                     will.rolledMods.push({mod: mod.modifier, bonus: mod});
@@ -98,7 +98,7 @@ export default function(engine) {
             if ([ "highest", "lowest", "will" ].includes(mod.valueAffected)) return true;
             if (mod.effectType === SFRPGEffectType.SAVES) return true;
             return false;
-        }), context, {actor: fact.actor});
+        });
 
         let fortMod = Object.entries(fortMods).reduce((sum, mod) => {
             if (mod[1] === null || mod[1].length < 1) return sum;

--- a/src/module/rules/actions/actor/calculate-skill-modifiers.js
+++ b/src/module/rules/actions/actor/calculate-skill-modifiers.js
@@ -12,7 +12,7 @@ export default function(engine) {
             } else {
                 item.calculatedMods = [{mod: bonus.modifier, bonus: bonus}];
             }
-            let computedBonus = bonus.max || 0;
+            const computedBonus = bonus.max || 0;
 
             if (computedBonus !== 0 && localizationKey) {
                 item.tooltip.push(game.i18n.format(localizationKey, {
@@ -30,43 +30,42 @@ export default function(engine) {
         });
 
         // Skills
-		const getFilteredSkills = (skl, skill, mod) => {
-			if (mod.modifierType === SFRPGModifierType.FORMULA 
+        const getFilteredSkills = (skl, skill, mod) => {
+            if (mod.modifierType === SFRPGModifierType.FORMULA
 				&& (
-					mod.effectType === SFRPGEffectType.ALL_SKILLS
+				    mod.effectType === SFRPGEffectType.ALL_SKILLS
                     || mod.effectType === SFRPGEffectType.SKILL && skl === mod.valueAffected
                     || mod.effectType === SFRPGEffectType.ABILITY_SKILLS && skill.ability === mod.valueAffected
 				)
-			) 
-			{
-				if (skill.rolledMods) {
-					skill.rolledMods.push({mod: mod.modifier, bonus: mod});
-				} else {
-					skill.rolledMods = [{mod: mod.modifier, bonus: mod}];
-				}
-				return false;
-			}
-			
-			return (mod.effectType === SFRPGEffectType.ALL_SKILLS) 
-				|| (mod.effectType === SFRPGEffectType.SKILL && skl === mod.valueAffected) 
-				|| (mod.effectType === SFRPGEffectType.ABILITY_SKILLS && skill.ability === mod.valueAffected);
-		};
-		
-		
-        for (let [skl, skill] of Object.entries(skills)) {
-            skill.rolledMods = null;
-			
-			//Imper1um 08/14/2023: 
-			//	I removed .process from this system.
-			//	What was happening is that the filter system was looping... infinitely. This is because
-			//  stackModifiers.process was calling calculate-skill-modifiers.
-			//  Please note you *CANNOT* call stackModifiers.process INSIDE of a processor, you will cause an infinite loop.
-			//  This has existed for years, but its been ignored by one problem or another.
-			//  Anyways, calling the .process from here is useless. By time it's gotten here, all of the mods have been
-			//  properly processed (at least in the correct order), so there's no reason to ask the system to call it again.
-			var skillFilteredMods = filteredMods.filter(mod => getFilteredSkills(skl, skill, mod));
+            )
+            {
+                if (skill.rolledMods) {
+                    skill.rolledMods.push({mod: mod.modifier, bonus: mod});
+                } else {
+                    skill.rolledMods = [{mod: mod.modifier, bonus: mod}];
+                }
+                return false;
+            }
 
-            let accumulator = Object.entries(skillFilteredMods).reduce((sum, mod) => {
+            return (mod.effectType === SFRPGEffectType.ALL_SKILLS)
+				|| (mod.effectType === SFRPGEffectType.SKILL && skl === mod.valueAffected)
+				|| (mod.effectType === SFRPGEffectType.ABILITY_SKILLS && skill.ability === mod.valueAffected);
+        };
+
+        for (const [skl, skill] of Object.entries(skills)) {
+            skill.rolledMods = null;
+
+            // Imper1um 08/14/2023:
+            //	I removed .process from this system.
+            //	What was happening is that the filter system was looping... infinitely. This is because
+            //  stackModifiers.process was calling calculate-skill-modifiers.
+            //  Please note you *CANNOT* call stackModifiers.process INSIDE of a processor, you will cause an infinite loop.
+            //  This has existed for years, but its been ignored by one problem or another.
+            //  Anyways, calling the .process from here is useless. By time it's gotten here, all of the mods have been
+            //  properly processed (at least in the correct order), so there's no reason to ask the system to call it again.
+            const skillFilteredMods = filteredMods.filter(mod => getFilteredSkills(skl, skill, mod));
+
+            const accumulator = Object.entries(skillFilteredMods).reduce((sum, mod) => {
                 if (mod[1] === null || mod[1].length < 1) return sum;
 
                 if ([SFRPGModifierTypes.CIRCUMSTANCE, SFRPGModifierTypes.UNTYPED].includes(mod[0])) {

--- a/src/module/rules/actions/actor/clear-tooltips.js
+++ b/src/module/rules/actions/actor/clear-tooltips.js
@@ -25,7 +25,7 @@ export default function(engine) {
         }
 
         if (data.abilities) {
-            for (let [abl, ability] of Object.entries(data.abilities)) {
+            for (const [abl, ability] of Object.entries(data.abilities)) {
                 ability.tooltip = [];
                 ability.modifierTooltip = [];
             }
@@ -64,7 +64,7 @@ export default function(engine) {
         }
 
         if (data.skills) {
-            for (let [skl, skill] of Object.entries(data.skills)) {
+            for (const [skl, skill] of Object.entries(data.skills)) {
                 skill.tooltip = [];
             }
         }


### PR DESCRIPTION
There was a very serious issue in the rules js. Most of the calculate- js files had this issue, but it was being hidden by a crash occurring in calculate-encumbrance.js . The crash was minor, but it did result in a crash of the encumbrance calculation (no idea why encumbrance was still able to be calculated properly). Fixing the crash resulted in StackOverflowExceptions to bubble up from most of the calculate- .js files.

The problem is that these calculate- .js files were calling stackModifiers.process . However, these calculate- .js files were, in fact, stackModifiers being processed. What was happening is these stackModifiers were being added to the stack infinitely, causing the StackOverflowException because it was going in a loop. So, removing the stackModifiers.process from all the calculate- .js fixes the issue. They weren't necessary anyways; the idea behind the stackModifiers is the process *should* have been run prior to each calculation step being necessary.