### PR TITLE
choice-dialog.hbs fix for array

### DIFF
--- a/src/templates/apps/choice-dialog.hbs
+++ b/src/templates/apps/choice-dialog.hbs
@@ -5,7 +5,7 @@
         <label>{{capitalize choice.name}}{{#if choice.label}}: {{choice.label}}{{/if}}</label>
         <div class="form-fields">
             <select id="{{id}}">
-                {{selectOptions choice.options selected=choice.default localize=true}}
+                {{selectOptions choice.options selected=choice.default valueAttr="label" localize=true}}
             </select>
         </div>
     </div>


### PR DESCRIPTION
In the update for V12 using the selectOptions from https://foundryvtt.com/api/classes/client.HandlebarsHelpers.html#selectOptions the api does not play nice with existing code if you just pass an array of strings and pass that array as the choices.

This fix uses the valueAttr (documentation reads as nameAttr but is deprecated) to specify the value of the choices should also be the label/string used for display rather than the index  of the choice.

This makes it work again with all the relevant code
1) starship actions
2) npc crew
3) critical damage effect editing