### PR TITLE
second try to fix "dropped item can't be picked up/moved to character"

### DIFF
--- a/src/module/actor/sheet/base.js
+++ b/src/module/actor/sheet/base.js
@@ -1233,7 +1233,8 @@ export class ActorSheetSFRPG extends ActorSheet {
 
         let item = null;
         if (parsedDragData.type !== 'ItemCollection') item = (await Item.fromDropData(parsedDragData)).toObject();
-        else item = parsedDragData.items[0].toObject?.();
+        else if(parsedDragData.items[0].toObject !== undefined) item = parsedDragData.items[0].toObject();
+        else item = parsedDragData.items[0];
 
         // Level up existing class item if dragging on an existing one.
         if (item.type === "class") {

--- a/src/module/actor/sheet/base.js
+++ b/src/module/actor/sheet/base.js
@@ -1233,7 +1233,7 @@ export class ActorSheetSFRPG extends ActorSheet {
 
         let item = null;
         if (parsedDragData.type !== 'ItemCollection') item = (await Item.fromDropData(parsedDragData)).toObject();
-        else if(parsedDragData.items[0].toObject !== undefined) item = parsedDragData.items[0].toObject();
+        else if (parsedDragData.items[0].toObject !== undefined) item = parsedDragData.items[0].toObject();
         else item = parsedDragData.items[0];
 
         // Level up existing class item if dragging on an existing one.


### PR DESCRIPTION
This solution checks now if toObject is available, executes it if possible or takes the existing item instance transmitted.

As the purpose of the function is actually to transfer an item, the instance can be changed and/or preserved without issue. If this is still unwanted, a solution would be to use:

item = structuredClone(parsedDragData.items[0]);