### PR TITLE
Ignore unhandled drop types.

### DIFF
--- a/src/module/actor/sheet/base.js
+++ b/src/module/actor/sheet/base.js
@@ -1136,13 +1136,12 @@ export class ActorSheetSFRPG extends ActorSheet {
         const parsedDragData = TextEditor.getDragEventData(event);
         if (!parsedDragData) {
             console.log("Unknown item data");
-            return;
+        } else if (parsedDragData.type === 'Item' || parsedDragData.type === 'ItemCollection') {
+            await this.processDroppedItems(event, parsedDragData);
         }
-
-        return this.processDroppedData(event, parsedDragData);
     }
 
-    async processDroppedData(event, parsedDragData) {
+    async processDroppedItems(event, parsedDragData) {
         const targetActor = new ActorItemHelper(this.actor.id, this.token?.id, this.token?.parent?.id, { actor: this.actor });
         if (!ActorItemHelper.IsValidHelper(targetActor)) {
             ui.notifications.warn(game.i18n.format("SFRPG.ActorSheet.Inventory.Interface.DragToExternalTokenError"));

--- a/src/module/actor/sheet/starship.js
+++ b/src/module/actor/sheet/starship.js
@@ -590,7 +590,7 @@ export class ActorSheetSFRPGStarship extends ActorSheetSFRPG {
             if (SFRPG.starshipDefinitionItemTypes.includes(rawItemData.type)) {
                 return this.actor.createEmbeddedDocuments("Item", [rawItemData]);
             } else if (this.acceptedItemTypes.includes(rawItemData.type)) {
-                return this.processDroppedData(event, data);
+                return this.processDroppedItems(event, data);
             } else {
                 ui.notifications.error(game.i18n.format("SFRPG.InvalidStarshipItem", { name: rawItemData.name }));
                 return false;
@@ -616,7 +616,7 @@ export class ActorSheetSFRPGStarship extends ActorSheetSFRPG {
             if (acceptedItems.length > 0) {
                 const acceptedItemData = foundry.utils.deepClone(data);
                 acceptedItemData.items = acceptedItems;
-                await this.processDroppedData(event, data);
+                await this.processDroppedItems(event, data);
             }
 
             if (rejectedItems.length > 0) {

--- a/src/module/actor/sheet/vehicle.js
+++ b/src/module/actor/sheet/vehicle.js
@@ -271,7 +271,7 @@ export class ActorSheetSFRPGVehicle extends ActorSheetSFRPG {
             const rawItemData = (await Item.fromDropData(data)).toObject();
 
             if (rawItemData.type === "weapon" || rawItemData.type === "vehicleAttack") {
-                return this.processDroppedData(event, data);
+                return this.processDroppedItems(event, data);
             } else if (rawItemData.type === "starshipExpansionBay" || rawItemData.type === "vehicleSystem" || rawItemData.type === "actorResource") {
                 return this.actor.createEmbeddedDocuments("Item", [rawItemData]);
             }

--- a/src/module/canvas/canvas.js
+++ b/src/module/canvas/canvas.js
@@ -193,7 +193,7 @@ export function canvasHandler(canvas, data) {
             const target = new ActorItemHelper(targetActor.id, tokenId, sceneId);
 
             // Simulate a drop to the sheet
-            targetActor.sheet.processDroppedData({ preventDefault() {} }, data);
+            targetActor.sheet.processDroppedItems({ preventDefault() {} }, data);
             const sourceItem = fromUuidSync(data.uuid);
             if (sourceItem.type !== "effect") {
                 const tokens = target?.token || targetActor.getActiveTokens(true);


### PR DESCRIPTION
Allows other data types (such as `JournalEntry`) to pass through the drop hook without causing an exception.

Closes #1394