### PR TITLE
Remove explicit checks for dos newlines.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,7 +6,6 @@ root = true
 [*]
 indent_style = space
 indent_size = 4
-end_of_line = crlf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -13,7 +13,6 @@
   "rules": {
     "indent": ["error", 4, {"SwitchCase": 1}],
     "keyword-spacing": ["error"],
-    "linebreak-style": ["error", "windows"],
     "semi": ["error", "always"],
     "no-unused-vars": "warn",
     "camelcase": "warn",


### PR DESCRIPTION
Git for Windows, by default, will automatically convert crlf line endings to lf for internal representation, then back again on checkout. (See the [`core.autocrlf`](https://git-scm.com/docs/git-config#Documentation/git-config.txt-coreautocrlf) option.) On my Linux machine the files are checked out with lf endings. My editor then reads `.editorconfig`, learns that it should use dos endings and writes the file with crlf endings. I then run `git diff` and learn that I have edited the entire file.

Without line end guidance, tools should default to using the OS's native line end, and then the repo leans on `autocrlf` to make that Just Work™.

As a note, to view info about the internal representations of the files, use `git ls-files --eol`.

Fixes #1392