### PR TITLE
Fix bug preventing combat type switch

### DIFF
--- a/src/module/combat/combat.js
+++ b/src/module/combat/combat.js
@@ -395,7 +395,7 @@ export class CombatSFRPG extends Combat {
         // Get an active GM to run events players may not have permissions to do.
         if (!game.users.activeGM?.isSelf) return;
 
-        if (!changed.flags?.sfrpg?.combatType) {
+        if (!changed.flags?.sfrpg?.combatType && options.eventData) {
             this._handleTimedEffects(options.eventData);
         }
     }

--- a/src/module/combat/combat.js
+++ b/src/module/combat/combat.js
@@ -395,7 +395,9 @@ export class CombatSFRPG extends Combat {
         // Get an active GM to run events players may not have permissions to do.
         if (!game.users.activeGM?.isSelf) return;
 
-        this._handleTimedEffects(options.eventData);
+        if (!changed.flags?.sfrpg?.combatType) {
+            this._handleTimedEffects(options.eventData);
+        }
     }
 
     /**

--- a/src/module/combat/combat.js
+++ b/src/module/combat/combat.js
@@ -395,7 +395,8 @@ export class CombatSFRPG extends Combat {
         // Get an active GM to run events players may not have permissions to do.
         if (!game.users.activeGM?.isSelf) return;
 
-        if (!changed.flags?.sfrpg?.combatType && options.eventData) {
+        // Handle timed events if the event that is occurring is phase/round/turn advance.
+        if (options.eventData) {
             this._handleTimedEffects(options.eventData);
         }
     }


### PR DESCRIPTION
Fixes an issue in 0.27 where clicking the combat type switch button would erroneously call the routine to handle timed effects and throw an error.