### PR TITLE
Also apply allModifiers against static dc's.

### DIFF
--- a/src/module/rules/actions/item/calculate-save-dc.js
+++ b/src/module/rules/actions/item/calculate-save-dc.js
@@ -28,14 +28,6 @@ export default function(engine) {
                     if (abilityKey) {
                         if (itemData.type === "spell") {
                             dcFormula = `10 + @item.level + @owner.abilities.${abilityKey}.mod`;
-
-                            // Get owner spell save dc modifiers and append to roll
-                            const allModifiers = actor?.getAllModifiers();
-                            if (allModifiers) {
-                                for (const modifier of allModifiers.filter(x => x.enabled && x.effectType === "spell-save-dc")) {
-                                    dcFormula += ` + ${modifier.modifier}[${modifier.name}]`;
-                                }
-                            }
                         } else if (itemData.type === "feat") {
                             dcFormula = `10 + floor(@owner.details.level.value / 2) + @owner.abilities.${abilityKey}.mod`;
                         } else {
@@ -46,6 +38,16 @@ export default function(engine) {
                             dcFormula = `@owner.attributes.baseSpellDC.value + @item.level`;
                         } else {
                             dcFormula = `@owner.attributes.abilityDC.value`;
+                        }
+                    }
+                }
+
+                if (itemData.type === "spell") {
+                    // Get owner spell save dc modifiers and append to roll
+                    const allModifiers = actor?.getAllModifiers();
+                    if (allModifiers) {
+                        for (const modifier of allModifiers.filter(x => x.enabled && x.effectType === "spell-save-dc")) {
+                            dcFormula += ` + ${modifier.modifier}[${modifier.name}]`;
                         }
                     }
                 }


### PR DESCRIPTION
When spells that specify a spell DC are on actors that have modifiers the modifiers do not get applied.

Ex. An NPC with spells with dc's of 15 if you apply a modifier from for example Ego Whip to that NPC with a constant modifier of -2 the DC's of the spells stay at 15. 

This change instead adds allModifiers with a type of spell-save-dc to spell dc's regardless of if the DC is specified or not.