### PR TITLE
Define modifiers as SFRPGModifier

### DIFF
--- a/src/module/item/sheet.js
+++ b/src/module/item/sheet.js
@@ -1,4 +1,5 @@
 import { SFRPG } from "../config.js";
+import SFRPGModifier from "../modifiers/modifier.js";
 import RollContext from "../rolls/rollcontext.js";
 
 const itemSizeArmorClassModifier = {
@@ -879,7 +880,10 @@ export class ItemSheetSFRPG extends ItemSheet {
         const target = $(event.currentTarget);
         const modifierId = target.closest('.item.modifier').data('modifierId');
 
-        const modifiers = this.item.system.modifiers;
+        const modifiers = this.item.system.modifiers.map(mod => {
+            return new SFRPGModifier(mod, {parent: this.item});
+        });
+
         const modifier = modifiers.find(mod => mod._id === modifierId);
 
         return modifier.toggle();

--- a/src/module/item/sheet.js
+++ b/src/module/item/sheet.js
@@ -269,6 +269,12 @@ export class ItemSheetSFRPG extends ItemSheet {
             }
         }
 
+        // Similar to actor-modifiers.getAllModifiers() 
+        // we need to enforce the type of the modifiers to be SFRPGModifier
+        this.item.system.modifiers = this.item.system.modifiers.map(mod => {
+            return new SFRPGModifier(mod, {parent: this.item});
+        });
+
         data.modifiers = this.item.system.modifiers;
 
         data.hasSpeed = this.item.system.weaponType === "tracking" || (this.item.system.special && this.item.system.special["limited"]);
@@ -880,10 +886,7 @@ export class ItemSheetSFRPG extends ItemSheet {
         const target = $(event.currentTarget);
         const modifierId = target.closest('.item.modifier').data('modifierId');
 
-        const modifiers = this.item.system.modifiers.map(mod => {
-            return new SFRPGModifier(mod, {parent: this.item});
-        });
-
+        const modifiers = this.item.system.modifiers;
         const modifier = modifiers.find(mod => mod._id === modifierId);
 
         return modifier.toggle();

--- a/src/module/modifiers/modifier.js
+++ b/src/module/modifiers/modifier.js
@@ -194,9 +194,7 @@ export default class SFRPGModifier extends foundry.abstract.DataModel {
     }
 
     async toggle(active = null) {
-        const parentMods = this.parent.system.modifiers.map(mod => {
-            return new SFRPGModifier(mod, {parent: this.parent});
-        });
+        const parentMods = this.parent.system.modifiers;
 
         const modInParent = parentMods.find(mod => mod._id === this._id);
         modInParent.updateSource({enabled: active ?? !modInParent.enabled});

--- a/src/module/modifiers/modifier.js
+++ b/src/module/modifiers/modifier.js
@@ -194,7 +194,9 @@ export default class SFRPGModifier extends foundry.abstract.DataModel {
     }
 
     async toggle(active = null) {
-        const parentMods = this.parent.system.modifiers;
+        const parentMods = this.parent.system.modifiers.map(mod => {
+            return new SFRPGModifier(mod, {parent: this.parent});
+        });
 
         const modInParent = parentMods.find(mod => mod._id === this._id);
         modInParent.updateSource({enabled: active ?? !modInParent.enabled});


### PR DESCRIPTION
When not contained on a parent actor modifiers were throwing errors when attempting to toggle the modifier state using the checkbox.

With this change the toggle functionality should work when on a standalone item or in the compendium.