### PR TITLE
Fixes #1233

### DIFF
--- a/src/module/actor/mixins/actor-damage.js
+++ b/src/module/actor/mixins/actor-damage.js
@@ -89,7 +89,7 @@ export class SFRPGDamage {
     static createDamage(damageAmount, damageTypes = [], isCritical = false, properties = [], options = {}) {
         const parsedDamageTypes = [];
         if (damageTypes.constructor === String) {
-            const splitTypes = damageTypes.trim().split(/([^,;])+/gi);
+            const splitTypes = damageTypes.trim().split(/([,;])+/gi);
             for (const type of splitTypes) {
                 if (type === ',' || type === ';') {
                     continue;


### PR DESCRIPTION
Fixes #1233 

The extra regex ^ was causing the expression to treat the first character as a splitter, but, with how JavaScript Regex Splitters work, it will see that ^ is index 0, and then use that character at index 0 as the split, so if you have a string:

"so"
A regex with ([^,;])+ will create three groups:
"","o",""
This is because it finds that index 0 is a split character, and creates an empty string for the first item, and then puts index 1 as the second item. The third item is something something extra that RegEx likes to do. I'm sure I could look it up, but this just fixes the issue entirely.