### PR TITLE
Refactor modifier toggling and parent propagation

### DIFF
--- a/src/less/apps.less
+++ b/src/less/apps.less
@@ -429,6 +429,7 @@ img.icon-enricher {
             &:hover:not(.active) {
                 backdrop-filter: brightness(0.5);
                 filter: drop-shadow(0px 2px 4px #00a0ff);
+                transition: background 0.2s, backdrop-filter 0.2s, filter 700ms;
             }
         }
     }

--- a/src/less/apps.less
+++ b/src/less/apps.less
@@ -3,7 +3,6 @@
 @navHeight: 30px;
 @headerHeight: 100px;
 @detailsHeight: 40px;
-@sheetNavTransition: background 0.2s, backdrop-filter 0.2s;
 
 // Global background style
 button {
@@ -421,7 +420,6 @@ img.icon-enricher {
             color: #fff;
             // border-bottom: 3px solid @colorBeige;
             flex: 1;
-            transition: @sheetNavTransition;
 
             &.active {
                 // border-bottom: 3px solid @colorCrimson;
@@ -431,7 +429,6 @@ img.icon-enricher {
             &:hover:not(.active) {
                 backdrop-filter: brightness(0.5);
                 filter: drop-shadow(0px 2px 4px #00a0ff);
-                transition: @sheetNavTransition, filter 700ms;
             }
         }
     }

--- a/src/module/actor/mixins/actor-modifiers.js
+++ b/src/module/actor/mixins/actor-modifiers.js
@@ -114,8 +114,7 @@ export const ActorModifiersMixin = (superclass) => class extends superclass {
         if (!invalidate && this.system.allModifiers) return this.system.allModifiers;
 
         this.system.modifiers = this.system.modifiers.map(mod => {
-            const container = {actorUuid: this.uuid, itemUuid: null};
-            return new SFRPGModifier({...mod, container});
+            return new SFRPGModifier(mod, {parent: this});
         }, this);
 
         const allModifiers = this.system.modifiers.filter(mod => (!ignoreTemporary || mod.subtab === "permanent"));
@@ -125,8 +124,7 @@ export const ActorModifiersMixin = (superclass) => class extends superclass {
 
             // Create each modifier as an SFRPGModifier instance first on the item data.
             const itemModifiers = itemData.modifiers = itemData?.modifiers?.map(mod => {
-                const container = {actorUuid: this.uuid, itemUuid: item.uuid};
-                return new SFRPGModifier({...mod, container});
+                return new SFRPGModifier(mod, {parent: item});
             }, this) || [];
 
             if (!itemModifiers || itemModifiers.length === 0) continue;

--- a/src/module/actor/sheet/base.js
+++ b/src/module/actor/sheet/base.js
@@ -536,20 +536,10 @@ export class ActorSheetSFRPG extends ActorSheet {
         const target = $(event.currentTarget);
         const modifierId = target.closest('.item.modifier').data('modifierId');
 
-        const modifiers = foundry.utils.deepClone(this.actor.system.modifiers);
+        const modifiers = this.actor.system.modifiers;
         const modifier = modifiers.find(mod => mod._id === modifierId);
 
-        const formula = modifier.modifier;
-        if (formula) {
-            const roll = Roll.create(formula, this.actor.system);
-            modifier.max = await roll.evaluate({maximize: true}).total;
-        } else {
-            modifier.max = 0;
-        }
-
-        modifier.enabled = !modifier.enabled;
-
-        await this.actor.update({'system.modifiers': modifiers});
+        return modifier.toggle();
     }
 
     /**

--- a/src/module/actor/sheet/character.js
+++ b/src/module/actor/sheet/character.js
@@ -270,7 +270,6 @@ export class ActorSheetSFRPGCharacter extends ActorSheetSFRPG {
 
         if (!this.options.editable) return;
 
-        // html.find('.toggle-prepared').click(this._onPrepareItem.bind(this));
         html.find('.reload').on('click', this._onReloadWeapon.bind(this));
 
         html.find('.short-rest').on('click', this._onShortRest.bind(this));
@@ -280,20 +279,6 @@ export class ActorSheetSFRPGCharacter extends ActorSheetSFRPG {
         html.find('.modifier-delete').on('click', this._onModifierDelete.bind(this));
         html.find('.modifier-toggle').on('click', this._onToggleModifierEnabled.bind(this));
         html.find('.player-class-level-up').on('click', this._onLevelUp.bind(this));
-    }
-
-    /**
-     * Handle toggling the prepared status of an Owned Itme within the Actor
-     *
-     * @param {Event} event The triggering click event
-     */
-    _onPrepareItem(event) {
-        event.preventDefault();
-
-        const itemId = event.currentTarget.closest('.item').dataset.itemId;
-        const item = this.actor.items.get(itemId);
-
-        return item.update({'system.preparation.prepared': !item.system.preparation.prepared});
     }
 
     /**

--- a/src/module/actor/sheet/drone.js
+++ b/src/module/actor/sheet/drone.js
@@ -302,7 +302,6 @@ export class ActorSheetSFRPGDrone extends ActorSheetSFRPG {
 
         if (!this.options.editable) return;
 
-        // html.find('.toggle-prepared').click(this._onPrepareItem.bind(this));
         html.find(".reload").click(this._onReloadWeapon.bind(this));
 
         html.find(".repair").click(this._onRepair.bind(this));
@@ -352,48 +351,6 @@ export class ActorSheetSFRPGDrone extends ActorSheetSFRPG {
         const modifierId = target.closest(".item.modifier").data("modifierId");
 
         this.actor.editModifier(modifierId);
-    }
-
-    /**
-     * Toggle a modifier to be enabled or disabled.
-     *
-     * @param {Event} event The originating click event
-     */
-    async _onToggleModifierEnabled(event) {
-        event.preventDefault();
-        const target = $(event.currentTarget);
-        const modifierId = target.closest(".item.modifier").data("modifierId");
-
-        const modifiers = foundry.utils.deepClone(this.actor.system.modifiers);
-        const modifier = modifiers.find((mod) => mod._id === modifierId);
-
-        const formula = modifier.modifier;
-        if (formula) {
-            const roll = Roll.create(formula, this.actor.system);
-            modifier.max = await roll.evaluate({maximize: true}).total;
-        } else {
-            modifier.max = 0;
-        }
-
-        modifier.enabled = !modifier.enabled;
-
-        await this.actor.update({ "system.modifiers": modifiers });
-    }
-
-    /**
-     * Handle toggling the prepared status of an Owned Itme within the Actor
-     *
-     * @param {Event} event The triggering click event
-     */
-    _onPrepareItem(event) {
-        event.preventDefault();
-
-        const itemId = event.currentTarget.closest(".item").dataset.itemId;
-        const item = this.actor.items.get(itemId);
-
-        return item.update({
-            "system.preparation.prepared": !item.system.preparation.prepared
-        });
     }
 
     /**

--- a/src/module/apps/roll-dialog.js
+++ b/src/module/apps/roll-dialog.js
@@ -216,28 +216,8 @@ export default class RollDialog extends Dialog {
         const modifierIndex = $(event.currentTarget).data('modifierIndex');
         const modifier = this.availableModifiers[modifierIndex];
 
-        // Non-SFRPGModifier objects
         modifier.enabled = !modifier.enabled;
         this.render(false);
-
-        // SFRPGModifier instances
-        if (modifier._id) {
-            // Toggle modifier object itself
-            modifier.updateSource({"enabled": modifier.enabled});
-
-            const owner = modifier.primaryOwner;
-            if (!owner) return;
-
-            // Find the modifier in the owner and set to the updated object
-            const ownerModifiers = owner.system.modifiers;
-            const index = ownerModifiers.findIndex(x => x._id === modifier._id);
-            if (!index < 0) return;  // Will be -1 if using a global attack modifier
-
-            ownerModifiers[index] = modifier;
-            await owner.update({ "system.modifiers": ownerModifiers });
-            this.render(false);
-
-        }
     }
 
     async _onSelectorChanged(event) {

--- a/src/module/item/item.js
+++ b/src/module/item/item.js
@@ -13,7 +13,7 @@ import { ItemCapacityMixin } from "./mixins/item-capacity.js";
 
 export class ItemSFRPG extends Mix(Item).with(ItemActivationMixin, ItemCapacityMixin) {
 
-    constructor(data, context={}) {
+    constructor(data, context = {}) {
         // Set module art if available. This applies art to items viewed or created from compendiums.
         if (context.pack && data._id) {
             const art = game.sfrpg.compendiumArt.map.get(`Compendium.${context.pack}.${data._id}`);
@@ -950,8 +950,7 @@ export class ItemSFRPG extends Mix(Item).with(ItemActivationMixin, ItemCapacityM
 
         /** Create global attack modifiers. */
         const additionalModifiers = foundry.utils.deepClone(SFRPG.globalAttackRollModifiers).map(mod => {
-            const container = {actorUuid: this.actor.uuid, itemUuid: this.uuid};
-            const modInstance = {bonus: new SFRPGModifier({...mod.bonus, container})};
+            const modInstance = {bonus: new SFRPGModifier(mod.bonus, {parent: this, globalModifier: true})};
             return modInstance;
         });
 
@@ -1009,9 +1008,9 @@ export class ItemSFRPG extends Mix(Item).with(ItemActivationMixin, ItemCapacityM
             // Remove inactive constant and damage section mods. Keep all situational mods, regardless of status.
             if (!mod.enabled && mod.modifierType !== SFRPGModifierType.FORMULA) return false;
 
-            if (mod.limitTo === "parent" && mod.container.itemUuid !== this.uuid) return false;
+            if (mod.limitTo === "parent" && mod.item !== this) return false;
             if (mod.limitTo === "container") {
-                const parentItem = getItemContainer(this.actor.items, fromUuidSync(mod.container.itemUuid));
+                const parentItem = getItemContainer(this.actor.items, mod.item);
                 if (parentItem?.id !== this.id) return false;
             }
 
@@ -1388,9 +1387,9 @@ export class ItemSFRPG extends Mix(Item).with(ItemActivationMixin, ItemCapacityM
                 return false;
             }
 
-            if (mod.limitTo === "parent" && mod.container.itemUuid !== this.uuid) return false;
+            if (mod.limitTo === "parent" && mod.item !== this) return false;
             if (mod.limitTo === "container") {
-                const parentItem = getItemContainer(this.actor.items, fromUuidSync(mod.container.itemUuid));
+                const parentItem = getItemContainer(this.actor.items, mod.item);
                 if (parentItem?.id !== this.id) return false;
             }
 

--- a/src/module/item/sheet.js
+++ b/src/module/item/sheet.js
@@ -858,23 +858,10 @@ export class ItemSheetSFRPG extends ItemSheet {
         const target = $(event.currentTarget);
         const modifierId = target.closest('.item.modifier').data('modifierId');
 
-        const modifiers = foundry.utils.deepClone(this.item.system.modifiers);
+        const modifiers = this.item.system.modifiers;
         const modifier = modifiers.find(mod => mod._id === modifierId);
 
-        const formula = modifier.modifier;
-        if (formula) {
-            // TODO: test this this.item should be the actor if not try to get the actor here
-            const roll = Roll.create(formula, this.item.system);
-            modifier.max = await roll.evaluate({maximize: true}).total;
-        } else {
-            modifier.max = 0;
-        }
-
-        modifier.enabled = !modifier.enabled;
-
-        await this.item.update({
-            'system.modifiers': modifiers
-        });
+        return modifier.toggle();
     }
 
     async _onAddStorage(event) {

--- a/src/module/modifiers/modifier.js
+++ b/src/module/modifiers/modifier.js
@@ -1,3 +1,5 @@
+import { ActorSFRPG } from "../actor/actor.js";
+import { ItemSFRPG } from "../item/item.js";
 import { generateUUID } from "../utils/utilities.js";
 import { SFRPGEffectType, SFRPGModifierType, SFRPGModifierTypes } from "./types.js";
 
@@ -17,13 +19,13 @@ import { SFRPGEffectType, SFRPGModifierType, SFRPGModifierTypes } from "./types.
  * @param {String}        data.subtab        What subtab should this appear on in the character sheet?
  * @param {String}        data.condition     The condition, if any, that this modifier is associated with.
  * @param {String|null}   data.id            Override a random id with a specific one.
- * @param {Object|null}   data.container     The UUIDs of the actor and item, if applicable, the modifier is owned by.
  * @param {Object|null}   data.damage        If this modifier is a damage section modifier, the damage type and group
  * @param {String}        data.limitTo       If this modifier is on an item, should the modifier affect only that item?
  */
 export default class SFRPGModifier extends foundry.abstract.DataModel {
     constructor(data, options = {}) {
         super(data, options);
+        this.globalModifier = options.globalModifier || false;
     }
 
     _initializeSource(source, options = {}) {
@@ -61,10 +63,8 @@ export default class SFRPGModifier extends foundry.abstract.DataModel {
 
         // Calculate max, if not already
         try {
-            if (!this.max) {
-                const roll = Roll.create(this.modifier.toString());
-                this.max = roll.evaluateSync({strict: false}).total;
-            }
+            const roll = Roll.create(this.modifier.toString(), this.parent.system);
+            this.max = roll.evaluateSync({strict: false}).total;
         } catch {
             this.max = 0;
         }
@@ -118,7 +118,7 @@ export default class SFRPGModifier extends foundry.abstract.DataModel {
             }),
             enabled: new fields.BooleanField({
                 initial: false,
-                required: false,
+                required: true,
                 label: "SFRPG.ModifierEnabledLabel",
                 hint: "SFRPG.ModifierEnabledTooltip"
             }),
@@ -140,14 +140,6 @@ export default class SFRPGModifier extends foundry.abstract.DataModel {
                 choices: ["permanent", "temporary", "misc", "condition"]
             }),
             condition: new fields.StringField({ initial: "", required: false }),
-            container: new fields.SchemaField(
-                {
-                    actorUuid: new fields.StringField({ initial: null, required: true, nullable: true }),
-                    itemUuid: new fields.StringField({ initial: null, required: false, nullable: true }),
-                    tokenUuid: new fields.StringField({ initial: null, required: false, nullable: true })
-                },
-                { nullable: true, required: false }
-            ),
             damage: new fields.SchemaField(
                 {
                     damageGroup: new fields.NumberField({
@@ -182,19 +174,15 @@ export default class SFRPGModifier extends foundry.abstract.DataModel {
     }
 
     get actor() {
-        return fromUuidSync(this.container.actorUuid);
+        return this.parent instanceof ActorSFRPG ? this.parent : this.parent.actor;
     }
 
     get item() {
-        return fromUuidSync(this.container.itemUuid);
+        return this.parent instanceof ItemSFRPG ? this.parent : null;
     }
 
     get token() {
-        return fromUuidSync(this.container.tokenUuid);
-    }
-
-    get primaryOwner() {
-        return this.item || this.actor;
+        return this.actor.isToken ? this.actor.token : this.actor.getActiveTokens(true, true);
     }
 
     get hasDamageSection() {
@@ -203,5 +191,15 @@ export default class SFRPGModifier extends foundry.abstract.DataModel {
 
     static _hasDamageSection(obj) {
         return (obj.damage && Object.values(obj.damage.damageTypes).some(type => !!type)) || false;
+    }
+
+    async toggle(active = null) {
+        const parentMods = this.parent.system.modifiers;
+
+        const modInParent = parentMods.find(mod => mod._id === this._id);
+        modInParent.updateSource({enabled: active ?? !modInParent.enabled});
+
+        return this.parent.update({"system.modifiers": parentMods});
+
     }
 }

--- a/src/module/rules/closures/stack-modifiers.js
+++ b/src/module/rules/closures/stack-modifiers.js
@@ -35,7 +35,7 @@ export default class StackModifiers extends Closure {
                         modifier.max = 0;
                     }
                 } catch (error) {
-                    console.warn(`Could not calculate modifier: ${modifier.name} for actor with ID: ${modifier.container.actorUuid}. Setting to zero. ${error}`);
+                    console.warn(`Could not calculate modifier: ${modifier.name} for actor: ${modifier.actor.name}. Setting to zero. ${error}`);
                     modifier.max = 0;
                 }
             } else {


### PR DESCRIPTION
- Add a `toggle` method to `SFRPGModifier`
- Remove `container` in favour of passing the owning actor/item to the DataModel constructor, simplifying accessing them, and allowing for access to them without data prep
- Always re-calculate `max` during `_initialize`
- Remove active tab transition to eliminate flickering