### PR TITLE
migrate `{{#select}}` to `{{selectOptions}}`

### DIFF
--- a/src/module/apps/movement-config.js
+++ b/src/module/apps/movement-config.js
@@ -25,9 +25,9 @@ export class ActorMovementConfig extends DocumentSheet {
 
     /** @override */
     getData(options) {
-        const sourceMovement = foundry.utils.getProperty(this.document._source, "system.attributes.speed") || {};
-        const data = {
-            speed: foundry.utils.deepClone(sourceMovement)
+        this.document.config = {
+            speeds: CONFIG.SFRPG.speeds,
+            flightManeuverability: CONFIG.SFRPG.flightManeuverability
         };
         return this.document;
     }

--- a/src/module/config.js
+++ b/src/module/config.js
@@ -426,6 +426,13 @@ SFRPG.skills = {
     "sur": "SFRPG.SkillSur"
 };
 
+SFRPG.controlSkills = {
+    "pil": "SFRPG.SkillPil",
+    "ath": "SFRPG.SkillAth",
+    "sur": "SFRPG.SkillSur",
+    "none": "SFRPG.None"
+};
+
 // Weapon Types
 SFRPG.weaponTypes = {
     "basicM": "SFRPG.WeaponTypesBasicMelee",
@@ -1958,6 +1965,12 @@ SFRPG.droneBadSaveBonusPerLevel = [0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 
 SFRPG.droneFeatsPerLevel = [1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 5, 5, 5, 6, 6, 6, 7, 7, 8, 8];
 SFRPG.droneModsPerLevel = [1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10];
 SFRPG.droneAbilityScoreIncreaseLevels = [4, 7, 10, 13, 16, 19];
+
+SFRPG.droneArmTypes = {
+    "general": "SFRPG.DroneSheet.Mod.Details.Arms.ArmType.General",
+    "melee": "SFRPG.DroneSheet.Mod.Details.Arms.ArmType.Melee",
+    "ranged": "SFRPG.DroneSheet.Mod.Details.Arms.ArmType.Ranged"
+};
 
 SFRPG.capacityUsagePer = {
     "action": "SFRPG.Capacity.UsagePer.Action",

--- a/src/module/handlebars.js
+++ b/src/module/handlebars.js
@@ -166,14 +166,15 @@ export function setupHandlebars() {
         return false;
     });
 
-    Handlebars.registerHelper('console', function(value) {
-        console.log(value);
+    Handlebars.registerHelper('console', function(...args) {
+        let options = args.pop();
+        console.log(...args);
     });
 
-    Handlebars.registerHelper('indexOf', function(array, value, zeroBased = true) {
+    Handlebars.registerHelper('indexOf', function(array, value, options) {
         const index = array.indexOf(value);
         if (index < 0) return index;
-        return index + (zeroBased ? 0 : 1);
+        return index + (Number(options.hash.firstIdx) || 0);
     });
 
     Handlebars.registerHelper('append', function(left, right) {
@@ -259,4 +260,22 @@ export function setupHandlebars() {
         return formattedValue;
     });
 
+    /**
+     * An API-similar supplement to Foundry's {@linkcode https://foundryvtt.com/api/classes/client.HandlebarsHelpers.html#selectOptions|selectOptions}.
+     * This helper is for adding one-off select options and is meant to be used alongside `selectOptions`.
+     */
+    Handlebars.registerHelper('selectOption', function(value, label, options) {
+        let tagParams = [
+            `value="${Handlebars.escapeExpression(value)}"`,
+            options.hash.hidden && 'hidden',
+            (value === options.hash.selected) && 'selected',
+        ].filter(Boolean).join(' ');
+        let safeLabel = Handlebars.escapeExpression(options.hash.localize? game.i18n.localize(label): label);
+        return new Handlebars.SafeString(`<option ${tagParams}>${safeLabel}</option>`);
+    });
+
+    /** Utility helper to get global config when it's not provided to the template */
+    Handlebars.registerHelper('config', function(key, options) {
+        return foundry.utils.getProperty(CONFIG.SFRPG, key);
+    });
 }

--- a/src/module/handlebars.js
+++ b/src/module/handlebars.js
@@ -273,9 +273,4 @@ export function setupHandlebars() {
         const safeLabel = Handlebars.escapeExpression(options.hash.localize? game.i18n.localize(label): label);
         return new Handlebars.SafeString(`<option ${tagParams}>${safeLabel}</option>`);
     });
-
-    /** Utility helper to get global config when it's not provided to the template */
-    Handlebars.registerHelper('config', function(key, options) {
-        return foundry.utils.getProperty(CONFIG.SFRPG, key);
-    });
 }

--- a/src/module/handlebars.js
+++ b/src/module/handlebars.js
@@ -265,12 +265,12 @@ export function setupHandlebars() {
      * This helper is for adding one-off select options and is meant to be used alongside `selectOptions`.
      */
     Handlebars.registerHelper('selectOption', function(value, label, options) {
-        let tagParams = [
+        const tagParams = [
             `value="${Handlebars.escapeExpression(value)}"`,
             options.hash.hidden && 'hidden',
             (value === options.hash.selected) && 'selected',
         ].filter(Boolean).join(' ');
-        let safeLabel = Handlebars.escapeExpression(options.hash.localize? game.i18n.localize(label): label);
+        const safeLabel = Handlebars.escapeExpression(options.hash.localize? game.i18n.localize(label): label);
         return new Handlebars.SafeString(`<option ${tagParams}>${safeLabel}</option>`);
     });
 

--- a/src/module/packs/document-browser.js
+++ b/src/module/packs/document-browser.js
@@ -211,9 +211,9 @@ export class DocumentBrowserSFRPG extends Application {
         }
 
         const data = {};
-        data.defaultSortMethod = this.getDefaultSortMethod();
         data.tags = this.getTags();
         data.items = this.items;
+        data.sortingMethod = this.getDefaultSortMethod();
         data.sortingMethods = this.sortingMethods;
         data.filters = this.filters;
         return data;
@@ -227,7 +227,6 @@ export class DocumentBrowserSFRPG extends Application {
         const sortingMethods = {
             name: {
                 name: game.i18n.format("SFRPG.Browsers.ItemBrowser.BrowserSortMethodName"),
-                selected: true,
                 method: this._sortByName
             }
         };

--- a/src/sfrpg.js
+++ b/src/sfrpg.js
@@ -420,6 +420,7 @@ Hooks.once("i18nInit", () => {
         "senses",
         "skillProficiencyLevels",
         "skills",
+        "controlSkills",
         "specialAbilityTypes",
         "specialMaterials",
         "speeds",
@@ -437,6 +438,7 @@ Hooks.once("i18nInit", () => {
         "starshipWeaponRanges",
         "starshipWeaponTypes",
         "turnEventTypes",
+        "droneArmTypes",
         "vehicleCoverTypes",
         "vehicleSizes",
         "vehicleTypes",
@@ -446,6 +448,7 @@ Hooks.once("i18nInit", () => {
         "weaponProficiencies",
         "weaponProperties",
         "weaponPropertiesTooltips",
+        "weaponAccessoriesSupportedTypes",
         "weaponTypes"
     ];
 

--- a/src/templates/actors/parts/actor-spellbook.hbs
+++ b/src/templates/actors/parts/actor-spellbook.hbs
@@ -2,12 +2,8 @@
     <div class="form-group spellcasting-ability">
         <label><h4 class="attribute-name box-title">{{localize "SFRPG.SpellBook.SpellCastingAbility"}}</h4></label>
         <select name="system.attributes.spellcasting" data-type="String">
-            {{#select system.attributes.spellcasting}}
-            <option value="">{{localize "SFRPG.SpellBook.AttributesNone"}}</option>
-            {{#each system.abilities as |abl a|}}
-            <option value="{{a}}">{{abl.label}}</option>
-            {{/each}}
-            {{/select}}
+            {{selectOption "" "SFRPG.SpellBook.AttributesNone" selected=system.attributes.spellcasting localize=true}}
+            {{selectOptions (config "abilities") selected=system.attributes.spellcasting}}
         </select>
     </div>
 </div>

--- a/src/templates/actors/parts/actor-spellbook.hbs
+++ b/src/templates/actors/parts/actor-spellbook.hbs
@@ -3,7 +3,7 @@
         <label><h4 class="attribute-name box-title">{{localize "SFRPG.SpellBook.SpellCastingAbility"}}</h4></label>
         <select name="system.attributes.spellcasting" data-type="String">
             {{selectOption "" "SFRPG.SpellBook.AttributesNone" selected=system.attributes.spellcasting localize=true}}
-            {{selectOptions (config "abilities") selected=system.attributes.spellcasting}}
+            {{selectOptions config.abilities selected=system.attributes.spellcasting}}
         </select>
     </div>
 </div>

--- a/src/templates/actors/parts/actor-traits.hbs
+++ b/src/templates/actors/parts/actor-traits.hbs
@@ -3,12 +3,8 @@
         <div class="form-group">
         <label>{{localize "SFRPG.CombatRoles.Label"}}</label>
         <select class="npc-combat-role" name="system.details.combatRole">
-            {{#select system.details.combatRole}}
-                <option value=""></option>
-            {{#each config.combatRoles as |label role|}}
-                <option value="{{role}}">{{label}}</option>
-            {{/each}}
-            {{/select}}
+            {{selectOption "" "" selected=system.details.combatRole}}
+            {{selectOptions config.combatRoles selected=system.details.combatRole}}
         </select>
     </div>
     {{/if}}
@@ -16,11 +12,7 @@
         <label>{{localize "SFRPG.Size"}}</label>
         {{#if (not isDrone)}}
         <select class="actor-size" name="system.traits.size">
-            {{#select system.traits.size}}
-            {{#each config.actorSizes as |label size|}}
-                <option value="{{size}}">{{label}}</option>
-            {{/each}}
-            {{/select}}
+            {{selectOptions config.actorSizes selected=system.traits.size}}
         </select>
         {{else}}
         <span class="value">{{system.traits.size}}</span>
@@ -31,12 +23,8 @@
     <div class="form-group" data-tooltip="<strong>{{localize "SFRPG.KeyAbility"}}</strong><br/>@system.attributes.keyability">
         <label>{{localize "SFRPG.KeyAbility"}}</label>
         <select class="actor-keyability" name="system.attributes.keyability">
-            {{#select system.attributes.keyability}}
-            <option value="">Choose One</option>
-            {{#each config.abilities as |label abl|}}
-                <option value="{{abl}}">{{label}}</option>
-            {{/each}}
-            {{/select}}
+            {{selectOption "" "Choose One" selected=system.attributes.keyability}}
+            {{selectOptions config.abilities selected=system.attributes.keyability}}
         </select>
     </div>
     {{/if}}

--- a/src/templates/actors/starship-sheet-full.hbs
+++ b/src/templates/actors/starship-sheet-full.hbs
@@ -396,41 +396,25 @@
                         <div class="form-group">
                             <label for="system.attributes.systems.lifeSupport.value">{{localize "SFRPG.StarshipSheet.Critical.Systems.LifeSupport"}} <a class="critical-edit" data-system="lifeSupport" title="{{localize "SFRPG.StarshipSheet.Critical.Edit"}}"><i class="fas fa-edit"></i></a></label>
                             <select name="system.attributes.systems.lifeSupport.value">
-                                {{#select system.attributes.systems.lifeSupport.value}}
-                                {{#each config.starshipSystemStatus as |status statusKey|}}
-                                <option value="{{statusKey}}">{{status}}</option>
-                                {{/each}}
-                                {{/select}}
+                                {{selectOptions config.starshipSystemStatus selected=system.attributes.systems.lifeSupport.value}}
                             </select>
                         </div>
                         <div class="form-group">
                             <label for="system.attributes.systems.sensors.value">{{localize "SFRPG.StarshipSheet.Critical.Systems.Sensors"}} <a class="critical-edit" data-system="sensors" title="{{localize "SFRPG.StarshipSheet.Critical.Edit"}}"><i class="fas fa-edit"></i></a></label>
                             <select name="system.attributes.systems.sensors.value">
-                                {{#select system.attributes.systems.sensors.value}}
-                                {{#each config.starshipSystemStatus as |status statusKey|}}
-                                <option value="{{statusKey}}">{{status}}</option>
-                                {{/each}}
-                                {{/select}}
+                                {{selectOptions config.starshipSystemStatus selected=system.attributes.systems.sensors.value}}
                             </select>
                         </div>
                         <div class="form-group">
                             <label for="system.attributes.systems.engines.value">{{localize "SFRPG.StarshipSheet.Critical.Systems.Engines"}} <a class="critical-edit" data-system="engines" title="{{localize "SFRPG.StarshipSheet.Critical.Edit"}}"><i class="fas fa-edit"></i></a></label>
                             <select name="system.attributes.systems.engines.value">
-                                {{#select system.attributes.systems.engines.value}}
-                                {{#each config.starshipSystemStatus as |status statusKey|}}
-                                <option value="{{statusKey}}">{{status}}</option>
-                                {{/each}}
-                                {{/select}}
+                                {{selectOptions config.starshipSystemStatus selected=system.attributes.systems.engines.value}}
                             </select>
                         </div>
                         <div class="form-group">
                             <label for="system.attributes.systems.powerCore.value">{{localize "SFRPG.StarshipSheet.Critical.Systems.PowerCore"}} <a class="critical-edit" data-system="powerCore" title="{{localize "SFRPG.StarshipSheet.Critical.Edit"}}"><i class="fas fa-edit"></i></a></label>
                             <select name="system.attributes.systems.powerCore.value">
-                                {{#select system.attributes.systems.powerCore.value}}
-                                {{#each config.starshipSystemStatus as |status statusKey|}}
-                                <option value="{{statusKey}}">{{status}}</option>
-                                {{/each}}
-                                {{/select}}
+                                {{selectOptions config.starshipSystemStatus selected=system.attributes.systems.powerCore.value}}
                             </select>
                         </div>
                     </div>
@@ -438,41 +422,25 @@
                         <div class="form-group">
                             <label for="system.attributes.systems.weaponsArrayForward.value">{{localize "SFRPG.StarshipSheet.Critical.Systems.WeaponsArrayForward"}} <a class="critical-edit" data-system="weaponsArrayForward" title="{{localize "SFRPG.StarshipSheet.Critical.Edit"}}"><i class="fas fa-edit"></i></a></label>
                             <select name="system.attributes.systems.weaponsArrayForward.value">
-                                {{#select system.attributes.systems.weaponsArrayForward.value}}
-                                {{#each config.starshipSystemStatus as |status statusKey|}}
-                                <option value="{{statusKey}}">{{status}}</option>
-                                {{/each}}
-                                {{/select}}
+                                {{selectOptions config.starshipSystemStatus selected=system.attributes.systems.weaponsArrayForward.value}}
                             </select>
                         </div>
                         <div class="form-group">
                             <label for="system.attributes.systems.weaponsArrayPort.value">{{localize "SFRPG.StarshipSheet.Critical.Systems.WeaponsArrayPort"}} <a class="critical-edit" data-system="weaponsArrayPort" title="{{localize "SFRPG.StarshipSheet.Critical.Edit"}}"><i class="fas fa-edit"></i></a></label>
                             <select name="system.attributes.systems.weaponsArrayPort.value">
-                                {{#select system.attributes.systems.weaponsArrayPort.value}}
-                                {{#each config.starshipSystemStatus as |status statusKey|}}
-                                <option value="{{statusKey}}">{{status}}</option>
-                                {{/each}}
-                                {{/select}}
+                                {{selectOptions config.starshipSystemStatus selected=system.attributes.systems.weaponsArrayPort.value}}
                             </select>
                         </div>
                         <div class="form-group">
                             <label for="system.attributes.systems.weaponsArrayStarboard.value">{{localize "SFRPG.StarshipSheet.Critical.Systems.WeaponsArrayStarboard"}} <a class="critical-edit" data-system="weaponsArrayStarboard" title="{{localize "SFRPG.StarshipSheet.Critical.Edit"}}"><i class="fas fa-edit"></i></a></label>
                             <select name="system.attributes.systems.weaponsArrayStarboard.value">
-                                {{#select system.attributes.systems.weaponsArrayStarboard.value}}
-                                {{#each config.starshipSystemStatus as |status statusKey|}}
-                                <option value="{{statusKey}}">{{status}}</option>
-                                {{/each}}
-                                {{/select}}
+                                {{selectOptions config.starshipSystemStatus selected=system.attributes.systems.weaponsArrayStarboard.value}}
                             </select>
                         </div>
                         <div class="form-group">
                             <label for="system.attributes.systems.weaponsArrayAft.value">{{localize "SFRPG.StarshipSheet.Critical.Systems.WeaponsArrayAft"}} <a class="critical-edit" data-system="WeaponsArrayAft" title="{{localize "SFRPG.StarshipSheet.Critical.Edit"}}"><i class="fas fa-edit"></i></a></label>
                             <select name="system.attributes.systems.weaponsArrayAft.value">
-                                {{#select system.attributes.systems.weaponsArrayAft.value}}
-                                {{#each config.starshipSystemStatus as |status statusKey|}}
-                                <option value="{{statusKey}}">{{status}}</option>
-                                {{/each}}
-                                {{/select}}
+                                {{selectOptions config.starshipSystemStatus selected=system.attributes.systems.weaponsArrayAft.value}}
                             </select>
                         </div>
                     </div>

--- a/src/templates/actors/vehicle-sheet-full.hbs
+++ b/src/templates/actors/vehicle-sheet-full.hbs
@@ -143,12 +143,7 @@
                             <label>Control</label>
                             <div class="form-fields">
                                 <select name="system.attributes.controlSkill">
-                                    {{#select system.attributes.controlSkill}}
-                                    <option value="pil">{{ config.skills.pil }}</option>
-                                    <option value="ath">{{ config.skills.ath }}</option>
-                                    <option value="sur">{{ config.skills.sur }}</option>
-                                    <option value="none">None</option>
-                                    {{/select}}
+                                    {{selectOptions (config "controlSkills") selected=system.attributes.controlSkill}}
                                 </select>
                                 {{#if (eq system.attributes.controlSkill "pil")}}
                                 <input type="text" name="system.attributes.modifiers.piloting" value="{{system.attributes.modifiers.piloting}}" />
@@ -195,11 +190,7 @@
                             <label>{{ localize "SFRPG.VehicleSheet.Details.OtherAttributes.Size" }}</label>
                             <div class="form-fields">
                                 <select name="system.attributes.size">
-                                    {{#select system.attributes.size}}
-                                    {{#each config.vehicleSizes as |size s|}}
-                                    <option value="{{s}}">{{size}}</option>
-                                    {{/each}}
-                                    {{/select}}
+                                    {{selectOptions config.vehicleSizes selected=system.attributes.size}}
                                 </select>
                             </div>
                         </div>
@@ -207,11 +198,7 @@
                             <label>{{ localize "SFRPG.VehicleSheet.Details.OtherAttributes.Type" }}</label>
                             <div class="form-fields">
                                 <select name="system.attributes.type">
-                                    {{#select system.attributes.type}}
-                                    {{#each config.vehicleTypes as |type t|}}
-                                    <option value="{{t}}">{{type}}</option>
-                                    {{/each}}
-                                    {{/select}}
+                                    {{selectOptions config.vehicleTypes selected=system.attributes.type}}
                                 </select>
                             </div>
                         </div>
@@ -219,11 +206,7 @@
                             <label>{{ localize "SFRPG.VehicleSheet.Details.OtherAttributes.Cover" }}</label>
                             <div class="form-fields">
                                 <select name="system.attributes.cover">
-                                    {{#select system.attributes.cover}}
-                                    {{#each config.vehicleCoverTypes as |cover c|}}
-                                    <option value="{{c}}">{{cover}}</option>
-                                    {{/each}}
-                                    {{/select}}
+                                    {{selectOptions config.vehicleCoverTypes selected=system.attributes.cover}}
                                 </select>
                             </div>
                         </div>

--- a/src/templates/actors/vehicle-sheet-full.hbs
+++ b/src/templates/actors/vehicle-sheet-full.hbs
@@ -143,7 +143,7 @@
                             <label>Control</label>
                             <div class="form-fields">
                                 <select name="system.attributes.controlSkill">
-                                    {{selectOptions (config "controlSkills") selected=system.attributes.controlSkill}}
+                                    {{selectOptions config.controlSkills selected=system.attributes.controlSkill}}
                                 </select>
                                 {{#if (eq system.attributes.controlSkill "pil")}}
                                 <input type="text" name="system.attributes.modifiers.piloting" value="{{system.attributes.modifiers.piloting}}" />

--- a/src/templates/apps/actor-flags.hbs
+++ b/src/templates/apps/actor-flags.hbs
@@ -1,5 +1,5 @@
 <form class="{{cssClass}}" autocomplete="off">
-	<p class="notes">{{localize 'SFRPG.FlagsInstructions'}}</p>
+    <p class="notes">{{localize 'SFRPG.FlagsInstructions'}}</p>
 
     {{#each flags as |fs section|}}
     <h3 class="form-header noborder">{{localize section}}</h3>
@@ -13,11 +13,7 @@
 
         {{else if flag.isSelect}}
         <select name="{{key}}" data-dtype="{{flag.type}}">
-            {{#select flag.value}}
-            {{#each flag.choices as |v k|}}
-            <option value="{{k}}">{{localize v}}</option>
-            {{/each}}
-            {{/select}}
+            {{selectOptions flag.choices selected=flag.value localize=true}}
         </select>
 
         {{else}}

--- a/src/templates/apps/add-edit-skill.hbs
+++ b/src/templates/apps/add-edit-skill.hbs
@@ -3,11 +3,7 @@
         <label>{{localize "SFRPG.ModifierTypeAbility"}}</label>
         <div class="form-fields">
             <select name="ability">
-                {{#select skill.ability}}
-                {{#each config.abilities as |ability a|}}
-                <option value="{{a}}">{{ability}}</option>
-                {{/each}}
-                {{/select}}
+                {{selectOptions config.abilities selected=skill.ability}}
             </select>
         </div>
     </div>

--- a/src/templates/apps/choice-dialog.hbs
+++ b/src/templates/apps/choice-dialog.hbs
@@ -5,12 +5,8 @@
         <label>{{capitalize choice.name}}{{#if choice.label}}: {{choice.label}}{{/if}}</label>
         <div class="form-fields">
             <select id="{{id}}">
-                {{#select choice.default}}
-                {{#each choice.options as |choice|}}
-                    <option value="{{choice}}">{{localize choice}}</option>
-                {{/each}}
-                {{/select}}
-            </select>    
+                {{selectOptions choice.options selected=choice.default localize=true}}
+            </select>
         </div>
     </div>
     {{/each}}

--- a/src/templates/apps/modifier-app.hbs
+++ b/src/templates/apps/modifier-app.hbs
@@ -10,21 +10,13 @@
     <div class="form-group modifier-type">
         <label for="type">{{localize "SFRPG.ModifierTypeLabel"}}</label>
         <select name="type" data-tooltip="{{localize "SFRPG.ModifierTypeTooltip"}}">
-            {{#select modifier.type}}
-                {{#each config.modifierTypes as |type key|}}
-                    <option value="{{key}}">{{type}}</option>
-                {{/each}}
-            {{/select}}
+            {{selectOptions config.modifierTypes selected=modifier.type}}
         </select>
     </div>
     <div class="form-group modifier-effect-type">
         <label for="effectType">{{localize "SFRPG.ModifierEffectTypeLabel"}}</label>
         <select name="effectType" data-tooltip="{{localize "SFRPG.ModifierEffectTypeTooltip"}}">
-            {{#select modifier.effectType}}
-                {{#each config.modifierEffectTypes as |effect key|}}
-                    <option value="{{key}}">{{effect}}</option>
-                {{/each}}
-            {{/select}}
+            {{selectOptions config.modifierEffectTypes selected=modifier.effectType}}
         </select>
     </div>
     <div class="form-group modifier-value-affected">
@@ -33,104 +25,62 @@
             <input type="text" name="valueAffected" value="{{modifier.valueAffected}}" data-tooltip="{{localize "SFRPG.ModifierValueAffectedTooltip"}}">
         {{else}}
             <select name="valueAffected" data-tooltip="{{localize "SFRPG.ModifierValueAffectedTooltip"}}">
-                {{#select modifier.valueAffected}}
-                    {{#if (eq modifier.effectType "ac")}}
-                        {{#each config.modifierArmorClassAffectedValues as |armorClass key|}}
-                            <option value="{{key}}">{{armorClass}}</option>
-                        {{/each}}
-                    {{else if (eq modifier.effectType "ability-skills")}}
-                        {{#each config.abilities as |ability abl|}}
-                            <option value="{{abl}}">{{ability}}</option>
-                        {{/each}}
-                    {{else if (eq modifier.effectType "acp")}}
-                        {{#each config.acpEffectingArmorType as |armorType key|}}
-                            <option value="{{key}}">{{armorType}}</option>
-                        {{/each}}
-                    {{else if (eq modifier.effectType "save")}}
-                        <option value="highest">{{localize "SFRPG.ModifierSaveHighest"}}</option>
-                        <option value="lowest">{{localize "SFRPG.ModifierSaveLowest"}}</option>
-                        {{#each config.saves as |save key|}}
-                            <option value="{{key}}">{{save}}</option>
-                        {{/each}}
-                    {{else if (eq modifier.effectType "skill")}}
-                        <option value="">-</option>
-                        {{#each config.skills as |skill key|}}
-                            <option value="{{key}}">{{skill}}</option>
-                        {{/each}}
-                    {{else if (eq modifier.effectType "skill-ranks")}}
-                        {{#each config.skills as |skill key|}}
-                            <option value="{{key}}">{{skill}}</option>
-                        {{/each}}
-                    {{else if (eq modifier.effectType "ability-check")}}
-                        {{#each config.abilities as |ability abl|}}
-                            <option value="{{abl}}">{{ability}}</option>
-                        {{/each}}
-                    {{else if (eq modifier.effectType "ability-score")}}
-                        {{#each config.abilities as |ability abl|}}
-                            <option value="{{abl}}">{{ability}}</option>
-                        {{/each}}
-                    {{else if (eq modifier.effectType "weapon-attacks")}}
-                        {{#each config.weaponTypes as |name key|}}
-                            <option value="{{key}}">{{name}}</option>
-                        {{/each}}
-                    {{else if (eq modifier.effectType "weapon-property-attacks")}}
-                        {{#each config.weaponProperties as |name key|}}
-                            <option value="{{key}}">{{name}}</option>
-                        {{/each}}
-                    {{else if (eq modifier.effectType "weapon-category-attacks")}}
-                        {{#each config.weaponCategories as |name key|}}
-                            <option value="{{key}}">{{name}}</option>
-                        {{/each}}
-                    {{else if (eq modifier.effectType "weapon-damage")}}
-                        {{#each config.weaponTypes as |name key|}}
-                            <option value="{{key}}">{{name}}</option>
-                        {{/each}}
-                    {{else if (eq modifier.effectType "weapon-property-damage")}}
-                        {{#each config.weaponProperties as |name key|}}
-                            <option value="{{key}}">{{name}}</option>
-                        {{/each}}
-                    {{else if (eq modifier.effectType "weapon-category-damage")}}
-                        {{#each config.weaponCategories as |name key|}}
-                            <option value="{{key}}">{{name}}</option>
-                        {{/each}}
-                    {{else if (eq modifier.effectType "specific-speed")}}
-                        {{#each config.speeds as |speed key|}}
-                            <option value="{{key}}">{{speed}}</option>
-                        {{/each}}
-                    {{else if (eq modifier.effectType "damage-reduction")}}
-                        {{#each config.damageReductionTypes as |name key|}}
-                            <option value="{{key}}">{{name}}</option>
-                        {{/each}}
-                    {{else if (eq modifier.effectType "energy-resistance")}}
-                        {{#each config.energyResistanceTypes as |name key|}}
-                            <option value="{{key}}">{{name}}</option>
-                        {{/each}}
-                    {{else}}
-                        <option value=""></option>
-                    {{/if}}
-                {{/select}}
+                {{#if (eq modifier.effectType "ac")}}
+                    {{selectOptions config.modifierArmorClassAffectedValues selected=modifier.valueAffected}}
+                {{else if (eq modifier.effectType "ability-skills")}}
+                    {{selectOptions config.abilities selected=modifier.valueAffected}}
+                {{else if (eq modifier.effectType "acp")}}
+                    {{selectOptions config.acpEffectingArmorType selected=modifier.valueAffected}}
+                {{else if (eq modifier.effectType "save")}}
+                    {{selectOption "highest" "SFRPG.ModifierSaveHighest" selected=modifier.valueAffected localize=true}}
+                    {{selectOption "lowest" "SFRPG.ModifierSaveLowest" selected=modifier.valueAffected localize=true}}
+                    {{selectOptions config.saves selected=modifier.valueAffected}}
+                {{else if (eq modifier.effectType "skill")}}
+                    {{selectOption "" "-" selected=modifier.valueAffected}}
+                    {{selectOptions config.skills selected=modifier.valueAffected}}
+                {{else if (eq modifier.effectType "skill-ranks")}}
+                    {{selectOptions config.skills selected=modifier.valueAffected}}
+                {{else if (eq modifier.effectType "ability-check")}}
+                    {{selectOptions config.abilities selected=modifier.valueAffected}}
+                {{else if (eq modifier.effectType "ability-score")}}
+                    {{selectOptions config.abilities selected=modifier.valueAffected}}
+                {{else if (eq modifier.effectType "weapon-attacks")}}
+                    {{selectOptions config.weaponTypes selected=modifier.valueAffected}}
+                {{else if (eq modifier.effectType "weapon-property-attacks")}}
+                    {{selectOptions config.weaponProperties selected=modifier.valueAffected}}
+                {{else if (eq modifier.effectType "weapon-category-attacks")}}
+                    {{selectOptions config.weaponCategories selected=modifier.valueAffected}}
+                {{else if (eq modifier.effectType "weapon-damage")}}
+                    {{selectOptions config.weaponTypes selected=modifier.valueAffected}}
+                {{else if (eq modifier.effectType "weapon-property-damage")}}
+                    {{selectOptions config.weaponProperties selected=modifier.valueAffected}}
+                {{else if (eq modifier.effectType "weapon-category-damage")}}
+                    {{selectOptions config.weaponCategories selected=modifier.valueAffected}}
+                {{else if (eq modifier.effectType "specific-speed")}}
+                    {{selectOptions config.speeds selected=modifier.valueAffected}}
+                {{else if (eq modifier.effectType "damage-reduction")}}
+                    {{selectOptions config.damageReductionTypes selected=modifier.valueAffected}}
+                {{else if (eq modifier.effectType "energy-resistance")}}
+                    {{selectOptions config.energyResistanceTypes selected=modifier.valueAffected}}
+                {{else}}
+                    <option value=""></option>
+                {{/if}}
             </select>
         {{/if}}
     </div>
     <fieldset class="form-group modifier-limit-to" disabled=true>
         <label for="limitTo">{{localize "SFRPG.ModifierLimitToLabel"}}</label>
         <select name="limitTo" data-tooltip="{{localize "SFRPG.ModifierLimitToTooltip"}}">
-            {{#select modifier.limitTo}}
-                <option value="">{{localize "SFRPG.None"}}</option>
-                <option value="parent">{{localize "SFRPG.ModifierLimitToParent"}}</option>
-                <option value="container">{{localize "SFRPG.ModifierLimitToContainer"}}</option>
-            {{/select}}
+            {{selectOption ""          "SFRPG.None"                     selected=modifier.limitTo localize=true}}
+            {{selectOption "parent"    "SFRPG.ModifierLimitToParent"    selected=modifier.limitTo localize=true}}
+            {{selectOption "container" "SFRPG.ModifierLimitToContainer" selected=modifier.limitTo localize=true}}
         </select>
     </fieldset>
     <div class="form-group modifier-modifier-type">
         <label for="modifierType">{{localize "SFRPG.ModifierModifierTypeLabel"}}</label>
         <select name="modifierType" data-tooltip="{{localize "SFRPG.ModifierModifierTypeTooltip"}}">
-            {{#select modifier.modifierType}}
-                {{#each config.modifierType as |type key|}}
-                    <option value="{{key}}">{{type}}</option>
-                {{/each}}
-                    <option value="damageSection" style="display: none">{{localize "SFRPG.Items.Action.DamageSection" section=''}}</option>
-            {{/select}}
+            {{selectOptions config.modifierType selected=modifier.modifierType}}
+            {{selectOption "damageSection" (localize "SFRPG.Items.Action.DamageSection" section='') selected=modifier.modifierType hidden=true}}
         </select>
     </div>
     <fieldset class="damage-section-details" disabled=true>

--- a/src/templates/apps/movement-config.hbs
+++ b/src/templates/apps/movement-config.hbs
@@ -23,11 +23,7 @@
         <div class="form-fields">
             <input name="system.attributes.speed.flying.base" type="number" step="0.1" value="{{system.attributes.speed.flying.base}}"/>
             <select name="system.attributes.speed.flying.baseManeuverability">
-                {{#select system.attributes.speed.flying.baseManeuverability}}
-                <option value="-1">{{ localize "SFRPG.ActorSheet.Attributes.Speed.Flight.Clumsy" }}</option>
-                <option value="0">{{ localize "SFRPG.ActorSheet.Attributes.Speed.Flight.Average" }}</option>
-                <option value="1">{{ localize "SFRPG.ActorSheet.Attributes.Speed.Flight.Perfect" }}</option>
-                {{/select}}
+                {{selectOptions (config "flightManeuverability") selected=system.attributes.speed.flying.baseManeuverability}}
             </select>
         </div>
     </div>
@@ -47,14 +43,7 @@
         <label>{{ localize "SFRPG.ActorSheet.Attributes.Speed.MainMovementType" }}</label>
         <div class="form-fields">
             <select name="system.attributes.speed.mainMovement">
-                {{#select system.attributes.speed.mainMovement}}
-                <option value="land">{{ localize "SFRPG.ActorSheet.Attributes.Speed.Types.Land" }}</option>
-                <option value="burrowing">{{ localize "SFRPG.ActorSheet.Attributes.Speed.Types.Burrowing" }}</option>
-                <option value="climbing">{{ localize "SFRPG.ActorSheet.Attributes.Speed.Types.Climbing" }}</option>
-                <option value="flying">{{ localize "SFRPG.ActorSheet.Attributes.Speed.Types.Flying" }}</option>
-                <option value="swimming">{{ localize "SFRPG.ActorSheet.Attributes.Speed.Types.Swimming" }}</option>
-                <option value="special">{{ localize "SFRPG.ActorSheet.Attributes.Speed.Types.Special" }}</option>
-                {{/select}}
+                {{selectOptions (config "speeds") selected=system.attributes.speed.mainMovement}}
             </select>
         </div>
     </div>

--- a/src/templates/apps/movement-config.hbs
+++ b/src/templates/apps/movement-config.hbs
@@ -23,7 +23,7 @@
         <div class="form-fields">
             <input name="system.attributes.speed.flying.base" type="number" step="0.1" value="{{system.attributes.speed.flying.base}}"/>
             <select name="system.attributes.speed.flying.baseManeuverability">
-                {{selectOptions (config "flightManeuverability") selected=system.attributes.speed.flying.baseManeuverability}}
+                {{selectOptions config.flightManeuverability selected=system.attributes.speed.flying.baseManeuverability}}
             </select>
         </div>
     </div>
@@ -43,7 +43,7 @@
         <label>{{ localize "SFRPG.ActorSheet.Attributes.Speed.MainMovementType" }}</label>
         <div class="form-fields">
             <select name="system.attributes.speed.mainMovement">
-                {{selectOptions (config "speeds") selected=system.attributes.speed.mainMovement}}
+                {{selectOptions config.speeds selected=system.attributes.speed.mainMovement}}
             </select>
         </div>
     </div>

--- a/src/templates/apps/spell-cast.hbs
+++ b/src/templates/apps/spell-cast.hbs
@@ -7,7 +7,7 @@
         <div class="form-fields stacked">
             {{#each item.system.allowedClasses as |isAllowed allowedClass|}}
                 {{#if isAllowed}}
-                    <label class="checkbox"><input type="checkbox" name="" {{checked isAllowed}} disabled /> {{lookup ../config.spellcastingClasses allowedClass}}</label>
+                    <label class="checkbox"><input type="checkbox" name="" {{checked isAllowed}} disabled /> {{lookup (config "spellcastingClasses") allowedClass}}</label>
                 {{/if}}
             {{/each}}
         </div>
@@ -25,15 +25,11 @@
         <label>{{localize "SFRPG.SpellCasting.SelectSpellSlot"}}</label>
         <div class="form-fields">
             <select name="level" {{#unless hasSlots}}disabled{{/unless}}>
-                {{#select item.system.level}}
-                {{#each spellLevels as |spellSlot|}}
-                <option value="{{spellSlot.level}}">{{spellSlot.label}}</option>
-                {{/each}}
-                {{/select}}
+                {{selectOptions spellLevels selected=item.system.level nameAttr="level" labelAttr="label"}}
             </select>
         </div>
     </div>
-    
+
     {{#unless hasSlots}}
     <p type="note" style="color: #c00;">{{localize "SFRPG.SpellCasting.ErrorNoSlot"}}</p>
     {{/unless}}

--- a/src/templates/apps/spell-cast.hbs
+++ b/src/templates/apps/spell-cast.hbs
@@ -7,7 +7,7 @@
         <div class="form-fields stacked">
             {{#each item.system.allowedClasses as |isAllowed allowedClass|}}
                 {{#if isAllowed}}
-                    <label class="checkbox"><input type="checkbox" name="" {{checked isAllowed}} disabled /> {{lookup (config "spellcastingClasses") allowedClass}}</label>
+                    <label class="checkbox"><input type="checkbox" name="" {{checked isAllowed}} disabled /> {{lookup ../config.spellcastingClasses allowedClass}}</label>
                 {{/if}}
             {{/each}}
         </div>

--- a/src/templates/apps/spell-cast.hbs
+++ b/src/templates/apps/spell-cast.hbs
@@ -25,7 +25,7 @@
         <label>{{localize "SFRPG.SpellCasting.SelectSpellSlot"}}</label>
         <div class="form-fields">
             <select name="level" {{#unless hasSlots}}disabled{{/unless}}>
-                {{selectOptions spellLevels selected=item.system.level nameAttr="level" labelAttr="label"}}
+                {{selectOptions spellLevels selected=item.system.level valueAttr="level" labelAttr="label"}}
             </select>
         </div>
     </div>

--- a/src/templates/chat/roll-dialog.hbs
+++ b/src/templates/chat/roll-dialog.hbs
@@ -11,11 +11,7 @@
         <div class="form-group" data-tooltip="<b>{{localize "SFRPG.Rolls.Dialog.RollMode"}}</b><br/>{{localize "SFRPG.Rolls.Dialog.RollModeTooltip"}}">
             <label>{{localize "SFRPG.Rolls.Dialog.RollMode"}}:</label>
             <select name="rollMode">
-            {{#select rollMode}}
-            {{#each rollModes as |label mode|}}
-                <option value="{{mode}}">{{localize label}}</option>
-            {{/each}}
-            {{/select}}
+                {{selectOptions rollModes selected=rollMode localize=true}}
             </select>
         </div>
         {{#if hasSelectors}}
@@ -23,11 +19,7 @@
         <div class="form-group" data-tooltip="<b>{{localize "SFRPG.Rolls.Dialog.Selector" name=target}}</b><br/>{{localize "SFRPG.Rolls.Dialog.SelectorTooltip" name=target}}">
             <label>{{localize "SFRPG.Rolls.Dialog.Selector" name=target}}:</label>
             <select class="selector" name="{{target}}">
-            {{#select selector.value}}
-            {{#each selector.entries as |selectorName selectorKey|}}
-                <option value="{{selectorKey}}">{{selectorName}}</option>
-            {{/each}}
-            {{/select}}
+                {{selectOptions selector.entries selected=selector.value}}
             </select>
         </div>
         {{/each}}

--- a/src/templates/items/actorResource.hbs
+++ b/src/templates/items/actorResource.hbs
@@ -131,10 +131,8 @@
                                 <label>{{ localize "SFRPG.ItemSheet.ActorResource.RangeMode" }}</label>
                                 <div class="form-fields">
                                     <select name="system.range.mode">
-                                        {{#select itemData.range.mode}}
-                                        <option value="post">{{ localize "SFRPG.ItemSheet.ActorResource.RangeModePost" }}</option>
-                                        <option value="immediate">{{ localize "SFRPG.ItemSheet.ActorResource.RangeModeImmediate" }}</option>
-                                        {{/select}}
+                                        {{selectOption "post" "SFRPG.ItemSheet.ActorResource.RangeModePost" selected=itemData.range.mode localize=true}}
+                                        {{selectOption "immediate" "SFRPG.ItemSheet.ActorResource.RangeModeImmediate" selected=itemData.range.mode localize=true}}
                                     </select>
                                 </div>
                             </div>
@@ -144,10 +142,8 @@
                                 <label>{{ localize "SFRPG.ItemSheet.ActorResource.Stage" }}</label>
                                 <div class="form-fields">
                                     <select name="system.stage">
-                                        {{#select itemData.stage}}
-                                        <option value="early">{{ localize "SFRPG.ItemSheet.ActorResource.StageEarly" }}</option>
-                                        <option value="late">{{ localize "SFRPG.ItemSheet.ActorResource.StageLate" }}</option>
-                                        {{/select}}
+                                        {{selectOption "early" "SFRPG.ItemSheet.ActorResource.StageEarly" selected=itemData.stage localize=true}}
+                                        {{selectOption "late" "SFRPG.ItemSheet.ActorResource.StageLate" selected=itemData.stage localize=true}}
                                     </select>
                                 </div>
                             </div>
@@ -240,14 +236,12 @@
                                             <div class="visualization-part-mode flexcol">
                                                 <span>{{ localize "SFRPG.ItemSheet.ActorResource.VisualizationsIntro" }}</span>
                                                 <select name="resource-mode">
-                                                    {{#select part.mode}}
-                                                    <option value="eq">{{ localize "SFRPG.ItemSheet.ActorResource.VisualizationsModeEqual" }}</option>
-                                                    <option value="neq">{{ localize "SFRPG.ItemSheet.ActorResource.VisualizationsModeNotEqual" }}</option>
-                                                    <option value="lt">{{ localize "SFRPG.ItemSheet.ActorResource.VisualizationsModeLesserThan" }}</option>
-                                                    <option value="lte">{{ localize "SFRPG.ItemSheet.ActorResource.VisualizationsModeLesserThanEqual" }}</option>
-                                                    <option value="gt">{{ localize "SFRPG.ItemSheet.ActorResource.VisualizationsModeGreaterThan" }}</option>
-                                                    <option value="gte">{{ localize "SFRPG.ItemSheet.ActorResource.VisualizationsModeGreaterThanEqual" }}</option>
-                                                    {{/select}}
+                                                    {{selectOption "eq" "SFRPG.ItemSheet.ActorResource.VisualizationsModeEqual" selected=part.mode localize=true}}
+                                                    {{selectOption "neq" "SFRPG.ItemSheet.ActorResource.VisualizationsModeNotEqual" selected=part.mode localize=true}}
+                                                    {{selectOption "lt" "SFRPG.ItemSheet.ActorResource.VisualizationsModeLesserThan" selected=part.mode localize=true}}
+                                                    {{selectOption "lte" "SFRPG.ItemSheet.ActorResource.VisualizationsModeLesserThanEqual" selected=part.mode localize=true}}
+                                                    {{selectOption "gt" "SFRPG.ItemSheet.ActorResource.VisualizationsModeGreaterThan" selected=part.mode localize=true}}
+                                                    {{selectOption "gte" "SFRPG.ItemSheet.ActorResource.VisualizationsModeGreaterThanEqual" selected=part.mode localize=true}}
                                                 </select>
                                                 <input type="text" name="resource-value" value="{{part.value}}"/>
                                             </div>
@@ -278,7 +272,7 @@
                 {{/if}}
 
             </section>
-            
+
         </div>
 
         {{!-- Modifiers Tab --}}

--- a/src/templates/items/ammunition.hbs
+++ b/src/templates/items/ammunition.hbs
@@ -24,12 +24,8 @@
                         <label>{{ localize "SFRPG.Items.Ammunition.AmmunitionType" }}</label>
                         <div class="form-fields">
                             <select name="system.ammunitionType">
-                                {{#select itemData.ammunitionType}}
-                                <option value="">{{ localize "SFRPG.Items.Ammunition.Type.None" }}</option>
-                                {{#each config.ammunitionTypes as |ammunition type|}}
-                                <option value="{{type}}">{{ammunition}}</option>
-                                {{/each}}
-                                {{/select}}
+                                {{selectOption "" "SFRPG.Items.Ammunition.Type.None" selected=itemData.ammunitionType localize=true}}
+                                {{selectOptions config.ammunitionTypes selected=itemData.ammunitionType}}
                             </select>
                         </div>
                     </div>
@@ -57,6 +53,6 @@
             {{> "systems/sfrpg/templates/items/parts/physical-item-details.hbs"}}
 
         </div>
-        
+
     </section>
 </form>

--- a/src/templates/items/augmentation.hbs
+++ b/src/templates/items/augmentation.hbs
@@ -16,7 +16,7 @@
 
         {{!-- Details Tab --}}
         <div class="tab details" data-group="primary" data-tab="details">
-            
+
             {{!-- Details Tab Navigation --}}
             <nav class="sheet-subnavigation subtabs" data-group="subdetails">
                 <a class="item active" data-tab="properties">{{ localize "SFRPG.ItemSheet.Details.Tab.Properties" }}</a>
@@ -39,11 +39,7 @@
                                 <label>{{ localize "SFRPG.Items.Augmentation.Type" }}</label>
                                 <div class="form-fields">
                                     <select name="system.type">
-                                        {{#select itemData.type}}
-                                        {{#each config.augmentationTypes as |augmentation type|}}
-                                        <option value="{{type}}">{{augmentation}}</option>
-                                        {{/each}}
-                                        {{/select}}
+                                        {{selectOptions config.augmentationTypes selected=itemData.type}}
                                     </select>
                                 </div>
                             </div>
@@ -52,11 +48,7 @@
                                 <label>{{ localize "SFRPG.Items.Augmentation.System" }}</label>
                                 <div class="form-fields">
                                     <select name="system.system">
-                                        {{#select itemData.system}}
-                                        {{#each config.augmentationSystems as |system key|}}
-                                        <option value="{{key}}">{{system}}</option>
-                                        {{/each}}
-                                        {{/select}}
+                                        {{selectOptions config.augmentationSystems selected=itemData.system}}
                                     </select>
                                 </div>
                             </div>
@@ -74,10 +66,10 @@
 
                 {{!-- Usage and Action Tab --}}
                 <div class="tab usage" data-group="subdetails" data-tab="usage">
-                    
+
                     {{!-- Item Activation Template --}}
                     {{> "systems/sfrpg/templates/items/parts/item-activation.hbs" message="SFRPG.Items.Augmentation.Usage"}}
-                    
+
                     {{!-- Item Action Template --}}
                     {{> "systems/sfrpg/templates/items/parts/item-action.hbs" message="SFRPG.Items.Augmentation.Action"}}
 

--- a/src/templates/items/chassis.hbs
+++ b/src/templates/items/chassis.hbs
@@ -52,11 +52,7 @@
                         <label>{{ localize "SFRPG.DroneSheet.Chassis.Details.BaseStatistics.Size" }}</label>
                         <div class="form-fields">
                             <select class="actor-size" name="system.size">
-                                {{#select itemData.size}}
-                                {{#each config.actorSizes as |label size|}}
-                                    <option value="{{size}}">{{label}}</option>
-                                {{/each}}
-                                {{/select}}
+                                {{selectOptions config.actorSizes selected=itemData.size}}
                             </select>
                         </div>
                     </div>
@@ -94,37 +90,25 @@
                                 <label>{{localize "SFRPG.DroneSheet.Chassis.Details.Saves.Fortitude"}}</label>
                                 <div class="form-fields">
                                     <select name="system.fort">
-                                        {{#select itemData.fort}}
-                                        {{#each config.saveProgression as |name val|}}
-                                        <option value="{{val}}">{{name}}</option>
-                                        {{/each}}
-                                        {{/select}}
+                                        {{selectOptions config.saveProgression selected=itemData.fort}}
                                     </select>
                                 </div>
                             </div>
-                
+
                             <div class="form-group">
                                 <label>{{localize "SFRPG.DroneSheet.Chassis.Details.Saves.Reflex"}}</label>
                                 <div class="form-fields">
                                     <select name="system.ref">
-                                        {{#select itemData.ref}}
-                                        {{#each config.saveProgression as |name val|}}
-                                        <option value="{{val}}">{{name}}</option>
-                                        {{/each}}
-                                        {{/select}}
+                                        {{selectOptions config.saveProgression selected=itemData.ref}}
                                     </select>
                                 </div>
                             </div>
-                
+
                             <div class="form-group">
                                 <label>{{localize "SFRPG.DroneSheet.Chassis.Details.Saves.Will"}}</label>
                                 <div class="form-fields">
                                     <select name="system.will">
-                                        {{#select itemData.will}}
-                                        {{#each config.saveProgression as |name val|}}
-                                        <option value="{{val}}">{{name}}</option>
-                                        {{/each}}
-                                        {{/select}}
+                                        {{selectOptions config.saveProgression selected=itemData.will}}
                                     </select>
                                 </div>
                             </div>
@@ -187,14 +171,7 @@
                         <label>{{ localize "SFRPG.ActorSheet.Attributes.Speed.MainMovementType" }}</label>
                         <div class="form-fields">
                             <select name="system.speed.mainMovement">
-                                {{#select itemData.speed.mainMovement}}
-                                <option value="land">{{ localize "SFRPG.ActorSheet.Attributes.Speed.Types.Land" }}</option>
-                                <option value="burrowing">{{ localize "SFRPG.ActorSheet.Attributes.Speed.Types.Burrowing" }}</option>
-                                <option value="climbing">{{ localize "SFRPG.ActorSheet.Attributes.Speed.Types.Climbing" }}</option>
-                                <option value="flying">{{ localize "SFRPG.ActorSheet.Attributes.Speed.Types.Flying" }}</option>
-                                <option value="swimming">{{ localize "SFRPG.ActorSheet.Attributes.Speed.Types.Swimming" }}</option>
-                                <option value="special">{{ localize "SFRPG.ActorSheet.Attributes.Speed.Types.Special" }}</option>
-                                {{/select}}
+                                {{selectOptions config.speeds selected=itemData.speed.mainMovement}}
                             </select>
                         </div>
                     </div>
@@ -251,19 +228,11 @@
                         <div class="form-group bubble-info">
                             <div class="form-fields">
                                 <select name="system.abilityIncreaseStats.first">
-                                    {{#select itemData.abilityIncreaseStats.first}}
-                                    {{#each config.abilities as |name val|}}
-                                    <option value="{{val}}">{{name}}</option>
-                                    {{/each}}
-                                    {{/select}}
+                                    {{selectedOptions config.abilities selected=itemData.abilityIncreaseStats.first}}
                                 </select>
-                                
+
                                 <select name="system.abilityIncreaseStats.second">
-                                    {{#select itemData.abilityIncreaseStats.second}}
-                                    {{#each config.abilities as |name val|}}
-                                    <option value="{{val}}">{{name}}</option>
-                                    {{/each}}
-                                    {{/select}}
+                                    {{selectOptions config.abilities selected=itemData.abilityIncreaseStats.second}}
                                 </select>
                             </div>
                         </div>

--- a/src/templates/items/chassis.hbs
+++ b/src/templates/items/chassis.hbs
@@ -228,7 +228,7 @@
                         <div class="form-group bubble-info">
                             <div class="form-fields">
                                 <select name="system.abilityIncreaseStats.first">
-                                    {{selectedOptions config.abilities selected=itemData.abilityIncreaseStats.first}}
+                                    {{selectOptions config.abilities selected=itemData.abilityIncreaseStats.first}}
                                 </select>
 
                                 <select name="system.abilityIncreaseStats.second">

--- a/src/templates/items/class.hbs
+++ b/src/templates/items/class.hbs
@@ -69,11 +69,7 @@
                                 <label>{{localize "SFRPG.ClassKeyAbilityScore"}}</label>
                                 <div class="form-fields">
                                     <select name="system.kas">
-                                        {{#select itemData.kas}}
-                                        {{#each config.abilities as |name val|}}
-                                        <option value="{{val}}">{{name}}</option>
-                                        {{/each}}
-                                        {{/select}}
+                                        {{selectOptions config.abilities selected=itemData.kas}}
                                     </select>
                                 </div>
                             </div>
@@ -113,11 +109,7 @@
                                         <label>{{localize "SFRPG.ClassBABProgression"}}</label>
                                         <div class="form-fields">
                                             <select name="system.bab">
-                                                {{#select itemData.bab}}
-                                                {{#each config.babProgression as |name val|}}
-                                                <option value="{{val}}">{{name}}</option>
-                                                {{/each}}
-                                                {{/select}}
+                                                {{selectOptions config.babProgression selected=itemData.bab}}
                                             </select>
                                         </div>
                                     </div>
@@ -126,11 +118,7 @@
                                         <label>{{localize "SFRPG.ClassFortSaveProgression"}}</label>
                                         <div class="form-fields">
                                             <select name="system.fort">
-                                                {{#select itemData.fort}}
-                                                {{#each config.saveProgression as |name val|}}
-                                                <option value="{{val}}">{{name}}</option>
-                                                {{/each}}
-                                                {{/select}}
+                                                {{selectOptions config.saveProgression selected=itemData.fort}}
                                             </select>
                                         </div>
                                     </div>
@@ -139,11 +127,7 @@
                                         <label>{{localize "SFRPG.ClassReflexSaveProgression"}}</label>
                                         <div class="form-fields">
                                             <select name="system.ref">
-                                                {{#select itemData.ref}}
-                                                {{#each config.saveProgression as |name val|}}
-                                                <option value="{{val}}">{{name}}</option>
-                                                {{/each}}
-                                                {{/select}}
+                                                {{selectOptions config.saveProgression selected=itemData.ref}}
                                             </select>
                                         </div>
                                     </div>
@@ -152,11 +136,7 @@
                                         <label>{{localize "SFRPG.ClassWillSaveProgression"}}</label>
                                         <div class="form-fields">
                                             <select name="system.will">
-                                                {{#select itemData.will}}
-                                                {{#each config.saveProgression as |name val|}}
-                                                <option value="{{val}}">{{name}}</option>
-                                                {{/each}}
-                                                {{/select}}
+                                                {{selectOptions config.saveProgression selected=itemData.will}}
                                             </select>
                                         </div>
                                     </div>
@@ -166,7 +146,7 @@
 
                         </div>
                     </div>
-                    
+
                     {{!-- Skills and Proficiencies --}}
                     <div class="bubble">
                         <h3 class="bubble-header">{{localize "SFRPG.ItemSheet.Details.Section.SkillsAndProficiencies"}}</h3>
@@ -236,12 +216,8 @@
                         <div class="form-group bubble-info">
                             <div class="form-fields">
                                 <select name="system.spellAbility">
-                                    <option value=""></option>
-                                    {{#select itemData.spellAbility}}
-                                    {{#each config.abilities as |name val|}}
-                                    <option value="{{val}}">{{name}}</option>
-                                    {{/each}}
-                                    {{/select}}
+                                    {{selectOption "" "" selected=itemData.spellAbility}}
+                                    {{selectOptions config.abilities selected=itemData.spellAbility}}
                                 </select>
                             </div>
                         </div>
@@ -364,7 +340,7 @@
 
                 </div>
                 {{/if}}
-            
+
             </section>
 
         </div>

--- a/src/templates/items/consumable.hbs
+++ b/src/templates/items/consumable.hbs
@@ -41,11 +41,7 @@
                             <div class="form-group">
                                 <label>{{ localize "SFRPG.Items.Consumable.Type" }}</label>
                                 <select name="system.consumableType">
-                                    {{#select itemData.consumableType}}
-                                    {{#each config.consumableTypes as |name type|}}
-                                    <option value="{{type}}">{{name}}</option>
-                                    {{/each}}
-                                    {{/select}}
+                                    {{selectOptions config.consumableTypes selected=itemData.consumableType}}
                                 </select>
                             </div>
 
@@ -54,7 +50,7 @@
 
                     {{!-- Physical Properties --}}
                     {{> "systems/sfrpg/templates/items/parts/physical-item-details.hbs"}}
-                    
+
                 </div>
 
                 {{!-- Usage & Action Tab --}}
@@ -78,6 +74,6 @@
 
         {{!-- Modifiers Tab --}}
         {{> "systems/sfrpg/templates/items/parts/item-modifiers.hbs"}}
-        
+
     </section>
 </form>

--- a/src/templates/items/equipment.hbs
+++ b/src/templates/items/equipment.hbs
@@ -42,12 +42,8 @@
                             <div class="form-group">
                                 <label>{{ localize "SFRPG.Items.Equipment.Category" }}</label>
                                 <select name="system.armor.type">
-                                    {{#select itemData.armor.type}}
-                                    <option value=""></option>
-                                    {{#each config.armorTypes as |name type|}}
-                                    <option value="{{type}}">{{name}}</option>
-                                    {{/each}}
-                                    {{/select}}
+                                    {{selectOption "" "" selected=itemData.armor.type}}
+                                    {{selectOptions config.armorTypes selected=itemData.armor.type}}
                                 </select>
                             </div>
 
@@ -95,7 +91,7 @@
 
                             {{!-- Equipment Status --}}
                             {{> "systems/sfrpg/templates/items/parts/item-status.hbs"}}
-                            
+
                         </div>
                     </div>
 
@@ -124,11 +120,7 @@
                                 <label>{{ localize "SFRPG.Size" }}</label>
                                 <div class="form-fields">
                                     <select name="system.size">
-                                        {{#select itemData.size}}
-                                        {{#each config.actorSizes as |size s|}}
-                                        <option value="{{s}}">{{size}}</option>
-                                        {{/each}}
-                                        {{/select}}
+                                        {{selectOptions config.actorSizes selected=itemData.size}}
                                     </select>
                                 </div>
                             </div>

--- a/src/templates/items/feat.hbs
+++ b/src/templates/items/feat.hbs
@@ -65,11 +65,7 @@
                             <div class="form-group select">
                                 <label for="category">{{ localize "SFRPG.Items.Feat.FeatureCategory" }}</label>
                                 <select name="system.details.category" id="category">
-                                {{#select itemData.details.category}}
-                                    {{#each config.featureCategories as |category c|}}
-                                        <option value="{{c}}">{{category.label}}</option>
-                                    {{/each}}
-                                {{/select}}
+                                    {{selectOptions config.featureCategories selected=itemData.details.category labelAttr="label"}}
                                 </select>
                             </div>
 
@@ -83,11 +79,7 @@
                             <div class="form-group select">
                                 <label for="category">{{ localize "SFRPG.Items.Feat.SpecialAbilityType" }}</label>
                                 <select name="system.details.specialAbilityType" id="specialAbilityType">
-                                {{#select itemData.details.specialAbilityType}}
-                                    {{#each config.specialAbilityTypes as |type t|}}
-                                        <option value="{{t}}">{{type}}</option>
-                                    {{/each}}
-                                {{/select}}
+                                    {{selectOptions config.specialAbilityTypes selected=itemData.details.specialAbilityType}}
                                 </select>
                             </div>
 
@@ -130,7 +122,7 @@
                     {{> "systems/sfrpg/templates/items/parts/item-action.hbs" message="SFRPG.Items.Feat.FeatureAttack"}}
 
                 </div>
-            
+
             </section>
 
         </div>

--- a/src/templates/items/mod.hbs
+++ b/src/templates/items/mod.hbs
@@ -82,22 +82,18 @@
                                     <input type="text" name="system.arms.number" value="{{itemData.arms.number}}" data-dtype="Number"/>
                                 </div>
                             </div>
-                
+
                             <div class="form-group">
                                 <label>{{ localize "SFRPG.DroneSheet.Mod.Details.Arms.ArmType.Label" }}</label>
                                 <div class="form-fields">
                                     <select name="system.arms.armType">
-                                        {{#select itemData.arms.armType}}
-                                        <option value="general">{{ localize "SFRPG.DroneSheet.Mod.Details.Arms.ArmType.General" }}</option>
-                                        <option value="melee">{{ localize "SFRPG.DroneSheet.Mod.Details.Arms.ArmType.Melee" }}</option>
-                                        <option value="ranged">{{ localize "SFRPG.DroneSheet.Mod.Details.Arms.ArmType.Ranged" }}</option>
-                                        {{/select}}
+                                        {{selectOptions (config "droneArmTypes") selected=itemData.arms.armType}}
                                     </select>
                                 </div>
                             </div>
                         </div>
                     </div>
-                    
+
                     {{!-- Other Effects --}}
                     <div class="bubble">
                         <h3 class="bubble-header">{{ localize "SFRPG.DroneSheet.Mod.Details.OtherEffects.Header" }}</h3>
@@ -115,12 +111,8 @@
                                 <label>{{ localize "SFRPG.DroneSheet.Mod.Details.OtherEffects.WeaponProficiency" }}</label>
                                 <div class="form-fields">
                                     <select name="system.weaponProficiency">
-                                        <option value="">{{ localize "SFRPG.None" }}</option>
-                                        {{#select itemData.weaponProficiency}}
-                                        {{#each config.weaponProficiencies as |name val|}}
-                                        <option value="{{val}}">{{name}}</option>
-                                        {{/each}}
-                                        {{/select}}
+                                        {{selectOption "" "SFRPG.None" selected=itemData.weaponProficiency localize=true}}
+                                        {{selectOptions config.weaponProficiencies selected=itemData.weaponProficiency}}
                                     </select>
                                 </div>
                             </div>
@@ -129,12 +121,8 @@
                                 <label>{{ localize "SFRPG.DroneSheet.Mod.Details.OtherEffects.BonusSkill" }}</label>
                                 <div class="form-fields">
                                     <select name="system.bonusSkill">
-                                        <option value="">{{ localize "SFRPG.None" }}</option>
-                                        {{#select itemData.bonusSkill}}
-                                        {{#each config.skills as |name val|}}
-                                        <option value="{{val}}">{{name}}</option>
-                                        {{/each}}
-                                        {{/select}}
+                                        {{selectOption "" "SFRPG.None" selected=itemData.bonusSkill}}
+                                        {{selectOptions config.skills selected=itemData.bonusSkill}}
                                     </select>
                                 </div>
                             </div>

--- a/src/templates/items/mod.hbs
+++ b/src/templates/items/mod.hbs
@@ -87,7 +87,7 @@
                                 <label>{{ localize "SFRPG.DroneSheet.Mod.Details.Arms.ArmType.Label" }}</label>
                                 <div class="form-fields">
                                     <select name="system.arms.armType">
-                                        {{selectOptions (config "droneArmTypes") selected=itemData.arms.armType}}
+                                        {{selectOptions config.droneArmTypes selected=itemData.arms.armType}}
                                     </select>
                                 </div>
                             </div>

--- a/src/templates/items/parts/container-details.hbs
+++ b/src/templates/items/parts/container-details.hbs
@@ -32,7 +32,7 @@
             {{#each itemData.container.storage as |storage|}}
             <li class="storage-slot bubble" data-slot-index="{{indexOf ../itemData.container.storage storage}}">
                 <h4 class="bubble-header">
-                    {{ localize "SFRPG.ActorSheet.Inventory.Container.StorageSection" index=(indexOf ../itemData.container.storage storage false) }}
+                    {{ localize "SFRPG.ActorSheet.Inventory.Container.StorageSection" index=(indexOf ../itemData.container.storage storage firstIdx=1) }}
                     <a class="item-control bubble-icon remove-storage"> <i class="fas fa-minus"></i> </a>
                 </h4>
                 <div class="bubble-info">
@@ -40,10 +40,8 @@
                         <label>{{ localize "SFRPG.ActorSheet.Inventory.Container.StorageType" }}</label>
                         <div class="form-fields">
                             <select name="storage.type">
-                                {{#select storage.type}}
-                                <option value="slot">{{ localize "SFRPG.ActorSheet.Inventory.Container.StorageTypeSlot" }}</option>
-                                <option value="bulk">{{ localize "SFRPG.ActorSheet.Inventory.Container.StorageTypeBulk" }}</option>
-                                {{/select}}
+                                {{selectOption "slot" "SFRPG.ActorSheet.Inventory.Container.StorageTypeSlot" selected=storage.type localize=true}}
+                                {{selectOption "bulk" "SFRPG.ActorSheet.Inventory.Container.StorageTypeBulk" selected=storage.type localize=true}}
                             </select>
                         </div>
                     </div>
@@ -52,14 +50,12 @@
                         <label>{{ localize "SFRPG.ActorSheet.Inventory.Container.StorageIdentifier" }}</label>
                         <div class="form-fields">
                             <select name="storage.subtype">
-                                {{#select storage.subtype}}
-                                <option value="">{{ localize "SFRPG.ActorSheet.Inventory.Container.StorageIdentifierItem" }}</option>
-                                <option value="armorUpgrade">{{ localize "SFRPG.ActorSheet.Inventory.Container.StorageIdentifierArmorUpgrade" }}</option>
-                                <option value="weaponSlot">{{ localize "SFRPG.ActorSheet.Inventory.Container.StorageIdentifierWeaponSlot" }}</option>
-                                <option value="fusion">{{ localize "SFRPG.ActorSheet.Inventory.Container.StorageIdentifierFusion" }}</option>
-                                <option value="spellSlot">{{ localize "SFRPG.ActorSheet.Inventory.Container.StorageIdentifierSpellSlot" }}</option>
-                                <option value="ammunitionSlot">{{ localize "SFRPG.ActorSheet.Inventory.Container.StorageIdentifierAmmunitionSlot" }}</option>
-                                {{/select}}
+                                {{selectOption ""               "SFRPG.ActorSheet.Inventory.Container.StorageIdentifierItem"           selected=storage.subtype localize=true}}
+                                {{selectOption "armorUpgrade"   "SFRPG.ActorSheet.Inventory.Container.StorageIdentifierArmorUpgrade"   selected=storage.subtype localize=true}}
+                                {{selectOption "weaponSlot"     "SFRPG.ActorSheet.Inventory.Container.StorageIdentifierWeaponSlot"     selected=storage.subtype localize=true}}
+                                {{selectOption "fusion"         "SFRPG.ActorSheet.Inventory.Container.StorageIdentifierFusion"         selected=storage.subtype localize=true}}
+                                {{selectOption "spellSlot"      "SFRPG.ActorSheet.Inventory.Container.StorageIdentifierSpellSlot"      selected=storage.subtype localize=true}}
+                                {{selectOption "ammunitionSlot" "SFRPG.ActorSheet.Inventory.Container.StorageIdentifierAmmunitionSlot" selected=storage.subtype localize=true}}
                             </select>
                         </div>
                     </div>
@@ -68,11 +64,9 @@
                         <div class="form-fields">
                             <input type="text" name="storage.amount" value="{{storage.amount}}" data-dtype="Number" placeholder="0" />
                             <select name="storage.weightProperty" data-tooltip="<strong>{{ localize "SFRPG.ActorSheet.Inventory.Container.CapacityPropertyItems" }}</strong><br/>{{ localize "SFRPG.ActorSheet.Inventory.Container.CapacityPropertyItemsTooltip" }}<br/><br/><strong>{{ localize "SFRPG.ActorSheet.Inventory.Container.CapacityPropertySlots" }}</strong><br/>{{ localize "SFRPG.ActorSheet.Inventory.Container.CapacityPropertySlotsTooltip" }}<br/><br/><strong>{{ localize "SFRPG.ActorSheet.Inventory.Container.CapacityPropertyLevel" }}</strong><br/>{{ localize "SFRPG.ActorSheet.Inventory.Container.CapacityPropertyLevelTooltip" }}">
-                                {{#select storage.weightProperty}}
-                                <option value="">{{ localize "SFRPG.ActorSheet.Inventory.Container.CapacityPropertyItems" }}</option>
-                                <option value="slots">{{ localize "SFRPG.ActorSheet.Inventory.Container.CapacityPropertySlots" }}</option>
-                                <option value="level">{{ localize "SFRPG.ActorSheet.Inventory.Container.CapacityPropertyLevel" }}</option>
-                                {{/select}}
+                                {{selectOption "" "SFRPG.ActorSheet.Inventory.Container.CapacityPropertyItems" selected=storage.weightProperty localize=true}}
+                                {{selectOption "slots" "SFRPG.ActorSheet.Inventory.Container.CapacityPropertySlots" selected=storage.weightProperty localize=true}}
+                                {{selectOption "level" "SFRPG.ActorSheet.Inventory.Container.CapacityPropertyLevel" selected=storage.weightProperty localize=true}}
                             </select>
                         </div>
                     </div>

--- a/src/templates/items/parts/item-action.hbs
+++ b/src/templates/items/parts/item-action.hbs
@@ -11,12 +11,8 @@
         <div class="form-group select">
             <label>{{ localize "SFRPG.Items.Action.ActionType" }}</label>
             <select name="system.actionType">
-                {{#select itemData.actionType}}
-                <option value=""></option>
-                {{#each config.itemActionTypes as |name type|}}
-                <option value="{{type}}">{{name}}</option>
-                {{/each}}
-                {{/select}}
+                {{selectOption "" "" selected=itemData.actionType}}
+                {{selectOptions config.itemActionTypes selected=itemData.actionType}}
             </select>
         </div>
 
@@ -25,11 +21,7 @@
             <div class="form-group select" {{createTippy title="SFRPG.Items.Action.ActionTarget.Title" subtitle="SFRPG.Items.Action.ActionTarget.Tooltip"}}>
                 <label>{{ localize "SFRPG.Items.Action.ActionTarget.Title" }}</label>
                 <select name="system.actionTarget">
-                    {{#select itemData.actionTarget}}
-                    {{#each config.actionTargets as |name type|}}
-                    <option value="{{type}}">{{name}}</option>
-                    {{/each}}
-                    {{/select}}
+                    {{selectOptions config.actionTargets selected=itemData.actionTarget}}
                 </select>
             </div>
 
@@ -37,12 +29,8 @@
             <div class="form-group select">
                 <label>{{ localize "SFRPG.Items.Action.AbilityModifier" }}</label>
                 <select name="system.ability">
-                    {{#select itemData.ability}}
-                    <option value=""></option>
-                    {{#each config.abilities as |ability a|}}
-                    <option value="{{a}}">{{ability}}</option>
-                    {{/each}}
-                    {{/select}}
+                    {{selectOption "" "" selected=itemData.ability}}
+                    {{selectOptions config.abilities selected=itemData.ability}}
                 </select>
             </div>
 
@@ -62,19 +50,11 @@
                 <div class="form-fields">
                     <input type="text" class="wide-form-field" name="system.save.dc" value="{{itemData.save.dc}}" data-dtype="String" placeholder="{{placeholders.saveDC.formula}}"/>
                     <select name="system.save.type">
-                        {{#select itemData.save.type}}
-                        <option value=""></option>
-                        {{#each config.saves as |save s|}}
-                        <option value="{{s}}">{{save}}</option>
-                        {{/each}}
-                        {{/select}}
+                        {{selectOption "" "" selected=itemData.save.type}}
+                        {{selectOptions config.saves selected=itemData.save.type}}
                     </select>
                     <select name="system.save.descriptor">
-                        {{#select itemData.save.descriptor}}
-                        {{#each config.saveDescriptors as |descriptor k|}}
-                        <option value="{{k}}">{{descriptor}}</option>
-                        {{/each}}
-                        {{/select}}
+                        {{selectOptions config.saveDescriptors selected=itemData.save.descriptor}}
                     </select>
                 </div>
             </div>
@@ -85,12 +65,8 @@
                 <div class="form-fields">
                     <input type="text" class="wide-form-field" name="system.skillCheck.dc" value="{{itemData.skillCheck.dc}}" data-dtype="String" placeholder="{{placeholders.saveDC.formula}}"/>
                     <select name="system.skillCheck.type">
-                        {{#select itemData.skillCheck.type}}
-                        <option value=""></option>
-                        {{#each config.skills as |skill s|}}
-                        <option value="{{s}}">{{skill}}</option>
-                        {{/each}}
-                        {{/select}}
+                        {{selectOption "" "" selected=itemData.skillCheck.type}}
+                        {{selectOptions config.skills selected=itemData.skillCheck.type}}
                     </select>
                 </div>
             </div>
@@ -119,11 +95,7 @@
                                 <input class="wide-form-field" type="text" name="system.range.value" value="{{itemData.range.value}}" data-dtype="String" placeholder="Range"/>
                                 {{/if}}
                                 <select name="system.range.units">
-                                    {{#select itemData.range.units}}
-                                    {{#each config.distanceUnits as |unit key|}}
-                                    <option value="{{key}}">{{unit}}</option>
-                                    {{/each}}
-                                    {{/select}}
+                                    {{selectOptions config.distanceUnits selected=itemData.range.units}}
                                 </select>
                             </div>
                         </div>
@@ -135,27 +107,15 @@
                                 {{#if this.area.showTotal}}<p class="calculated-total"><strong>{{itemData.area.total}}</strong></p>{{/if}}
                                 <input type="text" {{#if (eq itemData.area.units "text")}}class="wide-form-field"{{/if}} name="system.area.value" value="{{itemData.area.value}}" data-dtype="String" placeholder="Area" />
                                 <select name="system.area.units" class="min-form-field">
-                                    {{#select itemData.area.units}}
-                                    {{#each config.variableDistanceUnits as |unit key|}}
-                                    <option value="{{key}}">{{unit}}</option>
-                                    {{/each}}
-                                    <option value="text">{{localize "SFRPG.Text"}}</option>
-                                    {{/select}}
+                                    {{selectOptions config.variableDistanceUnits selected=itemData.area.units}}
+                                    {{selectOption "text" "SFRPG.Text" selected=itemData.area.units localize=true}}
                                 </select>
                                 {{#unless (eq itemData.area.units "text")}}
                                 <select name="system.area.shape" class="min-form-field">
-                                    {{#select itemData.area.shape}}
-                                    {{#each config.spellAreaShapes as |shape s|}}
-                                    <option value="{{s}}">{{shape}}</option>
-                                    {{/each}}
-                                    {{/select}}
+                                    {{selectOptions config.spellAreaShapes selected=itemData.area.shape}}
                                 </select>
                                 <select name="system.area.effect" class="min-form-field">
-                                    {{#select itemData.area.effect}}
-                                    {{#each config.spellAreaEffects as |effect e|}}
-                                    <option value="{{e}}">{{effect}}</option>
-                                    {{/each}}
-                                    {{/select}}
+                                    {{selectOptions config.spellAreaEffects selected=itemData.area.effect}}
                                 </select>
                                 <label class="checkbox">
                                     <input type="checkbox" name="system.area.shapable" {{checked itemData.area.shapable}}>
@@ -246,11 +206,9 @@
                             <div class="damage-part-operator form-group flexrow" data-tooltip="When an item or ablity does multiple types of damage, this will determine if both damage types apply, or if only one or the other apply.">
                                 <label>{{localize "Damage Operator"}}</label>
                                 <select name="system.critical.parts.{{i}}.operator">
-                                    {{#select (lookup this "operator")}}
-                                    <option value=""></option>
-                                    <option value="and">{{localize "And"}}</option>
-                                    <option value="or">{{localize "Or"}}</option>
-                                    {{/select}}
+                                    {{selectOption "" "" selected=part.operator}}
+                                    {{selectOption "and" "And" selected=part.operator localize=true}}
+                                    {{selectOption "or" "Or" selected=part.operator localize=true}}
                                 </select>
                             </div>
                         </div>

--- a/src/templates/items/parts/item-activation.hbs
+++ b/src/templates/items/parts/item-activation.hbs
@@ -13,12 +13,8 @@
             <div class="form-fields">
                 <input type="text" name="system.activation.cost" value="{{itemData.activation.cost}}" data-dtype="Number" placeholder="-"/>
                 <select name="system.activation.type">
-                    {{#select itemData.activation.type}}
-                    <option value=""></option>
-                    {{#each config.abilityActivationTypes as |name key|}}
-                    <option value="{{key}}">{{name}}</option>
-                    {{/each}}
-                    {{/select}}
+                    {{selectOption "" "" selected=itemData.activation.type}}
+                    {{selectOptions config.abilityActivationTypes selected=itemData.activation.type}}
                 </select>
             </div>
         </div>
@@ -50,12 +46,8 @@
                 <input type="text" class="wide-form-field" name="system.duration.value" value="{{itemData.duration.value}}" data-dtype="String" placeholder="-"/>
                 {{/if}}
                 <select name="system.duration.units">
-                    {{#select itemData.duration.units}}
-                    <option value="text">{{localize "SFRPG.Text"}}</option>
-                    {{#each config.durationTypes as |unit key|}}
-                    <option value="{{key}}">{{unit}}</option>
-                    {{/each}}
-                    {{/select}}
+                    {{selectOption "text" "SFRPG.Text" selected=itemData.duration.units localize=true}}
+                    {{selectOptions config.durationTypes selected=itemData.duration.units}}
                 </select>
             </div>
         </div>
@@ -69,12 +61,8 @@
                 <input type="text" name="system.uses.max" value="{{itemData.uses.max}}" data-dtype="String"/>
                 {{#if this.uses.showTotal}}<p class="calculated-total"><strong>{{itemData.uses.total}}</strong></p>{{/if}}
                 <select name="system.uses.per">
-                    {{#select itemData.uses.per}}
-                    <option value=""></option>
-                    {{#each config.limitedUsePeriods as |name key|}}
-                    <option value="{{key}}">{{name}}</option>
-                    {{/each}}
-                    {{/select}}
+                    {{selectOption "" "" selected=itemData.uses.per}}
+                    {{selectOptions config.limitedUsePeriods selected=itemData.uses.per}}
                 </select>
             </div>
         </div>
@@ -92,11 +80,7 @@
                         <input class="wide-form-field" type="text" name="system.range.value" value="{{itemData.range.value}}" data-dtype="String" placeholder="Range"/>
                         {{/if}}
                         <select name="system.range.units">
-                            {{#select itemData.range.units}}
-                            {{#each config.distanceUnits as |unit key|}}
-                            <option value="{{key}}">{{unit}}</option>
-                            {{/each}}
-                            {{/select}}
+                            {{selectOptions config.distanceUnits selected=itemData.range.units}}
                         </select>
                     </div>
                 </div>
@@ -108,27 +92,15 @@
                         {{#if this.area.showTotal}}<p class="calculated-total"><strong>{{itemData.area.total}}</strong></p>{{/if}}
                         <input type="text" {{#if (eq itemData.area.units "text")}}class="wide-form-field"{{/if}} name="system.area.value" value="{{itemData.area.value}}" data-dtype="String" placeholder="Area" />
                         <select name="system.area.units" class="min-form-field">
-                            {{#select itemData.area.units}}
-                            {{#each config.variableDistanceUnits as |unit key|}}
-                            <option value="{{key}}">{{unit}}</option>
-                            {{/each}}
-                            <option value="text">{{localize "SFRPG.Text"}}</option>
-                            {{/select}}
+                            {{selectOptions config.variableDistanceUnits selected=itemData.area.units}}
+                            {{selectOption "text" "SFRPG.Text" selected=itemData.area.units localize=true}}
                         </select>
                         {{#unless (eq itemData.area.units "text")}}
                         <select name="system.area.shape" class="min-form-field">
-                            {{#select itemData.area.shape}}
-                            {{#each config.spellAreaShapes as |shape s|}}
-                            <option value="{{s}}">{{shape}}</option>
-                            {{/each}}
-                            {{/select}}
+                            {{selectOptions config.spellAreaShapes selected=itemData.area.shape}}
                         </select>
                         <select name="system.area.effect" class="min-form-field">
-                            {{#select itemData.area.effect}}
-                            {{#each config.spellAreaEffects as |effect e|}}
-                            <option value="{{e}}">{{effect}}</option>
-                            {{/each}}
-                            {{/select}}
+                            {{selectOptions config.spellAreaEffects selected=itemData.area.effect}}
                         </select>
                         <label class="checkbox">
                             <input type="checkbox" name="system.area.shapable" {{checked itemData.area.shapable}}>

--- a/src/templates/items/parts/item-capacity.hbs
+++ b/src/templates/items/parts/item-capacity.hbs
@@ -6,12 +6,8 @@
             <label>{{ localize "SFRPG.Items.Ammunition.AmmunitionType" }}</label>
             <div class="form-fields">
                 <select name="system.ammunitionType">
-                    {{#select itemData.ammunitionType}}
-                    <option value="">{{ localize "SFRPG.Items.Ammunition.Type.None" }}</option>
-                    {{#each config.ammunitionTypes as |ammunition type|}}
-                    <option value="{{type}}">{{ammunition}}</option>
-                    {{/each}}
-                    {{/select}}
+                    {{selectOption "" "SFRPG.Items.Ammunition.Type.None" selected=itemData.ammunitionType localize=true}}
+                    {{selectOptions config.ammunitionTypes selected=itemData.ammunitionType}}
                 </select>
             </div>
         </div>
@@ -37,12 +33,8 @@
                 <input type="text" data-tooltip="{{ localize "SFRPG.Items.Capacity.UsageTooltip" }}" name="system.usage.value" value="{{itemData.usage.value}}" data-dtype="Number" />
                 <span class="sep"> / </span>
                 <select name="system.usage.per" data-tooltip="{{ localize "SFRPG.Items.Capacity.UsageValueTooltip" }}">
-                {{#select itemData.usage.per}}
-                    <option value=""></option>
-                    {{#each config.capacityUsagePer as |usage u|}}
-                    <option value="{{u}}">{{usage}}</option>
-                    {{/each}}
-                {{/select}}
+                    {{selectOption "" "" selected=itemData.usage.per}}
+                    {{selectOptions config.capacityUsagePer selected=itemData.usage.per}}
                 </select>
             </div>
         </div>

--- a/src/templates/items/parts/item-duration.hbs
+++ b/src/templates/items/parts/item-duration.hbs
@@ -24,11 +24,7 @@
                                 data-tooltip="<p>Use the <code>@owner</code> prefix to reference the parent actor.</p><p>Use <code>@origin.actor</code> or <code>@origin.item</code> to reference the origin actor or item respectively." />
                         {{/unless}}
                         <select name="system.activeDuration.unit">
-                            {{#select itemData.activeDuration.unit}}
-                                {{#each config.effectDurationTypes as |name key|}}
-                                    <option value="{{key}}">{{localize name}}</option>
-                                {{/each}}
-                            {{/select}}
+                            {{selectedOptions config.effectDurationTypes selected=itemData.activeDuration.unit}}
                         </select>
                     </div>
                 </div>
@@ -38,33 +34,21 @@
                     <div class="form-group input-select">
                         <label>{{localize "SFRPG.Effect.EndTypesLabel"}}</label>
                         <div class="form-fields">
-                            <select name="system.activeDuration.expiryMode.type" {{createTippy
-                                title="SFRPG.Effect.ExpiryModeLabel" subtitle="SFRPG.Effect.ExpiryModeTooltip" }}>
-                                {{#select itemData.activeDuration.expiryMode.type}}
-                                    <option value="turn">{{ localize "SFRPG.Effect.ExpiryModeTurn"}}</option>
-                                    <option value="init">{{ localize "SFRPG.Effect.ExpiryModeInit"}}</option>
-                                {{/select}}
+                            <select name="system.activeDuration.expiryMode.type" {{createTippy title="SFRPG.Effect.ExpiryModeLabel" subtitle="SFRPG.Effect.ExpiryModeTooltip" }}>
+                                {{selectOption "turn" "SFRPG.Effect.ExpiryModeTurn" selected=itemData.activeDuration.expiryMode.type localize=true}}
+                                {{selectOption "init" "SFRPG.Effect.ExpiryModeInit" selected=itemData.activeDuration.expiryMode.type localize=true}}
                             </select>
                             {{#if (eq itemData.activeDuration.expiryMode.type "turn")}}
-                                <select name="system.activeDuration.expiryMode.turn" {{createTippy
-                                    title="SFRPG.Effect.EndTypesLabel" subtitle="SFRPG.Effect.EndsOnTooltip" }}>
-                                    {{#select itemData.activeDuration.expiryMode.turn}}
-                                        <option value="parent">Parent Actor's Turn</option>
-                                        <option value="origin">Origin Actor's Turn</option>
-                                        <option value="init">Nearest Initiative</option>
-                                        <optgroup label="Combatant Turns">
-                                            {{#each this.sourceActorChoices as |name id|}}
-                                                <option value="{{id}}">{{name}}</option>
-                                            {{/each}}
-                                        </optgroup>
-                                    {{/select}}
+                                <select name="system.activeDuration.expiryMode.turn" {{createTippy title="SFRPG.Effect.EndTypesLabel" subtitle="SFRPG.Effect.EndsOnTooltip" }}>
+                                    {{selectOption "parent" "Parent Actor's Turn" selected=itemData.activeDuration.expiryMode.turn}}
+                                    {{selectOption "origin" "Origin Actor's Turn" selected=itemData.activeDuration.expiryMode.turn}}
+                                    {{selectOption "init"   "Nearest Initiative"  selected=itemData.activeDuration.expiryMode.turn}}
+                                    <optgroup label="Combatant Turns">
+                                        {{selectOptions sourceActorChoices selected=itemData.activeDuration.expiryMode.turn}}
+                                    </optgroup>
                                 </select>
                                 <select name="system.activeDuration.endsOn">
-                                    {{#select itemData.activeDuration.endsOn}}
-                                        {{#each config.effectEndTypes as |name key|}}
-                                            <option value="{{key}}">{{localize name}}</option>
-                                        {{/each}}
-                                    {{/select}}
+                                    {{selectOptions config.effectEndTypes selected=itemData.activeDuration.endsOn localize=true}}
                                 </select>
                             {{else if (eq itemData.activeDuration.expiryMode.type "init")}}
                                 <input name="system.activeDuration.expiryInit" type="number" data-dtype="Number"

--- a/src/templates/items/parts/item-duration.hbs
+++ b/src/templates/items/parts/item-duration.hbs
@@ -24,7 +24,7 @@
                                 data-tooltip="<p>Use the <code>@owner</code> prefix to reference the parent actor.</p><p>Use <code>@origin.actor</code> or <code>@origin.item</code> to reference the origin actor or item respectively." />
                         {{/unless}}
                         <select name="system.activeDuration.unit">
-                            {{selectedOptions config.effectDurationTypes selected=itemData.activeDuration.unit}}
+                            {{selectOptions config.effectDurationTypes selected=itemData.activeDuration.unit}}
                         </select>
                     </div>
                 </div>

--- a/src/templates/items/parts/physical-item-details.hbs
+++ b/src/templates/items/parts/physical-item-details.hbs
@@ -18,11 +18,7 @@
             <label>{{ localize "SFRPG.ItemSheet.PhysicalProperties.Size" }}</label>
             <div class="form-fields">
                 <select class="actor-size" name="system.attributes.size">
-                    {{#select selectedSize}}
-                    {{#each config.actorSizes as |label size|}}
-                        <option value="{{size}}">{{label}}</option>
-                    {{/each}}
-                    {{/select}}
+                    {{selectOptions config.actorSizes selected=selectedSize}}
                 </select>
             </div>
         </div>

--- a/src/templates/items/race.hbs
+++ b/src/templates/items/race.hbs
@@ -61,18 +61,14 @@
                         <label>{{localize "SFRPG.RaceSize"}}</label>
                         <div class="form-fields">
                             <select name="system.size">
-                                {{#select itemData.size}}
-                                {{#each config.actorSizes as |name val|}}
-                                <option value="{{val}}">{{name}}</option>
-                                {{/each}}
-                                {{/select}}
+                                {{selectOptions config.actorSizes selected=itemData.size}}
                             </select>
                         </div>
                     </div>
 
                 </div>
             </div>
-            
+
             {{!-- Ability Adjustments Formula --}}
             <div class="bubble">
                 <h3 class="bubble-header">
@@ -85,15 +81,11 @@
                     <ol class="ability-adjustment-parts form-group">
                         {{#each itemData.abilityMods.parts as |part i| }}
                         <li class="ability-adjustment-part flexrow" data-ability-adjustment="{{i}}">
-                            <input type="text" name="system.abilityMods.parts.{{i}}.0" data-dtype="Number" value="{{numberFormat (lookup this "0") decimals=0 sign=true}}"/>
+                            <input type="text" name="system.abilityMods.parts.{{i}}.0" data-dtype="Number" value="{{numberFormat part.[0] decimals=0 sign=true}}"/>
                             <select name="system.abilityMods.parts.{{i}}.1">
-                                {{#select (lookup this "1") }}
-                                <option value="">{{ localize "SFRPG.None" }}</option>
-                                {{#each ../config.abilities as |name val|}}
-                                <option value="{{val}}">{{name}}</option>
-                                {{/each}}
-                                <option value="any">{{localize "SFRPG.RaceAbilityAdjustmentAny"}}</option>
-                                {{/select}}
+                                {{selectOption "" "SFRPG.None" selected=part.[1] localize=true}}
+                                {{selectOptions (config "abilities") selected=part.[1]}}
+                                {{selectOption "any" "SFRPG.RaceAbilityAdjustmentAny" selected=part.[1] localize=true}}
                             </select>
                             <a class="ability-adjustments-control delete-ability-adjustment"><i class="fas fa-minus"></i></a>
                         </li>
@@ -102,7 +94,7 @@
 
                 </div>
             </div>
-            
+
         </div>
 
         {{!-- Modifiers Tab --}}

--- a/src/templates/items/race.hbs
+++ b/src/templates/items/race.hbs
@@ -84,7 +84,7 @@
                             <input type="text" name="system.abilityMods.parts.{{i}}.0" data-dtype="Number" value="{{numberFormat part.[0] decimals=0 sign=true}}"/>
                             <select name="system.abilityMods.parts.{{i}}.1">
                                 {{selectOption "" "SFRPG.None" selected=part.[1] localize=true}}
-                                {{selectOptions (config "abilities") selected=part.[1]}}
+                                {{selectOptions ../config.abilities selected=part.[1]}}
                                 {{selectOption "any" "SFRPG.RaceAbilityAdjustmentAny" selected=part.[1] localize=true}}
                             </select>
                             <a class="ability-adjustments-control delete-ability-adjustment"><i class="fas fa-minus"></i></a>

--- a/src/templates/items/spell.hbs
+++ b/src/templates/items/spell.hbs
@@ -14,7 +14,7 @@
                     <span data-tooltip="Item Status" class="item-status">{{itemStatus}}</span>
                 </div>
             </div>
-    
+
             {{!-- Item Summary --}}
             <ul class="summary flexrow">
                 {{#if category.enabled}}
@@ -26,7 +26,7 @@
                     <input type="text" name="system.source" value="{{itemData.source}}" placeholder="{{ localize "SFRPG.ItemSheet.Header.Source" }}"/>
                 </li>
             </ul>
-    
+
             {{!-- Header Attributes --}}
             <ul class="summary flexrow">
                 <li>
@@ -88,11 +88,7 @@
                                 <label>{{ localize "SFRPG.Items.Spell.Level" }}</label>
                                 <div class="form-fields">
                                     <select name="system.level" data-dtype="Number">
-                                        {{#select itemData.level}}
-                                        {{#each config.spellLevels as |name lvl|}}
-                                        <option value="{{lvl}}">{{localize name}}</option>
-                                        {{/each}}
-                                        {{/select}}
+                                        {{selectOptions config.spellLevels selected=itemData.level localize=true}}
                                     </select>
                                     <span>&nbsp;</span>
                                     <label class="checkbox">
@@ -106,11 +102,7 @@
                                 <label>{{ localize "SFRPG.Items.Spell.School" }}</label>
                                 <div class="form-fields">
                                     <select name="system.school">
-                                        {{#select itemData.school}}
-                                        {{#each config.spellSchools as |name sch|}}
-                                        <option value="{{sch}}">{{localize name}}</option>
-                                        {{/each}}
-                                        {{/select}}
+                                        {{selectOptions config.spellSchools selected=itemData.school localize=true}}
                                     </select>
                                 </div>
                             </div>
@@ -140,12 +132,8 @@
                                     </label>
                                     <span>&nbsp;</span>
                                     <select name="system.preparation.mode">
-                                        {{#select itemData.preparation.mode}}
-                                        <option value=""></option>
-                                        {{#each config.spellPreparationModes as |name key|}}
-                                        <option value="{{key}}">{{name}}</option>
-                                        {{/each}}
-                                        {{/select}}
+                                        {{selectOption "" "" selected=itemData.preparation.mode}}
+                                        {{selectOptions config.spellPreparationModes selected=itemData.preparation.mode}}
                                     </select>
                                 </div>
                             </div>
@@ -167,13 +155,13 @@
                                     {{/if}}
                                 </div>
                             </div>
-                            
+
                         </div>
                     </div>
 
                     {{!-- Descriptors Selector --}}
                     {{> "systems/sfrpg/templates/items/parts/item-descriptors.hbs"}}
-                
+
                 </div>
 
                 {{!-- Usage Tab --}}
@@ -184,7 +172,7 @@
 
                     {{!-- Item Action Template --}}
                     {{> "systems/sfrpg/templates/items/parts/item-action.hbs" message="SFRPG.Items.Spell.Effects"}}
-                    
+
                 </div>
 
             </section>

--- a/src/templates/items/starshipAction.hbs
+++ b/src/templates/items/starshipAction.hbs
@@ -17,7 +17,7 @@
 
         {{!-- Details Tab --}}
         <div class="tab details" data-group="primary" data-tab="details">
-            
+
             {{!-- Details Tab Navigation --}}
             <nav class="sheet-subnavigation subtabs" data-group="subdetails">
                 <a class="item active" data-tab="properties">{{ localize "SFRPG.ItemSheet.Details.Tab.Properties" }}</a>
@@ -34,16 +34,12 @@
                         <h3 class="bubble-header">{{ localize "SFRPG.Items.Action.Details" }}</h3>
 
                         <div class="bubble-info">
-                            
+
                             {{!-- Role --}}
                             <div class="form-group">
                                 <label>{{ localize "SFRPG.ItemSheet.StarshipAction.CrewRole" }}</label>
                                 <select name="system.role">
-                                    {{#select itemData.role}}
-                                        {{#each config.starshipRoleNames as |name id|}}
-                                            <option value="{{id}}">{{localize name}}</option>
-                                        {{/each}}
-                                    {{/select}}
+                                    {{selectOptions config.starshipRoleNames selected=itemData.role localize=true}}
                                 </select>
                             </div>
 

--- a/src/templates/items/starshipDriftEngine.hbs
+++ b/src/templates/items/starshipDriftEngine.hbs
@@ -26,7 +26,7 @@
                 <h3 class="bubble-header">{{ localize "SFRPG.ItemSheet.StarshipDriftEngine.Header" }}</h3>
 
                 <div class="bubble-info">
-                    
+
                     <div class="form-group" data-tooltip="<b>{{ localize "SFRPG.ItemSheet.StarshipDriftEngine.EngineRating" }}</b><br/>{{ localize "SFRPG.ItemSheet.StarshipDriftEngine.EngineRatingTooltip" }}">
                         <label>{{ localize "SFRPG.ItemSheet.StarshipDriftEngine.EngineRating" }}</label>
                         <div class="form-fields">
@@ -37,11 +37,7 @@
                     <div class="form-group" data-tooltip="<b>{{ localize "SFRPG.ItemSheet.StarshipDriftEngine.MaxSize" }}</b><br/>{{ localize "SFRPG.ItemSheet.StarshipDriftEngine.MaxSizeTooltip" }}">
                         <label>{{ localize "SFRPG.ItemSheet.StarshipDriftEngine.MaxSize" }}</label>
                         <select name="system.maxSize">
-                            {{#select itemData.maxSize}}
-                            {{#each config.starshipSizes as |name type|}}
-                            <option value="{{type}}">{{localize name}}</option>
-                            {{/each}}
-                            {{/select}}
+                            {{selectOptions config.starshipSizes selected=itemData.maxSize localize=true}}
                         </select>
                     </div>
 

--- a/src/templates/items/starshipFrame.hbs
+++ b/src/templates/items/starshipFrame.hbs
@@ -36,17 +36,13 @@
                         <h3 class="bubble-header">{{ localize "SFRPG.ItemSheet.StarshipFrame.Details.HeaderSpecs" }}</h3>
 
                         <div class="bubble-info">
-                            
+
                             {{!-- Size --}}
                             <div class="form-group" data-tooltip="{{ localize "SFRPG.ItemSheet.StarshipFrame.Details.SizeTooltip" }}">
                                 <label>{{ localize "SFRPG.ItemSheet.StarshipFrame.Details.Size" }}</label>
                                 <div class="form-fields">
                                     <select class="actor-size" name="system.size">
-                                        {{#select itemData.size}}
-                                        {{#each config.starshipSizes as |label size|}}
-                                            <option value="{{size}}">{{label}}</option>
-                                        {{/each}}
-                                        {{/select}}
+                                        {{selectOptions config.starshipSizes selected=itemData.size}}
                                     </select>
                                 </div>
                             </div>
@@ -56,11 +52,7 @@
                                 <label>{{ localize "SFRPG.ItemSheet.StarshipFrame.Details.Maneuverability" }}</label>
                                 <div class="form-fields">
                                     <select class="actor-size" name="system.maneuverability">
-                                        {{#select itemData.maneuverability}}
-                                        {{#each config.maneuverability as |label size|}}
-                                            <option value="{{size}}">{{label}}</option>
-                                        {{/each}}
-                                        {{/select}}
+                                        {{selectOptions config.maneuverability selected=itemData.maneuverability}}
                                     </select>
                                 </div>
                             </div>
@@ -96,7 +88,7 @@
                                     <input type="text" name="system.cost" value="{{itemData.cost}}" data-dtype="Number" />
                                 </div>
                             </div>
-                            
+
                         </div>
                     </div>
 
@@ -129,7 +121,7 @@
                                     <input type="text" name="system.damageThreshold.base" value="{{itemData.damageThreshold.base}}" data-dtype="Number" />
                                 </div>
                             </div>
-                            
+
                         </div>
                     </div>
 
@@ -143,7 +135,7 @@
                         <h3 class="bubble-header">{{ localize "SFRPG.ItemSheet.StarshipFrame.Details.WeaponMounts" }}</h3>
 
                         <div class="bubble-info">
-                            
+
                             {{!-- Forward Arc --}}
                             <div class="form-group input-select-select-select" data-tooltip="{{ localize "SFRPG.ItemSheet.StarshipFrame.Details.WeaponArcTooltip" }}">
                                 <label>{{ localize "SFRPG.ItemSheet.StarshipFrame.Details.WeaponArcForward" }}</label>
@@ -218,7 +210,7 @@
                                     <input type="text" name="system.weaponMounts.turret.spinalSlots" value="{{itemData.weaponMounts.turret.spinalSlots}}" data-dtype="Number" placeholder="0" />
                                 </div>
                             </div>
-                            
+
                         </div>
                     </div>
 

--- a/src/templates/items/starshipSensor.hbs
+++ b/src/templates/items/starshipSensor.hbs
@@ -39,17 +39,13 @@
                     <div class="form-group" data-tooltip="<b>{{ localize "SFRPG.ItemSheet.StarshipSensor.Range" }}</b><br/>{{ localize "SFRPG.ItemSheet.StarshipSensor.RangeTooltip" }}">
                         <label>{{ localize "SFRPG.ItemSheet.StarshipSensor.Range" }}</label>
                         <select name="system.range">
-                            {{#select itemData.range}}
-                            {{#each config.starshipWeaponRanges as |name type|}}
-                            <option value="{{type}}">{{localize name}}</option>
-                            {{/each}}
-                            {{/select}}
+                            {{selectOptions config.starshipWeaponRanges selected=itemData.range localize=true}}
                         </select>
                     </div>
 
                 </div>
             </div>
-            
+
             {{!-- Special Materials Template --}}
             {{> "systems/sfrpg/templates/items/parts/item-special-materials.hbs"}}
 

--- a/src/templates/items/starshipThruster.hbs
+++ b/src/templates/items/starshipThruster.hbs
@@ -26,16 +26,12 @@
                 <h3 class="bubble-header">{{ localize "SFRPG.ItemSheet.StarshipThruster.Header" }}</h3>
 
                 <div class="bubble-info">
-                    
+
                     {{!-- Supported Size --}}
                     <div class="form-group" data-tooltip="<b>{{ localize "SFRPG.ItemSheet.StarshipThruster.Size" }}</b><br/>{{ localize "SFRPG.ItemSheet.StarshipThruster.SizeTooltip" }}">
                         <label>{{ localize "SFRPG.ItemSheet.StarshipThruster.Size" }}</label>
                         <select name="system.supportedSize">
-                            {{#select itemData.supportedSize}}
-                            {{#each config.starshipSizes as |name type|}}
-                            <option value="{{type}}">{{localize name}}</option>
-                            {{/each}}
-                            {{/select}}
+                            {{selectOptions config.starshipSizes selected=itemData.supportedSize localize=true}}
                         </select>
                     </div>
 
@@ -67,7 +63,7 @@
                             </label>
                         </div>
                     </div>
-                    
+
                 </div>
             </div>
 
@@ -76,7 +72,7 @@
 
             <h4 class="section-header first"></h4>
 
-            
+
 
         </div>
 

--- a/src/templates/items/starshipWeapon.hbs
+++ b/src/templates/items/starshipWeapon.hbs
@@ -69,11 +69,7 @@
                                 <label>{{ localize "SFRPG.Items.Weapon.Type" }}</label>
                                 <div class="form-fields">
                                     <select name="system.weaponType">
-                                        {{#select itemData.weaponType}}
-                                        {{#each config.starshipWeaponTypes as |name type|}}
-                                        <option value="{{type}}">{{name}}</option>
-                                        {{/each}}
-                                        {{/select}}
+                                        {{selectOptions config.starshipWeaponTypes selected=itemData.weaponType}}
                                     </select>
                                 </div>
                             </div>
@@ -83,11 +79,7 @@
                                 <label>{{ localize "SFRPG.Items.ShipWeapon.WeaponClass" }}</label>
                                 <div class="form-fields">
                                     <select name="system.class">
-                                        {{#select itemData.class}}
-                                        {{#each config.starshipWeaponClass as |name type|}}
-                                        <option value="{{type}}">{{name}}</option>
-                                        {{/each}}
-                                        {{/select}}
+                                        {{selectOptions config.starshipWeaponClass selected=itemData.class}}
                                     </select>
                                 </div>
                             </div>
@@ -101,12 +93,8 @@
                                     </label>
                                     <span class="sep"> </span>
                                     <select name="system.mount.arc">
-                                        {{#select itemData.mount.arc}}
-                                        <option value="">{{localize "SFRPG.ItemSheet.StarshipWeapon.Unmounted"}}</option>
-                                        {{#each config.starshipArcs as |arc a|}}
-                                        <option value="{{a}}">{{arc}}</option>
-                                        {{/each}}
-                                        {{/select}}
+                                        {{selectOption "" "SFRPG.ItemSheet.StarshipWeapon.Unmounted" selected=itemData.mount.arc localize=true}}
+                                        {{selectOptions config.starshipArcs selected=itemData.mount.arc}}
                                     </select>
                                 </div>
                             </div>
@@ -153,7 +141,7 @@
 
                     {{!-- Special Materials Template --}}
                     {{> "systems/sfrpg/templates/items/parts/item-special-materials.hbs"}}
-                
+
                 </div>
 
                 {{!-- Attack & Damage Tab --}}
@@ -164,16 +152,12 @@
                         <h3 class="bubble-header">{{localize "SFRPG.Items.Weapon.Attack"}}</h3>
 
                         <div class="bubble-info">
-                            
+
                             {{!-- Action Target --}}
                             <div class="form-group select" {{createTippy title="SFRPG.Items.Action.ActionTarget.Title" subtitle="SFRPG.Items.Action.ActionTarget.Tooltip"}}>
                                 <label>{{ localize "SFRPG.Items.Action.ActionTarget.Title" }}</label>
                                 <select name="system.actionTarget">
-                                    {{#select itemData.actionTarget}}
-                                    {{#each config.actionTargetsStarship as |name type|}}
-                                    <option value="{{type}}">{{name}}</option>
-                                    {{/each}}
-                                    {{/select}}
+                                    {{selectOptions config.actionTargetsStarship selected=itemData.actionTarget}}
                                 </select>
                             </div>
 
@@ -182,11 +166,7 @@
                                 <label>{{ localize "SFRPG.Items.ShipWeapon.Range" }}</label>
                                 <div class="form-fields">
                                     <select name="system.range">
-                                        {{#select itemData.range}}
-                                        {{#each config.starshipWeaponRanges as |range r|}}
-                                        <option value="{{r}}">{{range}}</option>
-                                        {{/each}}
-                                        {{/select}}
+                                        {{selectOptions config.starshipWeaponRanges selected=itemData.range}}
                                     </select>
                                 </div>
                             </div>
@@ -198,7 +178,7 @@
                                     <input type="text" name="system.attackBonus" value="{{itemData.attackBonus}}" />
                                 </div>
                             </div>
-                            
+
                         </div>
                     </div>
 

--- a/src/templates/items/theme.hbs
+++ b/src/templates/items/theme.hbs
@@ -45,12 +45,7 @@
                         <label>{{ localize "SFRPG.Items.Theme.AbilityAdjustment" }}</label>
                         <div class="form-fields">
                             <select name="system.abilityMod.ability">
-                                {{#select itemData.abilityMod.ability}}
-                                <option value=""></option>
-                                {{#each config.abilities as |ability key|}}
-                                <option value="{{key}}">{{ability}}</option>
-                                {{/each}}
-                                {{/select}}
+                                {{selectOptions config.abilities selected=itemData.abilityMod.ability}}
                             </select>
                             <input type="text" name="system.abilityMod.mod" value="{{itemData.abilityMod.mod}}" data-dtype="Number" />
                         </div>
@@ -59,12 +54,7 @@
                     <div class="form-group">
                         <label>{{ localize "SFRPG.Items.Theme.Skill" }}</label>
                         <select name="system.skill">
-                            {{#select itemData.skill}}
-                            <option value=""></option>
-                            {{#each config.skills as |skill skl|}}
-                            <option value="{{skl}}">{{skill}}</option>
-                            {{/each}}
-                            {{/select}}
+                            {{selectOptions config.skills selected=itemData.skill}}
                         </select>
                     </div>
                 </div>

--- a/src/templates/items/upgrade.hbs
+++ b/src/templates/items/upgrade.hbs
@@ -44,12 +44,8 @@
                             <div class="form-group">
                                 <label>{{ localize "SFRPG.Items.Upgrade.AllowedArmorType" }}</label>
                                 <select name="system.allowedArmorType">
-                                    {{#select itemData.allowedArmorType}}
-                                    <option value="any">{{ localize "SFRPG.Items.Upgrade.Any" }}</option>
-                                    {{#each config.allowedArmorTypes as |allowedArmorType k|}}
-                                    <option value="{{k}}">{{allowedArmorType}}</option>
-                                    {{/each}}
-                                    {{/select}}
+                                    {{selectOption "any" "SFRPG.Items.Upgrade.Any" selected=itemData.allowedArmorType localize=true}}
+                                    {{selectOptions config.allowedArmorTypes selected=itemData.allowedArmorType}}
                                 </select>
                             </div>
                         </div>
@@ -81,7 +77,7 @@
                     {{> "systems/sfrpg/templates/items/parts/container-details.hbs" message="SFRPG.Items.Equipment.ContainerTooltip"}}
 
                 </div>
-                
+
             </section>
         </div>
 

--- a/src/templates/items/vehicleAttack.hbs
+++ b/src/templates/items/vehicleAttack.hbs
@@ -68,19 +68,11 @@
                         <div class="form-fields">
                             <input type="text" name="system.save.dc" value="{{itemData.save.dc}}" data-dtype="String" placeholder="{{placeholders.saveDC.formula}}"/>
                             <select name="system.save.type">
-                                {{#select itemData.save.type}}
-                                <option value=""></option>
-                                {{#each config.saves as |save s|}}
-                                <option value="{{s}}">{{save}}</option>
-                                {{/each}}
-                                {{/select}}
+                                {{selectOption "" "" selected=itemData.save.type}}
+                                {{selectOptions config.saves selected=itemData.save.type}}
                             </select>
                             <select name="system.save.descriptor">
-                                {{#select itemData.save.descriptor}}
-                                {{#each config.saveDescriptors as |descriptor k|}}
-                                <option value="{{k}}">{{descriptor}}</option>
-                                {{/each}}
-                                {{/select}}
+                                {{selectOptions config.saveDescriptors selected=itemData.save.descriptor}}
                             </select>
                         </div>
                     </div>

--- a/src/templates/items/weapon.hbs
+++ b/src/templates/items/weapon.hbs
@@ -40,11 +40,7 @@
                             <div class="form-group">
                                 <label>{{ localize "SFRPG.Items.Weapon.Type" }}</label>
                                 <select name="system.weaponType">
-                                    {{#select itemData.weaponType}}
-                                    {{#each config.weaponTypes as |name type|}}
-                                    <option value="{{type}}">{{name}}</option>
-                                    {{/each}}
-                                    {{/select}}
+                                    {{selectOptions config.weaponTypes selected=itemData.weaponType}}
                                 </select>
                             </div>
 
@@ -52,12 +48,8 @@
                             <div class="form-group">
                                 <label>{{ localize "SFRPG.Items.Weapon.Category" }}</label>
                                 <select name="system.weaponCategory">
-                                    {{#select itemData.weaponCategory}}
-                                    <option value="">Unspecified</option>
-                                    {{#each config.weaponCategories as |name type|}}
-                                    <option value="{{type}}">{{name}}</option>
-                                    {{/each}}
-                                    {{/select}}
+                                    {{selectOption "" "Unspecified" selected=itemData.weaponCategory}}
+                                    {{selectOptions config.weaponCategories selected=itemData.weaponCategory}}
                                 </select>
                             </div>
 

--- a/src/templates/items/weaponAccessory.hbs
+++ b/src/templates/items/weaponAccessory.hbs
@@ -36,11 +36,7 @@
                             <div class="form-group">
                                 <div class="form-fields">
                                     <select name="system.weaponType">
-                                        {{#select itemData.weaponType}}
-                                        {{#each config.weaponAccessoriesSupportedTypes as |name type|}}
-                                        <option value="{{type}}">{{localize name}}</option>
-                                        {{/each}}
-                                        {{/select}}
+                                        {{selectOptions config.weaponAccessoriesSupportedTypes selected=itemData.weaponType}}
                                     </select>
                                 </div>
                             </div>

--- a/src/templates/packs/document-browser.hbs
+++ b/src/templates/packs/document-browser.hbs
@@ -8,11 +8,7 @@
             <dl id="sorter">
                 <dt>{{localize "SFRPG.Browsers.ItemBrowser.BrowserSortByLabel"}}:</dt>
                 <dd><select class="sortingControl" name="sortorder">
-                    {{#select defaultSortMethod}}
-                    {{#each sortingMethods as |method id|}}
-                    <option value="{{id}}" {{#if method.selected}}selected{{/if}}>{{method.name}}</option>
-                    {{/each}}
-                    {{/select}}
+                    {{selectOptions sortingMethods selected=sortingMethod labelAttr="name"}}
                 </select></dd>
             </dl>
         </div>


### PR DESCRIPTION
I got sick of seeing the warnings in my development console, so I decided to do something about it. This should also close out the last item of #1291's checklist.

I chose to create a `{{selectOption}}` helper that would add ad hoc options with a similar API to `{{selectOptions}}`. `{{selectOption}}` could be avoided by hoisting the extra options into `config.js`, but that implies more sweeping changes than I wanted to commit to. The result is somewhat janky, and probably contradicts Foundry's recommendations, but it greatly eased the transition away from `{{#select}}` and permitted relatively minimal code changes.