### PR TITLE
Fix default icons always applied on import from compendium

### DIFF
--- a/src/module/actor/actor.js
+++ b/src/module/actor/actor.js
@@ -199,7 +199,7 @@ export class ActorSFRPG extends Mix(Actor).with(ActorConditionsMixin, ActorCrewM
         }
 
         // Apply a default icon to the actor based on its type if it doesn't already have an icon selected
-        if (Object.values(SFRPG.foundryDefaultIcons).includes(data.img)) {
+        if (Object.values(SFRPG.foundryDefaultIcons).includes(this.img)) {
             if (Object.keys(SFRPG.defaultActorIcons).includes(this.type)) {
                 updates.img = ["systems/sfrpg/icons/default/", SFRPG.defaultActorIcons[this.type]].join("");
             }

--- a/src/module/actor/actor.js
+++ b/src/module/actor/actor.js
@@ -198,9 +198,11 @@ export class ActorSFRPG extends Mix(Actor).with(ActorConditionsMixin, ActorCrewM
             updates.items = [source];
         }
 
-        // Apply a default icon to the actor based on its type, if one has been chosen
-        if (Object.keys(SFRPG.defaultActorIcons).includes(this.type)) {
-            updates.img = ["systems/sfrpg/icons/default/", SFRPG.defaultActorIcons[this.type]].join("");
+        // Apply a default icon to the actor based on its type if it doesn't already have an icon selected
+        if (Object.values(SFRPG.foundryDefaultIcons).includes(data.img)) {
+            if (Object.keys(SFRPG.defaultActorIcons).includes(this.type)) {
+                updates.img = ["systems/sfrpg/icons/default/", SFRPG.defaultActorIcons[this.type]].join("");
+            }
         }
 
         this.updateSource(updates);

--- a/src/module/config.js
+++ b/src/module/config.js
@@ -2256,6 +2256,11 @@ SFRPG.enricherTypes = {
     "Template": TemplateEnricher
 };
 
+SFRPG.foundryDefaultIcons = {
+    "actor": "icons/svg/mystery-man.svg",
+    "item": "icons/svg/item-bag.svg"
+};
+
 SFRPG.defaultActorIcons = {
     "character": "astronaut-helmet.svg",
     "drone": "delivery-drone.svg",

--- a/src/module/item/item.js
+++ b/src/module/item/item.js
@@ -329,9 +329,11 @@ export class ItemSFRPG extends Mix(Item).with(ItemActivationMixin, ItemCapacityM
             }
         }
 
-        // Apply a default icon to the actor based on its type, if one has been chosen
-        if (Object.keys(SFRPG.defaultItemIcons).includes(this.type)) {
-            updates.img = ["systems/sfrpg/icons/default/", SFRPG.defaultItemIcons[this.type]].join("");
+        // Apply a default icon to the item based on its type if it doesn't already have an icon selected
+        if (Object.values(SFRPG.foundryDefaultIcons).includes(data.img)) {
+            if (Object.keys(SFRPG.defaultItemIcons).includes(this.type)) {
+                updates.img = ["systems/sfrpg/icons/default/", SFRPG.defaultItemIcons[this.type]].join("");
+            }
         }
 
         this.updateSource(updates);

--- a/src/module/item/item.js
+++ b/src/module/item/item.js
@@ -330,7 +330,7 @@ export class ItemSFRPG extends Mix(Item).with(ItemActivationMixin, ItemCapacityM
         }
 
         // Apply a default icon to the item based on its type if it doesn't already have an icon selected
-        if (Object.values(SFRPG.foundryDefaultIcons).includes(data.img)) {
+        if (Object.values(SFRPG.foundryDefaultIcons).includes(this.img)) {
             if (Object.keys(SFRPG.defaultItemIcons).includes(this.type)) {
                 updates.img = ["systems/sfrpg/icons/default/", SFRPG.defaultItemIcons[this.type]].join("");
             }


### PR DESCRIPTION
The original implementation of the default icons feature had a bug which caused a default icon to always be applied to an actor or item imported from a compendium, even if it had it's own unique icon selected. This update changes the behavior to first check if the actor/item's icon is the default mystery man or item bag, and only replace the icon if that is the case.