### PR TITLE
Guard against empty difficulty data

### DIFF
--- a/src/module/combat/combat.js
+++ b/src/module/combat/combat.js
@@ -629,9 +629,7 @@ export class CombatSFRPG extends Combat {
 
         const difficultyHTML = document.createElement("a");
         difficultyHTML.classList.add("combat-difficulty");
-		if (difficulty) {
-			difficultyHTML.classList.add(difficulty);
-		}
+        if (difficulty) difficultyHTML.classList.add(difficulty);
         if (combatType === 'normal') {
             difficultyHTML.title = `${game.i18n.format("SFRPG.Combat.Difficulty.Tooltip.ClickForDetails")}\n\n${game.i18n.format("SFRPG.Combat.Difficulty.Tooltip.PCs")}: ${diffObject.difficultyData.PCs.length} [${game.i18n.format("SFRPG.Combat.Difficulty.Tooltip.APL")} ${diffObject.difficultyData.APL}]\n${game.i18n.format("SFRPG.Combat.Difficulty.Tooltip.HostileNPCs")}: ${diffObject.difficultyData.enemies.length} [${game.i18n.format("SFRPG.Combat.Difficulty.Tooltip.CR")} ${diffObject.difficultyData.CR}]`;
         } else if (combatType === 'starship') {

--- a/src/module/combat/combat.js
+++ b/src/module/combat/combat.js
@@ -628,7 +628,10 @@ export class CombatSFRPG extends Combat {
         difficultyContainer.classList.add("combat-difficulty-container");
 
         const difficultyHTML = document.createElement("a");
-        difficultyHTML.classList.add("combat-difficulty", difficulty);
+        difficultyHTML.classList.add("combat-difficulty");
+		if (difficulty) {
+			difficultyHTML.classList.add(difficulty);
+		}
         if (combatType === 'normal') {
             difficultyHTML.title = `${game.i18n.format("SFRPG.Combat.Difficulty.Tooltip.ClickForDetails")}\n\n${game.i18n.format("SFRPG.Combat.Difficulty.Tooltip.PCs")}: ${diffObject.difficultyData.PCs.length} [${game.i18n.format("SFRPG.Combat.Difficulty.Tooltip.APL")} ${diffObject.difficultyData.APL}]\n${game.i18n.format("SFRPG.Combat.Difficulty.Tooltip.HostileNPCs")}: ${diffObject.difficultyData.enemies.length} [${game.i18n.format("SFRPG.Combat.Difficulty.Tooltip.CR")} ${diffObject.difficultyData.CR}]`;
         } else if (combatType === 'starship') {


### PR DESCRIPTION
Separates out difficulty add so that if difficulty is empty in any way that it won't attempt to add it as a classList add. This will prevent combat menu desync. Fixes #1261 