### PR TITLE
fix damage type migration idempotency

### DIFF
--- a/src/module/migration.js
+++ b/src/module/migration.js
@@ -206,7 +206,10 @@ const migrateMacro = async function(macro, schema) {
 };
 
 const damageTypeMigrationCallback = function(arr, curr) {
-    if (!Array.isArray(curr)) return arr;
+    if (!Array.isArray(curr)) {
+        arr.push(curr);
+        return arr;
+    }
     let [formula, type] = curr;
 
     if (!type) {


### PR DESCRIPTION
Hi there,

This should take care of it. If the damage isn't an array it's most likely in a good state and can be used without applying the migration.