### PR TITLE
Repaired "picking up dropped items"

### DIFF
--- a/src/module/actor/sheet/base.js
+++ b/src/module/actor/sheet/base.js
@@ -1233,7 +1233,7 @@ export class ActorSheetSFRPG extends ActorSheet {
 
         let item = null;
         if (parsedDragData.type !== 'ItemCollection') item = (await Item.fromDropData(parsedDragData)).toObject();
-        else item = parsedDragData.items[0].toObject();
+        else item = parsedDragData.items[0];
 
         // Level up existing class item if dragging on an existing one.
         if (item.type === "class") {

--- a/src/module/actor/sheet/base.js
+++ b/src/module/actor/sheet/base.js
@@ -1233,7 +1233,7 @@ export class ActorSheetSFRPG extends ActorSheet {
 
         let item = null;
         if (parsedDragData.type !== 'ItemCollection') item = (await Item.fromDropData(parsedDragData)).toObject();
-        else item = parsedDragData.items[0];
+        else item = parsedDragData.items[0].toObject?.();
 
         // Level up existing class item if dragging on an existing one.
         if (item.type === "class") {


### PR DESCRIPTION
If a dropped item is clicked on and pulled into the inventory, it results in a "processedDroppedData", transfering the instance of the dropped object under "parsedDragData.items[0]". The item is not given as ItemCollection but as an object already, and by casting "toObject()" it simply breaks at this point. As such things can't be taken into the inventory. Removing that wrong command makes it work as intendet.