### PR TITLE
Roll Deprecated (Fix for IsRoll and DiceSoNice integration)

### DIFF
--- a/src/module/actor/actor.js
+++ b/src/module/actor/actor.js
@@ -919,7 +919,7 @@ export class ActorSFRPG extends Mix(Actor).with(ActorConditionsMixin, ActorCrewM
             speaker: ChatMessage.getSpeaker({ actor: speakerActor }),
             content: rollContent,
             rollMode: rollMode,
-            roll: rollResult.roll,
+            rolls: [rollResult.roll],
             type: CONST.CHAT_MESSAGE_STYLES.ROLL,
             sound: CONFIG.sounds.dice
         });

--- a/src/module/chat/chatbox.js
+++ b/src/module/chat/chatbox.js
@@ -129,7 +129,7 @@ export default class SFRPGCustomChatMessage {
             speaker: data.speaker,
             content: cardContent, // + explainedRollContent + (options.additionalContent || ""),
             rollMode: rollMode,
-            roll: roll,
+            rolls: [roll],
             type: CONST.CHAT_MESSAGE_STYLES.ROLL,
             sound: CONFIG.sounds.dice,
             rollType: data.rollType,

--- a/src/module/item/item.js
+++ b/src/module/item/item.js
@@ -1561,7 +1561,7 @@ export class ItemSFRPG extends Mix(Item).with(ItemActivationMixin, ItemCapacityM
             chatMessage: options.chatMessage,
             content: content,
             rollMode: game.settings.get("core", "rollMode"),
-            roll: rollResult.roll,
+            rolls: [rollResult.roll],
             type: CONST.CHAT_MESSAGE_STYLES.ROLL,
             sound: CONFIG.sounds.dice
         });
@@ -1685,7 +1685,7 @@ export class ItemSFRPG extends Mix(Item).with(ItemActivationMixin, ItemCapacityM
             flavor: `${this.name} recharge check - ${success ? "success!" : "failure!"}`,
             whisper: (["gmroll", "blindroll"].includes(rollMode)) ? ChatMessage.getWhisperRecipients("GM") : null,
             blind: rollMode === "blindroll",
-            roll: roll,
+            rolls: [roll],
             speaker: ChatMessage.getSpeaker({
                 actor: this.actor,
                 alias: this.actor.name


### PR DESCRIPTION
roll has been deprecated in favor of rolls when doing ChatMessage.Create. When rolls:[] is not used the chat message will not flag itself as a roll when IsRoll is called which can break all kinds of functionality like DiceSoNice knowing there is a dice roll to render.