### PR TITLE
Starship Combat Initiative Fixes

### DIFF
--- a/src/module/combat/combat.js
+++ b/src/module/combat/combat.js
@@ -586,7 +586,7 @@ export class CombatSFRPG extends Combat {
 
     hasCombatantsWithoutInitiative() {
         for (const [index, combatant] of this.turns.entries()) {
-            if ((!this.settings.skipDefeated || !combatant.defeated) && !combatant.initiative) {
+            if ((!this.settings.skipDefeated || !combatant.defeated) && (combatant.initiative === undefined || combatant.initiative === null)) {
                 return true;
             }
         }

--- a/src/module/combat/combat.js
+++ b/src/module/combat/combat.js
@@ -710,6 +710,12 @@ export class CombatSFRPG extends Combat {
             const combatant = this.combatants.get(id);
             if ( !combatant?.isOwner ) return results;
 
+            // If starship combat and no pilot set initiative to 0
+            if (this.getCombatType() === "starship" && !combatant.actor.system.crew.useNPCCrew && combatant.actor.system.crew.pilot.actorIds.length === 0) {
+                updates.push({_id: id, initiative: 0});
+                continue;
+            }
+
             // Roll initiative
             const roll = await this._getInitiativeRoll(combatant, "");
             if (!roll) {


### PR DESCRIPTION
This fix allows having no pilot and also applies piloting bonus when rolling initiative
1) Set initiative to piloting bonus if no pilot
2) Include piloting bonus when rolling for initiative.