### PR TITLE
Fix character sheet tooltip for Enhanced classes

### DIFF
--- a/src/module/rules/actions/actor/character/calculate-character-level.js
+++ b/src/module/rules/actions/actor/character/calculate-character-level.js
@@ -20,8 +20,8 @@ export default function(engine) {
 
             const classLevel = classData.levels;
             const tooltip = game.i18n.format("SFRPG.CharacterLevelsTooltip", {
-                class: cls.name,
-                levels: classLevel + ` (@classes.${cls.name.toLowerCase()}.levels)`
+                class: cls.name.split(',')[0].trim(),
+                levels: classLevel + ` (@classes.${cls.name.toLowerCase().split(',')[0].trim()}.levels)`
             });
 
             data.details.level.value += classLevel;


### PR DESCRIPTION
This preemptively fixes the tooltip on the character sheet identifying character class information for the Starfinder Enhanced classes introduced in https://github.com/foundryvtt-starfinder/foundryvtt-starfinder/pull/1273.

Before:
![image](https://github.com/foundryvtt-starfinder/foundryvtt-starfinder/assets/34078802/bc8a451c-5ca1-4de9-bb01-09d9ef1b18af)

After:
![image](https://github.com/foundryvtt-starfinder/foundryvtt-starfinder/assets/34078802/f5474eec-a957-4273-88a0-0c3bbc40eda0)
