### PR TITLE
Fixed item constructor context argument not being optional

### DIFF
--- a/src/module/item/item.js
+++ b/src/module/item/item.js
@@ -13,7 +13,7 @@ import { ItemCapacityMixin } from "./mixins/item-capacity.js";
 
 export class ItemSFRPG extends Mix(Item).with(ItemActivationMixin, ItemCapacityMixin) {
 
-    constructor(data, context) {
+    constructor(data, context={}) {
         // Set module art if available. This applies art to items viewed or created from compendiums.
         if (context.pack && data._id) {
             const art = game.sfrpg.compendiumArt.map.get(`Compendium.${context.pack}.${data._id}`);


### PR DESCRIPTION
This fixes calling `new Item.implementation(data)` throwing error `Cannot read properties of undefined (reading 'pack')`.

See: https://github.com/fantasycalendar/FoundryVTT-ItemPiles/issues/606