### PR TITLE
Replace Handlebars config variable with helper

### DIFF
--- a/src/module/actor/sheet/base.js
+++ b/src/module/actor/sheet/base.js
@@ -76,7 +76,6 @@ export class ActorSheetSFRPG extends ActorSheet {
             isDrone: this.document.type === 'drone',
             isNPC: this.document.type === 'npc' || this.document.type === 'npc2',
             isHazard: this.document.type === 'hazard',
-            config: CONFIG.SFRPG
         };
 
         data.items = [...this.actor.items.values()];

--- a/src/module/apps/edit-skill-dialog.js
+++ b/src/module/apps/edit-skill-dialog.js
@@ -34,7 +34,6 @@ export class AddEditSkillDialog extends Dialog {
         const html = await renderTemplate("systems/sfrpg/templates/apps/add-edit-skill.hbs", {
             skill: skill,
             hasSubName,
-            config: CONFIG.SFRPG,
             canDelete: (skillId.startsWith("pro") && skillId !== "pro") && (game.user.isGM || isOwner) && isEdit,
             isEdit,
             isNpc

--- a/src/module/apps/item-collection-sheet.js
+++ b/src/module/apps/item-collection-sheet.js
@@ -81,7 +81,6 @@ export class ItemCollectionSheet extends DocumentSheet {
      */
     getData() {
         const data = super.getData();
-        data.config = CONFIG.SFRPG;
         data.isCharacter = true;
         data.isOwner = game.user.isGM;
         data.isGM = game.user.isGM;

--- a/src/module/apps/modifier-app.js
+++ b/src/module/apps/modifier-app.js
@@ -77,7 +77,6 @@ export default class SFRPGModifierApplication extends FormApplication {
             options: this.options,
             editable: this.isEditable,
             cssClass: this.target.isOwner ? "editable" : "locked",
-            config: CONFIG.SFRPG
         };
 
         return data;

--- a/src/module/apps/movement-config.js
+++ b/src/module/apps/movement-config.js
@@ -25,10 +25,6 @@ export class ActorMovementConfig extends DocumentSheet {
 
     /** @override */
     getData(options) {
-        this.document.config = {
-            speeds: CONFIG.SFRPG.speeds,
-            flightManeuverability: CONFIG.SFRPG.flightManeuverability
-        };
         return this.document;
     }
 }

--- a/src/module/apps/npc-skill-toggle-dialog.js
+++ b/src/module/apps/npc-skill-toggle-dialog.js
@@ -36,7 +36,6 @@ export class NpcSkillToggleDialog extends Dialog {
         }
 
         const html = await renderTemplate("systems/sfrpg/templates/apps/npc-skill-toggle.hbs", {
-            config: CONFIG.SFRPG,
             skillNames,
             skills
         });

--- a/src/module/apps/roll-dialog.js
+++ b/src/module/apps/roll-dialog.js
@@ -93,7 +93,6 @@ export default class RollDialog extends Dialog {
         const data = await super.getData();
         data.formula = this.formula;
         data.rollMode = this.rollMode;
-        data.rollModes = CONFIG.Dice.rollModes;
         data.additionalBonus = this.additionalBonus;
         data.availableModifiers = foundry.utils.deepClone(this.availableModifiers) || [];
         data.hasModifiers = data.availableModifiers.length > 0;

--- a/src/module/apps/spell-cast-dialog.js
+++ b/src/module/apps/spell-cast-dialog.js
@@ -142,7 +142,6 @@ export class SpellCastDialog extends Dialog {
             hasSlots: spellLevels.length > 0,
             consume: spellLevels.length > 0,
             spellLevels,
-            config: CONFIG.SFRPG,
             includedClasses: includedClasses
         });
 

--- a/src/module/chat/chatbox.js
+++ b/src/module/chat/chatbox.js
@@ -64,7 +64,6 @@ export default class SFRPGCustomChatMessage {
             rollType: data.rollType,
             rollNotes: data.htmlData?.find(x => x.name === "rollNotes")?.value,
             type: CONST.CHAT_MESSAGE_STYLES.OTHER,
-            config: CONFIG.SFRPG,
             tokenImg: actor.token?.img || actor.img,
             actorId: actor.id,
             tokenId: this.getToken(actor),

--- a/src/module/classes/counter-management-windows.js
+++ b/src/module/classes/counter-management-windows.js
@@ -24,7 +24,6 @@ export class CounterManagementWindows extends Dialog {
             classes: targetClasses,
             actorId:actorId,
             combatantId:combatantId,
-            config: CONFIG.SFRPG
         });
 
         return new Promise((resolve, reject) => {

--- a/src/module/handlebars.js
+++ b/src/module/handlebars.js
@@ -273,4 +273,39 @@ export function setupHandlebars() {
         const safeLabel = Handlebars.escapeExpression(options.hash.localize? game.i18n.localize(label): label);
         return new Handlebars.SafeString(`<option ${tagParams}>${safeLabel}</option>`);
     });
+
+    /**
+     * Look up a sequence of properties.
+     *
+     * @param {object} root     Topmost object.
+     * @param {object} hbsOpts  The Handlebars helper options parameter.
+     * @param {object} props    Sequence of properties (if any) to look up.
+     */
+    function configHelper(root, hbsOpts, ...props) {
+        let result = root;
+        for (const prop of props) {
+            result = foundry.utils.getProperty(result, prop);
+        }
+        return result;
+    }
+
+    /**
+     * Utility helper to get global config.
+     *
+     * Accepts any number (including zero) arguments, which will be recursively looked up starting from `CONFIG`.
+     */
+    Handlebars.registerHelper('config', function(...args) {
+        const options = args.pop();
+        return configHelper(CONFIG, options, ...args);
+    });
+
+    /**
+     * Utility helper to get global SFRPG config. Equivalent to `(config "SFRPG" ...)`
+     *
+     * Accepts any number (including zero) arguments, which will be recursively looked up starting from `CONFIG.SFRPG`.
+     */
+    Handlebars.registerHelper('sfrpg', function(...args) {
+        const options = args.pop();
+        return configHelper(CONFIG.SFRPG, options, ...args);
+    });
 }

--- a/src/module/item/sheet.js
+++ b/src/module/item/sheet.js
@@ -115,9 +115,6 @@ export class ItemSheetSFRPG extends ItemSheet {
         data.actor = this.document.parent;
         data.labels = this.item.labels;
 
-        // Include CONFIG values
-        data.config = CONFIG.SFRPG;
-
         // Item Type, Status, and Details
         data.itemType = game.i18n.format(`TYPES.Item.${data.item.type}`);
         data.itemStatus = this._getItemStatus();

--- a/src/templates/actors/npc2-sheet.hbs
+++ b/src/templates/actors/npc2-sheet.hbs
@@ -23,7 +23,7 @@
                     </div>
                 </div>
                 {{#if combatRoleImage}}
-                <img class="combat-role" src="{{combatRoleImage}}" alt="{{lookup config.combatRoles system.details.combatRole}}" {{createTippy title=(lookup config.combatRoles system.details.combatRole) subtitle=(lookup config.combatRolesDescriptions system.details.combatRole)}}>
+                <img class="combat-role" src="{{combatRoleImage}}" alt="{{sfrpg "combatRoles" system.details.combatRole}}" {{createTippy title=(sfrpg "combatRoles" system.details.combatRole) subtitle=(sfrpg "combatRolesDescriptions" system.details.combatRole)}}>
                 {{/if}}
             </div>
             <ul class="summary-row1">

--- a/src/templates/actors/parts/actor-inventory.hbs
+++ b/src/templates/actors/parts/actor-inventory.hbs
@@ -8,7 +8,7 @@
         <label class="denomination" data-tooltip="{{localize "SFRPG.ActorSheet.Inventory.ItemValue.Tooltip"}}">{{localize "SFRPG.ActorSheet.Inventory.ItemValue.Label"}}</label>
         <label class="denomination currency-value" {{createTippy title="SFRPG.ActorSheet.Inventory.ItemValue.Label" subtitle="SFRPG.ActorSheet.Inventory.ItemValue.Tooltip" tooltips=system.wealth.tooltip}}>{{i18nNumberFormat system.wealth.total}}</label>
         {{#each system.currency as |v k|}}
-        <label class="denomination {{k}}">{{ lookup ../config.currencies k }}</label>
+        <label class="denomination {{k}}">{{sfrpg "currencies" k}}</label>
         <input type="text" name="system.currency.{{k}}" value="{{v}}" data-dtype="Number"/>
         {{/each}}
     </ol>

--- a/src/templates/actors/parts/actor-modifiers.hbs
+++ b/src/templates/actors/parts/actor-modifiers.hbs
@@ -8,8 +8,8 @@
     <div class="tab {{section.dataset.subtab}} {{#unless section.isConditions}}flexrow{{else}}flexcol{{/unless}}" data-group="modifiers" data-tab="{{section.dataset.subtab}}">
         {{#if section.isConditions}}
         <div class="form-group stacked conditions">
-            {{#each ../config.conditionTypes as |condition name|}}
-            <label class="checkbox" data-tooltip="<strong>{{condition}}</strong><br><br>{{localize (lookup (lookup ../../config.conditions name) "tooltip")}}">
+            {{#each (sfrpg "conditionTypes") as |condition name|}}
+            <label class="checkbox" data-tooltip="<strong>{{condition}}</strong><br><br>{{localize (sfrpg "conditions" name "tooltip")}}">
                 <input type="checkbox"
                     class="condition {{name}}"
                     data-condition="{{name}}"
@@ -84,61 +84,61 @@
                         {{/if}}
                     </div>
                     <div class="item-detail modifier-type">
-                        {{lookup ../../config.modifierTypes modifier.type}}
+                        {{sfrpg "modifierTypes" modifier.type}}
                     </div>
                     <div class="item-detail modifier-effect-type">
-                        {{lookup ../../config.modifierEffectTypes modifier.effectType}}
+                        {{sfrpg "modifierEffectTypes" modifier.effectType}}
                     </div>
                     <div class="item-detail modifier-value-affected">
                         {{#if (eq modifier.effectType "ac")}}
-                            {{lookup ../../config.modifierArmorClassAffectedValues modifier.valueAffected}}
+                            {{sfrpg "modifierArmorClassAffectedValues" modifier.valueAffected}}
                         {{else if (eq modifier.effectType "acp")}}
-                            {{lookup ../../config.acpEffectingArmorType modifier.valueAffected}}
+                            {{sfrpg "acpEffectingArmorType" modifier.valueAffected}}
                         {{else if (eq modifier.effectType "ability-skills")}}
-                            {{lookup ../../config.abilities modifier.valueAffected}}
+                            {{sfrpg "abilities" modifier.valueAffected}}
                         {{else if (eq modifier.effectType "ability-check")}}
-                            {{lookup ../../config.abilities modifier.valueAffected}}
+                            {{sfrpg "abilities" modifier.valueAffected}}
                         {{else if (eq modifier.effectType "ability-score")}}
-                            {{lookup ../../config.abilities modifier.valueAffected}}
+                            {{sfrpg "abilities" modifier.valueAffected}}
                         {{else if (eq modifier.effectType "skill")}}
-                            {{lookup ../../config.skills modifier.valueAffected}}
+                            {{sfrpg "skills" modifier.valueAffected}}
                         {{else if (eq modifier.effectType "skill-ranks")}}
-                            {{lookup ../../config.skills modifier.valueAffected}}
+                            {{sfrpg "skills" modifier.valueAffected}}
                         {{else if (eq modifier.effectType "save")}}
                             {{#if (eq modifier.valueAffected "highest")}}
                                 {{localize "SFRPG.ModifierSaveHighest"}}
                             {{else if (eq modifier.valueAffected "lowest")}}
                                 {{localize "SFRPG.ModifierSaveLowest"}}
                             {{else}}
-                                {{lookup ../../config.saves modifier.valueAffected}}
+                                {{sfrpg "saves" modifier.valueAffected}}
                             {{/if}}
                         {{else if (eq modifier.effectType "weapon-attacks")}}
-                            {{lookup ../../config.weaponTypes modifier.valueAffected}}
+                            {{sfrpg "weaponTypes" modifier.valueAffected}}
                         {{else if (eq modifier.effectType "weapon-property-attacks")}}
-                            {{lookup ../../config.weaponProperties modifier.valueAffected}}
+                            {{sfrpg "weaponProperties" modifier.valueAffected}}
                         {{else if (eq modifier.effectType "weapon-category-attacks")}}
-                            {{lookup ../../config.weaponCategories modifier.valueAffected}}
+                            {{sfrpg "weaponCategories" modifier.valueAffected}}
                         {{else if (eq modifier.effectType "weapon-damage")}}
-                            {{lookup ../../config.weaponTypes modifier.valueAffected}}
+                            {{sfrpg "weaponTypes" modifier.valueAffected}}
                         {{else if (eq modifier.effectType "weapon-property-damage")}}
-                            {{lookup ../../config.weaponProperties modifier.valueAffected}}
+                            {{sfrpg "weaponProperties" modifier.valueAffected}}
                         {{else if (eq modifier.effectType "weapon-category-damage")}}
-                            {{lookup ../../config.weaponCategories modifier.valueAffected}}
+                            {{sfrpg "weaponCategories" modifier.valueAffected}}
                         {{else if (eq modifier.effectType "specific-speed")}}
-                            {{lookup ../../config.speeds modifier.valueAffected}}
+                            {{sfrpg "speeds" modifier.valueAffected}}
                         {{else if (eq modifier.effectType "actor-resource")}}
                             <h4>{{~modifier.valueAffected~}}</h4>
                         {{else if (eq modifier.effectType "damage-reduction")}}
                             {{#if (eq modifier.valueAffected "custom")}}
                                 {{modifier.notes}}
                             {{else}}
-                                {{lookup ../../config.damageReductionTypes modifier.valueAffected}}
+                                {{sfrpg "damageReductionTypes" modifier.valueAffected}}
                             {{/if}}
                         {{else if (eq modifier.effectType "energy-resistance")}}
                             {{#if (eq modifier.valueAffected "custom")}}
                                 {{modifier.notes}}
                             {{else}}
-                                {{lookup ../../config.energyResistanceTypes modifier.valueAffected}}
+                                {{sfrpg "energyResistanceTypes" modifier.valueAffected}}
                             {{/if}}
                         {{else}}
                         {{!-- Nothing --}}

--- a/src/templates/actors/parts/actor-movement-element.hbs
+++ b/src/templates/actors/parts/actor-movement-element.hbs
@@ -31,7 +31,7 @@
         {{else if (eq system.attributes.speed.mainMovement "climbing")}}
             {{ localize "SFRPG.ActorSheet.Attributes.Speed.Types.Climbing" }}
         {{else if (eq system.attributes.speed.mainMovement "flying")}}
-            {{ localize "SFRPG.ActorSheet.Attributes.Speed.Types.Flying" }} ({{lookup config.flightManeuverability system.attributes.speed.flying.maneuverability}})
+            {{ localize "SFRPG.ActorSheet.Attributes.Speed.Types.Flying" }} ({{sfrpg "flightManeuverability" system.attributes.speed.flying.maneuverability}})
         {{else if (eq system.attributes.speed.mainMovement "swimming")}}
             {{ localize "SFRPG.ActorSheet.Attributes.Speed.Types.Swimming" }}
         {{else if (eq system.attributes.speed.mainMovement "special")}}
@@ -52,7 +52,7 @@
             <li>{{ localize "SFRPG.ActorSheet.Attributes.Speed.Types.Climbing" }}: <span>{{system.attributes.speed.climbing.value}}</span> {{ localize "SFRPG.Units.Speed" }}</li>
         {{/if}}
         {{#if (gt system.attributes.speed.flying.value 0)}}
-            <li>{{ localize "SFRPG.ActorSheet.Attributes.Speed.Types.Flying" }} ({{lookup config.flightManeuverability system.attributes.speed.flying.maneuverability}}): <span>{{system.attributes.speed.flying.value}}</span> {{ localize "SFRPG.Units.Speed" }}</li>
+            <li>{{ localize "SFRPG.ActorSheet.Attributes.Speed.Types.Flying" }} ({{sfrpg "flightManeuverability" system.attributes.speed.flying.maneuverability}}): <span>{{system.attributes.speed.flying.value}}</span> {{ localize "SFRPG.Units.Speed" }}</li>
         {{/if}}
         {{#if (gt system.attributes.speed.swimming.value 0)}}
             <li>{{ localize "SFRPG.ActorSheet.Attributes.Speed.Types.Swimming" }}: <span>{{system.attributes.speed.swimming.value}}</span> {{ localize "SFRPG.Units.Speed" }}</li>

--- a/src/templates/actors/parts/actor-spellbook.hbs
+++ b/src/templates/actors/parts/actor-spellbook.hbs
@@ -3,7 +3,7 @@
         <label><h4 class="attribute-name box-title">{{localize "SFRPG.SpellBook.SpellCastingAbility"}}</h4></label>
         <select name="system.attributes.spellcasting" data-type="String">
             {{selectOption "" "SFRPG.SpellBook.AttributesNone" selected=system.attributes.spellcasting localize=true}}
-            {{selectOptions config.abilities selected=system.attributes.spellcasting}}
+            {{selectOptions (sfrpg "abilities") selected=system.attributes.spellcasting}}
         </select>
     </div>
 </div>

--- a/src/templates/actors/parts/actor-traits.hbs
+++ b/src/templates/actors/parts/actor-traits.hbs
@@ -4,7 +4,7 @@
         <label>{{localize "SFRPG.CombatRoles.Label"}}</label>
         <select class="npc-combat-role" name="system.details.combatRole">
             {{selectOption "" "" selected=system.details.combatRole}}
-            {{selectOptions config.combatRoles selected=system.details.combatRole}}
+            {{selectOptions (sfrpg "combatRoles") selected=system.details.combatRole}}
         </select>
     </div>
     {{/if}}
@@ -12,7 +12,7 @@
         <label>{{localize "SFRPG.Size"}}</label>
         {{#if (not isDrone)}}
         <select class="actor-size" name="system.traits.size">
-            {{selectOptions config.actorSizes selected=system.traits.size}}
+            {{selectOptions (sfrpg "actorSizes") selected=system.traits.size}}
         </select>
         {{else}}
         <span class="value">{{system.traits.size}}</span>
@@ -24,7 +24,7 @@
         <label>{{localize "SFRPG.KeyAbility"}}</label>
         <select class="actor-keyability" name="system.attributes.keyability">
             {{selectOption "" "Choose One" selected=system.attributes.keyability}}
-            {{selectOptions config.abilities selected=system.attributes.keyability}}
+            {{selectOptions (sfrpg "abilities") selected=system.attributes.keyability}}
         </select>
     </div>
     {{/if}}
@@ -119,8 +119,8 @@
                 {{#if (eq negatedBy "")}}
                     -
                 {{else}}
-                    {{#if (lookup ../config.damageReductionTypes negatedBy)}}
-                        {{lookup ../config.damageReductionTypes negatedBy}}
+                    {{#if (sfrpg "damageReductionTypes" negatedBy)}}
+                        {{sfrpg "damageReductionTypes" negatedBy}}
                     {{else}}
                         {{negatedBy}}
                     {{/if}}
@@ -141,7 +141,7 @@
             {{#if (eq damageType "custom")}}
             <li class="tag {{damageType}}">{{erModifier.source.notes}} {{erModifier.value}}</li>
             {{else}}
-                <li class="tag {{damageType}}">{{lookup ../config.energyResistanceTypes damageType}} {{erModifier.value}}</li>
+                <li class="tag {{damageType}}">{{sfrpg "energyResistanceTypes" damageType}} {{erModifier.value}}</li>
             {{/if}}
         {{/each}}
         </ul>

--- a/src/templates/actors/starship-sheet-full.hbs
+++ b/src/templates/actors/starship-sheet-full.hbs
@@ -396,25 +396,25 @@
                         <div class="form-group">
                             <label for="system.attributes.systems.lifeSupport.value">{{localize "SFRPG.StarshipSheet.Critical.Systems.LifeSupport"}} <a class="critical-edit" data-system="lifeSupport" title="{{localize "SFRPG.StarshipSheet.Critical.Edit"}}"><i class="fas fa-edit"></i></a></label>
                             <select name="system.attributes.systems.lifeSupport.value">
-                                {{selectOptions config.starshipSystemStatus selected=system.attributes.systems.lifeSupport.value}}
+                                {{selectOptions (sfrpg "starshipSystemStatus") selected=system.attributes.systems.lifeSupport.value}}
                             </select>
                         </div>
                         <div class="form-group">
                             <label for="system.attributes.systems.sensors.value">{{localize "SFRPG.StarshipSheet.Critical.Systems.Sensors"}} <a class="critical-edit" data-system="sensors" title="{{localize "SFRPG.StarshipSheet.Critical.Edit"}}"><i class="fas fa-edit"></i></a></label>
                             <select name="system.attributes.systems.sensors.value">
-                                {{selectOptions config.starshipSystemStatus selected=system.attributes.systems.sensors.value}}
+                                {{selectOptions (sfrpg "starshipSystemStatus") selected=system.attributes.systems.sensors.value}}
                             </select>
                         </div>
                         <div class="form-group">
                             <label for="system.attributes.systems.engines.value">{{localize "SFRPG.StarshipSheet.Critical.Systems.Engines"}} <a class="critical-edit" data-system="engines" title="{{localize "SFRPG.StarshipSheet.Critical.Edit"}}"><i class="fas fa-edit"></i></a></label>
                             <select name="system.attributes.systems.engines.value">
-                                {{selectOptions config.starshipSystemStatus selected=system.attributes.systems.engines.value}}
+                                {{selectOptions (sfrpg "starshipSystemStatus") selected=system.attributes.systems.engines.value}}
                             </select>
                         </div>
                         <div class="form-group">
                             <label for="system.attributes.systems.powerCore.value">{{localize "SFRPG.StarshipSheet.Critical.Systems.PowerCore"}} <a class="critical-edit" data-system="powerCore" title="{{localize "SFRPG.StarshipSheet.Critical.Edit"}}"><i class="fas fa-edit"></i></a></label>
                             <select name="system.attributes.systems.powerCore.value">
-                                {{selectOptions config.starshipSystemStatus selected=system.attributes.systems.powerCore.value}}
+                                {{selectOptions (sfrpg "starshipSystemStatus") selected=system.attributes.systems.powerCore.value}}
                             </select>
                         </div>
                     </div>
@@ -422,25 +422,25 @@
                         <div class="form-group">
                             <label for="system.attributes.systems.weaponsArrayForward.value">{{localize "SFRPG.StarshipSheet.Critical.Systems.WeaponsArrayForward"}} <a class="critical-edit" data-system="weaponsArrayForward" title="{{localize "SFRPG.StarshipSheet.Critical.Edit"}}"><i class="fas fa-edit"></i></a></label>
                             <select name="system.attributes.systems.weaponsArrayForward.value">
-                                {{selectOptions config.starshipSystemStatus selected=system.attributes.systems.weaponsArrayForward.value}}
+                                {{selectOptions (sfrpg "starshipSystemStatus") selected=system.attributes.systems.weaponsArrayForward.value}}
                             </select>
                         </div>
                         <div class="form-group">
                             <label for="system.attributes.systems.weaponsArrayPort.value">{{localize "SFRPG.StarshipSheet.Critical.Systems.WeaponsArrayPort"}} <a class="critical-edit" data-system="weaponsArrayPort" title="{{localize "SFRPG.StarshipSheet.Critical.Edit"}}"><i class="fas fa-edit"></i></a></label>
                             <select name="system.attributes.systems.weaponsArrayPort.value">
-                                {{selectOptions config.starshipSystemStatus selected=system.attributes.systems.weaponsArrayPort.value}}
+                                {{selectOptions (sfrpg "starshipSystemStatus") selected=system.attributes.systems.weaponsArrayPort.value}}
                             </select>
                         </div>
                         <div class="form-group">
                             <label for="system.attributes.systems.weaponsArrayStarboard.value">{{localize "SFRPG.StarshipSheet.Critical.Systems.WeaponsArrayStarboard"}} <a class="critical-edit" data-system="weaponsArrayStarboard" title="{{localize "SFRPG.StarshipSheet.Critical.Edit"}}"><i class="fas fa-edit"></i></a></label>
                             <select name="system.attributes.systems.weaponsArrayStarboard.value">
-                                {{selectOptions config.starshipSystemStatus selected=system.attributes.systems.weaponsArrayStarboard.value}}
+                                {{selectOptions (sfrpg "starshipSystemStatus") selected=system.attributes.systems.weaponsArrayStarboard.value}}
                             </select>
                         </div>
                         <div class="form-group">
                             <label for="system.attributes.systems.weaponsArrayAft.value">{{localize "SFRPG.StarshipSheet.Critical.Systems.WeaponsArrayAft"}} <a class="critical-edit" data-system="WeaponsArrayAft" title="{{localize "SFRPG.StarshipSheet.Critical.Edit"}}"><i class="fas fa-edit"></i></a></label>
                             <select name="system.attributes.systems.weaponsArrayAft.value">
-                                {{selectOptions config.starshipSystemStatus selected=system.attributes.systems.weaponsArrayAft.value}}
+                                {{selectOptions (sfrpg "starshipSystemStatus") selected=system.attributes.systems.weaponsArrayAft.value}}
                             </select>
                         </div>
                     </div>
@@ -549,7 +549,7 @@
             <ol class="crew-list">
                 {{#each system.crew.npcData as |role roleId|}}
                 <li class="flexrow crew-header" data-role="{{roleId}}">
-                    <h3 class="crew-name noborder flexrow">{{ localize (lookup ../config.starshipRoleNames roleId) }}</h3>
+                    <h3 class="crew-name noborder flexrow">{{localize (sfrpg "starshipRoleNames" roleId)}}</h3>
                     <div class="flexrow">
                         <label>{{localize "SFRPG.StarshipSheet.Crew.ActionsPerRound"}}</label>
                         <input type="text" class="crew-role-numberOfUses" value="{{role.numberOfUses}}" data-dtype="Number" placeholder="0" />
@@ -579,7 +579,7 @@
                     <li class="crew small flexrow crew-list-npc" data-role="{{roleId}}" data-skill="{{skillId}}">
                         <div class="crew-name flexrow crew-list-npc">
                         {{#unless (eq (skillId) "gun")}}
-                            <h4>{{ lookup ../../config.skills skillId }}</h4>
+                            <h4>{{sfrpg "skills" skillId}}</h4>
                         {{else}}
                             <h4>{{ localize "SFRPG.SkillGun" }}</h4>
                         {{/unless}}

--- a/src/templates/actors/vehicle-sheet-full.hbs
+++ b/src/templates/actors/vehicle-sheet-full.hbs
@@ -143,7 +143,7 @@
                             <label>Control</label>
                             <div class="form-fields">
                                 <select name="system.attributes.controlSkill">
-                                    {{selectOptions config.controlSkills selected=system.attributes.controlSkill}}
+                                    {{selectOptions (sfrpg "controlSkills") selected=system.attributes.controlSkill}}
                                 </select>
                                 {{#if (eq system.attributes.controlSkill "pil")}}
                                 <input type="text" name="system.attributes.modifiers.piloting" value="{{system.attributes.modifiers.piloting}}" />
@@ -190,7 +190,7 @@
                             <label>{{ localize "SFRPG.VehicleSheet.Details.OtherAttributes.Size" }}</label>
                             <div class="form-fields">
                                 <select name="system.attributes.size">
-                                    {{selectOptions config.vehicleSizes selected=system.attributes.size}}
+                                    {{selectOptions (sfrpg "vehicleSizes") selected=system.attributes.size}}
                                 </select>
                             </div>
                         </div>
@@ -198,7 +198,7 @@
                             <label>{{ localize "SFRPG.VehicleSheet.Details.OtherAttributes.Type" }}</label>
                             <div class="form-fields">
                                 <select name="system.attributes.type">
-                                    {{selectOptions config.vehicleTypes selected=system.attributes.type}}
+                                    {{selectOptions (sfrpg "vehicleTypes") selected=system.attributes.type}}
                                 </select>
                             </div>
                         </div>
@@ -206,7 +206,7 @@
                             <label>{{ localize "SFRPG.VehicleSheet.Details.OtherAttributes.Cover" }}</label>
                             <div class="form-fields">
                                 <select name="system.attributes.cover">
-                                    {{selectOptions config.vehicleCoverTypes selected=system.attributes.cover}}
+                                    {{selectOptions (sfrpg "vehicleCoverTypes") selected=system.attributes.cover}}
                                 </select>
                             </div>
                         </div>

--- a/src/templates/apps/add-edit-skill.hbs
+++ b/src/templates/apps/add-edit-skill.hbs
@@ -3,7 +3,7 @@
         <label>{{localize "SFRPG.ModifierTypeAbility"}}</label>
         <div class="form-fields">
             <select name="ability">
-                {{selectOptions config.abilities selected=skill.ability}}
+                {{selectOptions (sfrpg "abilities") selected=skill.ability}}
             </select>
         </div>
     </div>

--- a/src/templates/apps/modifier-app.hbs
+++ b/src/templates/apps/modifier-app.hbs
@@ -10,13 +10,13 @@
     <div class="form-group modifier-type">
         <label for="type">{{localize "SFRPG.ModifierTypeLabel"}}</label>
         <select name="type" data-tooltip="{{localize "SFRPG.ModifierTypeTooltip"}}">
-            {{selectOptions config.modifierTypes selected=modifier.type}}
+            {{selectOptions (sfrpg "modifierTypes") selected=modifier.type}}
         </select>
     </div>
     <div class="form-group modifier-effect-type">
         <label for="effectType">{{localize "SFRPG.ModifierEffectTypeLabel"}}</label>
         <select name="effectType" data-tooltip="{{localize "SFRPG.ModifierEffectTypeTooltip"}}">
-            {{selectOptions config.modifierEffectTypes selected=modifier.effectType}}
+            {{selectOptions (sfrpg "modifierEffectTypes") selected=modifier.effectType}}
         </select>
     </div>
     <div class="form-group modifier-value-affected">
@@ -26,42 +26,42 @@
         {{else}}
             <select name="valueAffected" data-tooltip="{{localize "SFRPG.ModifierValueAffectedTooltip"}}">
                 {{#if (eq modifier.effectType "ac")}}
-                    {{selectOptions config.modifierArmorClassAffectedValues selected=modifier.valueAffected}}
+                    {{selectOptions (sfrpg "modifierArmorClassAffectedValues") selected=modifier.valueAffected}}
                 {{else if (eq modifier.effectType "ability-skills")}}
-                    {{selectOptions config.abilities selected=modifier.valueAffected}}
+                    {{selectOptions (sfrpg "abilities") selected=modifier.valueAffected}}
                 {{else if (eq modifier.effectType "acp")}}
-                    {{selectOptions config.acpEffectingArmorType selected=modifier.valueAffected}}
+                    {{selectOptions (sfrpg "acpEffectingArmorType") selected=modifier.valueAffected}}
                 {{else if (eq modifier.effectType "save")}}
                     {{selectOption "highest" "SFRPG.ModifierSaveHighest" selected=modifier.valueAffected localize=true}}
                     {{selectOption "lowest" "SFRPG.ModifierSaveLowest" selected=modifier.valueAffected localize=true}}
-                    {{selectOptions config.saves selected=modifier.valueAffected}}
+                    {{selectOptions (sfrpg "saves") selected=modifier.valueAffected}}
                 {{else if (eq modifier.effectType "skill")}}
                     {{selectOption "" "-" selected=modifier.valueAffected}}
-                    {{selectOptions config.skills selected=modifier.valueAffected}}
+                    {{selectOptions (sfrpg "skills") selected=modifier.valueAffected}}
                 {{else if (eq modifier.effectType "skill-ranks")}}
-                    {{selectOptions config.skills selected=modifier.valueAffected}}
+                    {{selectOptions (sfrpg "skills") selected=modifier.valueAffected}}
                 {{else if (eq modifier.effectType "ability-check")}}
-                    {{selectOptions config.abilities selected=modifier.valueAffected}}
+                    {{selectOptions (sfrpg "abilities") selected=modifier.valueAffected}}
                 {{else if (eq modifier.effectType "ability-score")}}
-                    {{selectOptions config.abilities selected=modifier.valueAffected}}
+                    {{selectOptions (sfrpg "abilities") selected=modifier.valueAffected}}
                 {{else if (eq modifier.effectType "weapon-attacks")}}
-                    {{selectOptions config.weaponTypes selected=modifier.valueAffected}}
+                    {{selectOptions (sfrpg "weaponTypes") selected=modifier.valueAffected}}
                 {{else if (eq modifier.effectType "weapon-property-attacks")}}
-                    {{selectOptions config.weaponProperties selected=modifier.valueAffected}}
+                    {{selectOptions (sfrpg "weaponProperties") selected=modifier.valueAffected}}
                 {{else if (eq modifier.effectType "weapon-category-attacks")}}
-                    {{selectOptions config.weaponCategories selected=modifier.valueAffected}}
+                    {{selectOptions (sfrpg "weaponCategories") selected=modifier.valueAffected}}
                 {{else if (eq modifier.effectType "weapon-damage")}}
-                    {{selectOptions config.weaponTypes selected=modifier.valueAffected}}
+                    {{selectOptions (sfrpg "weaponTypes") selected=modifier.valueAffected}}
                 {{else if (eq modifier.effectType "weapon-property-damage")}}
-                    {{selectOptions config.weaponProperties selected=modifier.valueAffected}}
+                    {{selectOptions (sfrpg "weaponProperties") selected=modifier.valueAffected}}
                 {{else if (eq modifier.effectType "weapon-category-damage")}}
-                    {{selectOptions config.weaponCategories selected=modifier.valueAffected}}
+                    {{selectOptions (sfrpg "weaponCategories") selected=modifier.valueAffected}}
                 {{else if (eq modifier.effectType "specific-speed")}}
-                    {{selectOptions config.speeds selected=modifier.valueAffected}}
+                    {{selectOptions (sfrpg "speeds") selected=modifier.valueAffected}}
                 {{else if (eq modifier.effectType "damage-reduction")}}
-                    {{selectOptions config.damageReductionTypes selected=modifier.valueAffected}}
+                    {{selectOptions (sfrpg "damageReductionTypes") selected=modifier.valueAffected}}
                 {{else if (eq modifier.effectType "energy-resistance")}}
-                    {{selectOptions config.energyResistanceTypes selected=modifier.valueAffected}}
+                    {{selectOptions (sfrpg "energyResistanceTypes") selected=modifier.valueAffected}}
                 {{else}}
                     <option value=""></option>
                 {{/if}}
@@ -79,7 +79,7 @@
     <div class="form-group modifier-modifier-type">
         <label for="modifierType">{{localize "SFRPG.ModifierModifierTypeLabel"}}</label>
         <select name="modifierType" data-tooltip="{{localize "SFRPG.ModifierModifierTypeTooltip"}}">
-            {{selectOptions config.modifierType selected=modifier.modifierType}}
+            {{selectOptions (sfrpg "modifierType") selected=modifier.modifierType}}
             {{selectOption "damageSection" (localize "SFRPG.Items.Action.DamageSection" section='') selected=modifier.modifierType hidden=true}}
         </select>
     </div>
@@ -94,7 +94,7 @@
         <div class="damage-part-type form-group stacked">
             <div class="form-group form-group-stacked">
                 <label>{{localize "SFRPG.Damage.EnergyDamage"}}</label>
-                {{#each config.energyDamageTypes as |name type|}}
+                {{#each (sfrpg "energyDamageTypes") as |name type|}}
                     <label class="checkbox">
                         <input type="checkbox" name="damage.damageTypes.{{type}}" {{checked (lookup ../modifier.damage.damageTypes
                             type)}} />{{name}}
@@ -103,7 +103,7 @@
             </div>
             <div class="form-group form-group-stacked">
                 <label>{{localize "SFRPG.Damage.KineticDamage"}}</label>
-                {{#each config.kineticDamageTypes as |name type|}}
+                {{#each (sfrpg "kineticDamageTypes") as |name type|}}
                     <label class="checkbox">
                         <input type="checkbox" name="damage.damageTypes.{{type}}" {{checked (lookup ../modifier.damage.damageTypes
                             type)}} />{{name}}

--- a/src/templates/apps/movement-config.hbs
+++ b/src/templates/apps/movement-config.hbs
@@ -23,7 +23,7 @@
         <div class="form-fields">
             <input name="system.attributes.speed.flying.base" type="number" step="0.1" value="{{system.attributes.speed.flying.base}}"/>
             <select name="system.attributes.speed.flying.baseManeuverability">
-                {{selectOptions config.flightManeuverability selected=system.attributes.speed.flying.baseManeuverability}}
+                {{selectOptions (sfrpg "flightManeuverability") selected=system.attributes.speed.flying.baseManeuverability}}
             </select>
         </div>
     </div>
@@ -43,7 +43,7 @@
         <label>{{ localize "SFRPG.ActorSheet.Attributes.Speed.MainMovementType" }}</label>
         <div class="form-fields">
             <select name="system.attributes.speed.mainMovement">
-                {{selectOptions config.speeds selected=system.attributes.speed.mainMovement}}
+                {{selectOptions (sfrpg "speeds") selected=system.attributes.speed.mainMovement}}
             </select>
         </div>
     </div>

--- a/src/templates/apps/spell-cast.hbs
+++ b/src/templates/apps/spell-cast.hbs
@@ -7,7 +7,7 @@
         <div class="form-fields stacked">
             {{#each item.system.allowedClasses as |isAllowed allowedClass|}}
                 {{#if isAllowed}}
-                    <label class="checkbox"><input type="checkbox" name="" {{checked isAllowed}} disabled /> {{lookup ../config.spellcastingClasses allowedClass}}</label>
+                    <label class="checkbox"><input type="checkbox" name="" {{checked isAllowed}} disabled /> {{sfrpg "spellcastingClasses" allowedClass}}</label>
                 {{/if}}
             {{/each}}
         </div>

--- a/src/templates/chat/roll-dialog.hbs
+++ b/src/templates/chat/roll-dialog.hbs
@@ -11,7 +11,7 @@
         <div class="form-group" data-tooltip="<b>{{localize "SFRPG.Rolls.Dialog.RollMode"}}</b><br/>{{localize "SFRPG.Rolls.Dialog.RollModeTooltip"}}">
             <label>{{localize "SFRPG.Rolls.Dialog.RollMode"}}:</label>
             <select name="rollMode">
-                {{selectOptions rollModes selected=rollMode localize=true}}
+                {{selectOptions (config "Dice.rollModes") selected=rollMode localize=true}}
             </select>
         </div>
         {{#if hasSelectors}}

--- a/src/templates/items/ammunition.hbs
+++ b/src/templates/items/ammunition.hbs
@@ -25,7 +25,7 @@
                         <div class="form-fields">
                             <select name="system.ammunitionType">
                                 {{selectOption "" "SFRPG.Items.Ammunition.Type.None" selected=itemData.ammunitionType localize=true}}
-                                {{selectOptions config.ammunitionTypes selected=itemData.ammunitionType}}
+                                {{selectOptions (sfrpg "ammunitionTypes") selected=itemData.ammunitionType}}
                             </select>
                         </div>
                     </div>

--- a/src/templates/items/asi.hbs
+++ b/src/templates/items/asi.hbs
@@ -44,8 +44,8 @@
                         <h3 class="bubble-header">{{localize "SFRPG.ItemSheet.AbilityScoreIncrease.Instruction"}}</h3>
 
                         <div class="form-group stacked bubble-info">
-                            {{#each config.abilities as |ability name|}}
-                            <label class="checkbox" data-tooltip="{{lookup (lookup ../config.abilities name) "tooltip"}}">
+                            {{#each (sfrpg "abilities") as |ability name|}}
+                            <label class="checkbox">
                                 <input type="checkbox" name="system.abilities.{{name}}" {{checked (lookup ../itemData.abilities name)}} /> {{ability}}
                             </label>
                             {{/each}}

--- a/src/templates/items/augmentation.hbs
+++ b/src/templates/items/augmentation.hbs
@@ -39,7 +39,7 @@
                                 <label>{{ localize "SFRPG.Items.Augmentation.Type" }}</label>
                                 <div class="form-fields">
                                     <select name="system.type">
-                                        {{selectOptions config.augmentationTypes selected=itemData.type}}
+                                        {{selectOptions (sfrpg "augmentationTypes") selected=itemData.type}}
                                     </select>
                                 </div>
                             </div>
@@ -48,7 +48,7 @@
                                 <label>{{ localize "SFRPG.Items.Augmentation.System" }}</label>
                                 <div class="form-fields">
                                     <select name="system.system">
-                                        {{selectOptions config.augmentationSystems selected=itemData.system}}
+                                        {{selectOptions (sfrpg "augmentationSystems") selected=itemData.system}}
                                     </select>
                                 </div>
                             </div>

--- a/src/templates/items/chassis.hbs
+++ b/src/templates/items/chassis.hbs
@@ -52,7 +52,7 @@
                         <label>{{ localize "SFRPG.DroneSheet.Chassis.Details.BaseStatistics.Size" }}</label>
                         <div class="form-fields">
                             <select class="actor-size" name="system.size">
-                                {{selectOptions config.actorSizes selected=itemData.size}}
+                                {{selectOptions (sfrpg "actorSizes") selected=itemData.size}}
                             </select>
                         </div>
                     </div>
@@ -90,7 +90,7 @@
                                 <label>{{localize "SFRPG.DroneSheet.Chassis.Details.Saves.Fortitude"}}</label>
                                 <div class="form-fields">
                                     <select name="system.fort">
-                                        {{selectOptions config.saveProgression selected=itemData.fort}}
+                                        {{selectOptions (sfrpg "saveProgression") selected=itemData.fort}}
                                     </select>
                                 </div>
                             </div>
@@ -99,7 +99,7 @@
                                 <label>{{localize "SFRPG.DroneSheet.Chassis.Details.Saves.Reflex"}}</label>
                                 <div class="form-fields">
                                     <select name="system.ref">
-                                        {{selectOptions config.saveProgression selected=itemData.ref}}
+                                        {{selectOptions (sfrpg "saveProgression") selected=itemData.ref}}
                                     </select>
                                 </div>
                             </div>
@@ -108,7 +108,7 @@
                                 <label>{{localize "SFRPG.DroneSheet.Chassis.Details.Saves.Will"}}</label>
                                 <div class="form-fields">
                                     <select name="system.will">
-                                        {{selectOptions config.saveProgression selected=itemData.will}}
+                                        {{selectOptions (sfrpg "saveProgression") selected=itemData.will}}
                                     </select>
                                 </div>
                             </div>
@@ -171,7 +171,7 @@
                         <label>{{ localize "SFRPG.ActorSheet.Attributes.Speed.MainMovementType" }}</label>
                         <div class="form-fields">
                             <select name="system.speed.mainMovement">
-                                {{selectOptions config.speeds selected=itemData.speed.mainMovement}}
+                                {{selectOptions (sfrpg "speeds") selected=itemData.speed.mainMovement}}
                             </select>
                         </div>
                     </div>
@@ -228,11 +228,11 @@
                         <div class="form-group bubble-info">
                             <div class="form-fields">
                                 <select name="system.abilityIncreaseStats.first">
-                                    {{selectOptions config.abilities selected=itemData.abilityIncreaseStats.first}}
+                                    {{selectOptions (sfrpg "abilities") selected=itemData.abilityIncreaseStats.first}}
                                 </select>
 
                                 <select name="system.abilityIncreaseStats.second">
-                                    {{selectOptions config.abilities selected=itemData.abilityIncreaseStats.second}}
+                                    {{selectOptions (sfrpg "abilities") selected=itemData.abilityIncreaseStats.second}}
                                 </select>
                             </div>
                         </div>

--- a/src/templates/items/class.hbs
+++ b/src/templates/items/class.hbs
@@ -69,7 +69,7 @@
                                 <label>{{localize "SFRPG.ClassKeyAbilityScore"}}</label>
                                 <div class="form-fields">
                                     <select name="system.kas">
-                                        {{selectOptions config.abilities selected=itemData.kas}}
+                                        {{selectOptions (sfrpg "abilities") selected=itemData.kas}}
                                     </select>
                                 </div>
                             </div>
@@ -109,7 +109,7 @@
                                         <label>{{localize "SFRPG.ClassBABProgression"}}</label>
                                         <div class="form-fields">
                                             <select name="system.bab">
-                                                {{selectOptions config.babProgression selected=itemData.bab}}
+                                                {{selectOptions (sfrpg "babProgression") selected=itemData.bab}}
                                             </select>
                                         </div>
                                     </div>
@@ -118,7 +118,7 @@
                                         <label>{{localize "SFRPG.ClassFortSaveProgression"}}</label>
                                         <div class="form-fields">
                                             <select name="system.fort">
-                                                {{selectOptions config.saveProgression selected=itemData.fort}}
+                                                {{selectOptions (sfrpg "saveProgression") selected=itemData.fort}}
                                             </select>
                                         </div>
                                     </div>
@@ -127,7 +127,7 @@
                                         <label>{{localize "SFRPG.ClassReflexSaveProgression"}}</label>
                                         <div class="form-fields">
                                             <select name="system.ref">
-                                                {{selectOptions config.saveProgression selected=itemData.ref}}
+                                                {{selectOptions (sfrpg "saveProgression") selected=itemData.ref}}
                                             </select>
                                         </div>
                                     </div>
@@ -136,7 +136,7 @@
                                         <label>{{localize "SFRPG.ClassWillSaveProgression"}}</label>
                                         <div class="form-fields">
                                             <select name="system.will">
-                                                {{selectOptions config.saveProgression selected=itemData.will}}
+                                                {{selectOptions (sfrpg "saveProgression") selected=itemData.will}}
                                             </select>
                                         </div>
                                     </div>
@@ -166,7 +166,7 @@
                                 <h3 class="bubble-header">{{localize "SFRPG.ClassSkills"}}</h3>
 
                                 <div class="form-group stacked weapon-properties bubble-info">
-                                    {{#each config.skills as |name val|}}
+                                    {{#each (sfrpg "skills") as |name val|}}
                                     <label class="checkbox">
                                         <input type="checkbox" name="system.csk.{{val}}" {{checked (lookup ../itemData.csk val)}}/> {{ name }}
                                     </label>
@@ -179,7 +179,7 @@
                                 <h3 class="bubble-header">{{localize "SFRPG.ClassWeaponProf"}}</h3>
 
                                 <div class="form-group stacked weapon-properties bubble-info">
-                                    {{#each config.weaponProficiencies as |name val|}}
+                                    {{#each (sfrpg "weaponProficiencies") as |name val|}}
                                     <label class="checkbox">
                                         <input type="checkbox" name="system.proficiencies.weapon.{{val}}" {{checked (lookup ../itemData.proficiencies.weapon val)}}/> {{ name }}
                                     </label>
@@ -192,7 +192,7 @@
                                 <h3 class="bubble-header">{{localize "SFRPG.ClassArmorProf"}}</h3>
 
                                 <div class="form-group stacked weapon-properties bubble-info">
-                                    {{#each config.armorProficiencies as |name val|}}
+                                    {{#each (sfrpg "armorProficiencies") as |name val|}}
                                     <label class="checkbox">
                                         <input type="checkbox" name="system.proficiencies.armor.{{val}}" {{checked (lookup ../itemData.proficiencies.armor val)}}/> {{ name }}
                                     </label>
@@ -217,7 +217,7 @@
                             <div class="form-fields">
                                 <select name="system.spellAbility">
                                     {{selectOption "" "" selected=itemData.spellAbility}}
-                                    {{selectOptions config.abilities selected=itemData.spellAbility}}
+                                    {{selectOptions (sfrpg "abilities") selected=itemData.spellAbility}}
                                 </select>
                             </div>
                         </div>

--- a/src/templates/items/consumable.hbs
+++ b/src/templates/items/consumable.hbs
@@ -41,7 +41,7 @@
                             <div class="form-group">
                                 <label>{{ localize "SFRPG.Items.Consumable.Type" }}</label>
                                 <select name="system.consumableType">
-                                    {{selectOptions config.consumableTypes selected=itemData.consumableType}}
+                                    {{selectOptions (sfrpg "consumableTypes") selected=itemData.consumableType}}
                                 </select>
                             </div>
 

--- a/src/templates/items/equipment.hbs
+++ b/src/templates/items/equipment.hbs
@@ -43,7 +43,7 @@
                                 <label>{{ localize "SFRPG.Items.Equipment.Category" }}</label>
                                 <select name="system.armor.type">
                                     {{selectOption "" "" selected=itemData.armor.type}}
-                                    {{selectOptions config.armorTypes selected=itemData.armor.type}}
+                                    {{selectOptions (sfrpg "armorTypes") selected=itemData.armor.type}}
                                 </select>
                             </div>
 
@@ -120,7 +120,7 @@
                                 <label>{{ localize "SFRPG.Size" }}</label>
                                 <div class="form-fields">
                                     <select name="system.size">
-                                        {{selectOptions config.actorSizes selected=itemData.size}}
+                                        {{selectOptions (sfrpg "actorSizes") selected=itemData.size}}
                                     </select>
                                 </div>
                             </div>

--- a/src/templates/items/feat.hbs
+++ b/src/templates/items/feat.hbs
@@ -65,7 +65,7 @@
                             <div class="form-group select">
                                 <label for="category">{{ localize "SFRPG.Items.Feat.FeatureCategory" }}</label>
                                 <select name="system.details.category" id="category">
-                                    {{selectOptions config.featureCategories selected=itemData.details.category labelAttr="label"}}
+                                    {{selectOptions (sfrpg "featureCategories") selected=itemData.details.category labelAttr="label"}}
                                 </select>
                             </div>
 
@@ -79,7 +79,7 @@
                             <div class="form-group select">
                                 <label for="category">{{ localize "SFRPG.Items.Feat.SpecialAbilityType" }}</label>
                                 <select name="system.details.specialAbilityType" id="specialAbilityType">
-                                    {{selectOptions config.specialAbilityTypes selected=itemData.details.specialAbilityType}}
+                                    {{selectOptions (sfrpg "specialAbilityTypes") selected=itemData.details.specialAbilityType}}
                                 </select>
                             </div>
 

--- a/src/templates/items/mod.hbs
+++ b/src/templates/items/mod.hbs
@@ -87,7 +87,7 @@
                                 <label>{{ localize "SFRPG.DroneSheet.Mod.Details.Arms.ArmType.Label" }}</label>
                                 <div class="form-fields">
                                     <select name="system.arms.armType">
-                                        {{selectOptions config.droneArmTypes selected=itemData.arms.armType}}
+                                        {{selectOptions (sfrpg "droneArmTypes") selected=itemData.arms.armType}}
                                     </select>
                                 </div>
                             </div>
@@ -112,7 +112,7 @@
                                 <div class="form-fields">
                                     <select name="system.weaponProficiency">
                                         {{selectOption "" "SFRPG.None" selected=itemData.weaponProficiency localize=true}}
-                                        {{selectOptions config.weaponProficiencies selected=itemData.weaponProficiency}}
+                                        {{selectOptions (sfrpg "weaponProficiencies") selected=itemData.weaponProficiency}}
                                     </select>
                                 </div>
                             </div>
@@ -122,7 +122,7 @@
                                 <div class="form-fields">
                                     <select name="system.bonusSkill">
                                         {{selectOption "" "SFRPG.None" selected=itemData.bonusSkill}}
-                                        {{selectOptions config.skills selected=itemData.bonusSkill}}
+                                        {{selectOptions (sfrpg "skills") selected=itemData.bonusSkill}}
                                     </select>
                                 </div>
                             </div>

--- a/src/templates/items/parts/container-details.hbs
+++ b/src/templates/items/parts/container-details.hbs
@@ -80,7 +80,7 @@
                     {{/if}}
                     <div class="form-group stacked weapon-properties" data-tooltip="<strong>{{ localize "SFRPG.ActorSheet.Inventory.Container.AcceptedItemTypes" }}</strong><br/>{{ localize "SFRPG.ActorSheet.Inventory.Container.AcceptedItemTypesTooltip" }}">
                         <label>{{ localize "SFRPG.ActorSheet.Inventory.Container.AcceptedItemTypes" }}</label>
-                        {{#each ../config.containableTypes as |typeName typeKey|}}
+                        {{#each (sfrpg "containableTypes") as |typeName typeKey|}}
                         <label class="checkbox">
                             <input type="checkbox" class="storage.acceptsType" name="{{typeKey}}" {{checked (contains storage.acceptsType typeKey)}}/>{{localize typeName}}
                         </label>

--- a/src/templates/items/parts/damage-sections.hbs
+++ b/src/templates/items/parts/damage-sections.hbs
@@ -52,7 +52,7 @@
                 <div class="damage-part-type form-group stacked">
                     <div class="form-group form-group-stacked">
                         <label>{{localize "Energy Damage"}}</label>
-                        {{#each ../config.energyDamageTypes as |name type|}}
+                        {{#each (sfrpg "energyDamageTypes") as |name type|}}
                         <label class="checkbox">
                             <input type="checkbox" name="system.damage.parts.{{i}}.types.{{type}}" {{checked (lookup (lookup (lookup ../../itemData.damage.parts i) "types") type)}} />{{name}}
                         </label>
@@ -60,7 +60,7 @@
                     </div>
                     <div class="form-group form-group-stacked">
                         <label>{{localize "Kinetic Damage"}}</label>
-                        {{#each ../config.kineticDamageTypes as |name type|}}
+                        {{#each (sfrpg "kineticDamageTypes") as |name type|}}
                         <label class="checkbox">
                             <input type="checkbox" name="system.damage.parts.{{i}}.types.{{type}}" {{checked (lookup (lookup (lookup ../../itemData.damage.parts i) "types") type)}} />{{name}}
                         </label>

--- a/src/templates/items/parts/effect-turn-events.hbs
+++ b/src/templates/items/parts/effect-turn-events.hbs
@@ -20,7 +20,7 @@
                 <label>{{localize "SFRPG.TurnEvent.Trigger"}}</label>
                 <div class="form-fields">
                     <select name="system.turnEvents.{{i}}.trigger">
-                        {{selectOptions ../config.effectEndTypes selected=event.trigger localize=true}}
+                        {{selectOptions (sfrpg "effectEndTypes") selected=event.trigger localize=true}}
                     </select>
                 </div>
             </div>
@@ -29,7 +29,7 @@
                 <label>{{localize "SFRPG.TurnEvent.Type"}}</label>
                 <div class="form-fields">
                     <select name="system.turnEvents.{{i}}.type">
-                        {{selectOptions ../config.turnEventTypes selected=event.type localize=true}}
+                        {{selectOptions (sfrpg "turnEventTypes") selected=event.type localize=true}}
                     </select>
                 </div>
             </div>
@@ -47,7 +47,7 @@
                 <div class="turn-event-damage form-group stacked">
                     <div class="form-group form-group-stacked">
                         <label>{{localize "Energy Damage"}}</label>
-                        {{#each ../config.energyDamageTypes as |name type|}}
+                        {{#each (sfrpg "energyDamageTypes") as |name type|}}
                             <label class="checkbox">
                                 <input type="checkbox" name="system.turnEvents.{{i}}.damageTypes.{{type}}" {{checked
                                     (lookup event.damageTypes type)}} />{{name}}
@@ -56,7 +56,7 @@
                     </div>
                     <div class="form-group form-group-stacked">
                         <label>{{localize "Kinetic Damage"}}</label>
-                        {{#each ../config.kineticDamageTypes as |name type|}}
+                        {{#each (sfrpg "kineticDamageTypes") as |name type|}}
                             <label class="checkbox">
                                 <input type="checkbox" name="system.turnEvents.{{i}}.damageTypes.{{type}}" {{checked
                                     (lookup event.damageTypes type)}} />{{name}}

--- a/src/templates/items/parts/item-action.hbs
+++ b/src/templates/items/parts/item-action.hbs
@@ -12,7 +12,7 @@
             <label>{{ localize "SFRPG.Items.Action.ActionType" }}</label>
             <select name="system.actionType">
                 {{selectOption "" "" selected=itemData.actionType}}
-                {{selectOptions config.itemActionTypes selected=itemData.actionType}}
+                {{selectOptions (sfrpg "itemActionTypes") selected=itemData.actionType}}
             </select>
         </div>
 
@@ -21,7 +21,7 @@
             <div class="form-group select" {{createTippy title="SFRPG.Items.Action.ActionTarget.Title" subtitle="SFRPG.Items.Action.ActionTarget.Tooltip"}}>
                 <label>{{ localize "SFRPG.Items.Action.ActionTarget.Title" }}</label>
                 <select name="system.actionTarget">
-                    {{selectOptions config.actionTargets selected=itemData.actionTarget}}
+                    {{selectOptions (sfrpg "actionTargets") selected=itemData.actionTarget}}
                 </select>
             </div>
 
@@ -30,7 +30,7 @@
                 <label>{{ localize "SFRPG.Items.Action.AbilityModifier" }}</label>
                 <select name="system.ability">
                     {{selectOption "" "" selected=itemData.ability}}
-                    {{selectOptions config.abilities selected=itemData.ability}}
+                    {{selectOptions (sfrpg "abilities") selected=itemData.ability}}
                 </select>
             </div>
 
@@ -51,10 +51,10 @@
                     <input type="text" class="wide-form-field" name="system.save.dc" value="{{itemData.save.dc}}" data-dtype="String" placeholder="{{placeholders.saveDC.formula}}"/>
                     <select name="system.save.type">
                         {{selectOption "" "" selected=itemData.save.type}}
-                        {{selectOptions config.saves selected=itemData.save.type}}
+                        {{selectOptions (sfrpg "saves") selected=itemData.save.type}}
                     </select>
                     <select name="system.save.descriptor">
-                        {{selectOptions config.saveDescriptors selected=itemData.save.descriptor}}
+                        {{selectOptions (sfrpg "saveDescriptors") selected=itemData.save.descriptor}}
                     </select>
                 </div>
             </div>
@@ -66,7 +66,7 @@
                     <input type="text" class="wide-form-field" name="system.skillCheck.dc" value="{{itemData.skillCheck.dc}}" data-dtype="String" placeholder="{{placeholders.saveDC.formula}}"/>
                     <select name="system.skillCheck.type">
                         {{selectOption "" "" selected=itemData.skillCheck.type}}
-                        {{selectOptions config.skills selected=itemData.skillCheck.type}}
+                        {{selectOptions (sfrpg "skills") selected=itemData.skillCheck.type}}
                     </select>
                 </div>
             </div>
@@ -95,7 +95,7 @@
                                 <input class="wide-form-field" type="text" name="system.range.value" value="{{itemData.range.value}}" data-dtype="String" placeholder="Range"/>
                                 {{/if}}
                                 <select name="system.range.units">
-                                    {{selectOptions config.distanceUnits selected=itemData.range.units}}
+                                    {{selectOptions (sfrpg "distanceUnits") selected=itemData.range.units}}
                                 </select>
                             </div>
                         </div>
@@ -107,15 +107,15 @@
                                 {{#if this.area.showTotal}}<p class="calculated-total"><strong>{{itemData.area.total}}</strong></p>{{/if}}
                                 <input type="text" {{#if (eq itemData.area.units "text")}}class="wide-form-field"{{/if}} name="system.area.value" value="{{itemData.area.value}}" data-dtype="String" placeholder="Area" />
                                 <select name="system.area.units" class="min-form-field">
-                                    {{selectOptions config.variableDistanceUnits selected=itemData.area.units}}
+                                    {{selectOptions (sfrpg "variableDistanceUnits") selected=itemData.area.units}}
                                     {{selectOption "text" "SFRPG.Text" selected=itemData.area.units localize=true}}
                                 </select>
                                 {{#unless (eq itemData.area.units "text")}}
                                 <select name="system.area.shape" class="min-form-field">
-                                    {{selectOptions config.spellAreaShapes selected=itemData.area.shape}}
+                                    {{selectOptions (sfrpg "spellAreaShapes") selected=itemData.area.shape}}
                                 </select>
                                 <select name="system.area.effect" class="min-form-field">
-                                    {{selectOptions config.spellAreaEffects selected=itemData.area.effect}}
+                                    {{selectOptions (sfrpg "spellAreaEffects") selected=itemData.area.effect}}
                                 </select>
                                 <label class="checkbox">
                                     <input type="checkbox" name="system.area.shapable" {{checked itemData.area.shapable}}>
@@ -182,7 +182,7 @@
                             <div class="damage-part-type form-group stacked">
                                 <div class="form-group form-group-stacked">
                                     <label>{{localize "SFRPG.Damage.EnergyDamage"}}</label>
-                                    {{#each ../config.energyDamageTypes as |name type|}}
+                                    {{#each (sfrpg "energyDamageTypes") as |name type|}}
                                     <label class="checkbox">
                                         <input type="checkbox" name="system.critical.parts.{{i}}.types.{{type}}" {{checked (lookup (lookup (lookup ../../itemData.critical.parts i) "types") type)}} />{{name}}
                                     </label>
@@ -190,7 +190,7 @@
                                 </div>
                                 <div class="form-group form-group-stacked">
                                     <label>{{localize "SFRPG.Damage.KineticDamage"}}</label>
-                                    {{#each ../config.kineticDamageTypes as |name type|}}
+                                    {{#each (sfrpg "kineticDamageTypes") as |name type|}}
                                     <label class="checkbox">
                                         <input type="checkbox" name="system.critical.parts.{{i}}.types.{{type}}" {{checked (lookup (lookup (lookup ../../itemData.critical.parts i) "types") type)}} />{{name}}
                                     </label>

--- a/src/templates/items/parts/item-activation.hbs
+++ b/src/templates/items/parts/item-activation.hbs
@@ -14,7 +14,7 @@
                 <input type="text" name="system.activation.cost" value="{{itemData.activation.cost}}" data-dtype="Number" placeholder="-"/>
                 <select name="system.activation.type">
                     {{selectOption "" "" selected=itemData.activation.type}}
-                    {{selectOptions config.abilityActivationTypes selected=itemData.activation.type}}
+                    {{selectOptions (sfrpg "abilityActivationTypes") selected=itemData.activation.type}}
                 </select>
             </div>
         </div>
@@ -47,7 +47,7 @@
                 {{/if}}
                 <select name="system.duration.units">
                     {{selectOption "text" "SFRPG.Text" selected=itemData.duration.units localize=true}}
-                    {{selectOptions config.durationTypes selected=itemData.duration.units}}
+                    {{selectOptions (sfrpg "durationTypes") selected=itemData.duration.units}}
                 </select>
             </div>
         </div>
@@ -62,7 +62,7 @@
                 {{#if this.uses.showTotal}}<p class="calculated-total"><strong>{{itemData.uses.total}}</strong></p>{{/if}}
                 <select name="system.uses.per">
                     {{selectOption "" "" selected=itemData.uses.per}}
-                    {{selectOptions config.limitedUsePeriods selected=itemData.uses.per}}
+                    {{selectOptions (sfrpg "limitedUsePeriods") selected=itemData.uses.per}}
                 </select>
             </div>
         </div>
@@ -80,7 +80,7 @@
                         <input class="wide-form-field" type="text" name="system.range.value" value="{{itemData.range.value}}" data-dtype="String" placeholder="Range"/>
                         {{/if}}
                         <select name="system.range.units">
-                            {{selectOptions config.distanceUnits selected=itemData.range.units}}
+                            {{selectOptions (sfrpg "distanceUnits") selected=itemData.range.units}}
                         </select>
                     </div>
                 </div>
@@ -92,15 +92,15 @@
                         {{#if this.area.showTotal}}<p class="calculated-total"><strong>{{itemData.area.total}}</strong></p>{{/if}}
                         <input type="text" {{#if (eq itemData.area.units "text")}}class="wide-form-field"{{/if}} name="system.area.value" value="{{itemData.area.value}}" data-dtype="String" placeholder="Area" />
                         <select name="system.area.units" class="min-form-field">
-                            {{selectOptions config.variableDistanceUnits selected=itemData.area.units}}
+                            {{selectOptions (sfrpg "variableDistanceUnits") selected=itemData.area.units}}
                             {{selectOption "text" "SFRPG.Text" selected=itemData.area.units localize=true}}
                         </select>
                         {{#unless (eq itemData.area.units "text")}}
                         <select name="system.area.shape" class="min-form-field">
-                            {{selectOptions config.spellAreaShapes selected=itemData.area.shape}}
+                            {{selectOptions (sfrpg "spellAreaShapes") selected=itemData.area.shape}}
                         </select>
                         <select name="system.area.effect" class="min-form-field">
-                            {{selectOptions config.spellAreaEffects selected=itemData.area.effect}}
+                            {{selectOptions (sfrpg "spellAreaEffects") selected=itemData.area.effect}}
                         </select>
                         <label class="checkbox">
                             <input type="checkbox" name="system.area.shapable" {{checked itemData.area.shapable}}>

--- a/src/templates/items/parts/item-capacity.hbs
+++ b/src/templates/items/parts/item-capacity.hbs
@@ -7,7 +7,7 @@
             <div class="form-fields">
                 <select name="system.ammunitionType">
                     {{selectOption "" "SFRPG.Items.Ammunition.Type.None" selected=itemData.ammunitionType localize=true}}
-                    {{selectOptions config.ammunitionTypes selected=itemData.ammunitionType}}
+                    {{selectOptions (sfrpg "ammunitionTypes") selected=itemData.ammunitionType}}
                 </select>
             </div>
         </div>
@@ -34,7 +34,7 @@
                 <span class="sep"> / </span>
                 <select name="system.usage.per" data-tooltip="{{ localize "SFRPG.Items.Capacity.UsageValueTooltip" }}">
                     {{selectOption "" "" selected=itemData.usage.per}}
-                    {{selectOptions config.capacityUsagePer selected=itemData.usage.per}}
+                    {{selectOptions (sfrpg "capacityUsagePer") selected=itemData.usage.per}}
                 </select>
             </div>
         </div>

--- a/src/templates/items/parts/item-descriptors.hbs
+++ b/src/templates/items/parts/item-descriptors.hbs
@@ -3,8 +3,8 @@
     <h3 class="bubble-header">{{localize "SFRPG.Descriptors.Descriptors"}}</h3>
 
     <div class="bubble-info form-group stacked item-descriptors">
-        {{#each config.descriptors as |name desc|}}
-        <label class="checkbox" {{#if (lookup ../config.descriptorsTooltips desc)}} data-tooltip='<strong>{{ name }}</strong><br/>{{lookup ../config.descriptorsTooltips desc}}' {{/if}}>
+        {{#each (sfrpg "descriptors") as |name desc|}}
+        <label class="checkbox" {{#if (sfrpg "descriptorsTooltips" desc)}} data-tooltip='<strong>{{ name }}</strong><br/>{{sfrpg "descriptorsTooltips" desc}}' {{/if}}>
             <input type="checkbox" name="system.descriptors.{{desc}}" {{checked (lookup ../itemData.descriptors desc)}} /> {{ name }}
         </label>
         {{/each}}

--- a/src/templates/items/parts/item-duration.hbs
+++ b/src/templates/items/parts/item-duration.hbs
@@ -24,7 +24,7 @@
                                 data-tooltip="<p>Use the <code>@owner</code> prefix to reference the parent actor.</p><p>Use <code>@origin.actor</code> or <code>@origin.item</code> to reference the origin actor or item respectively." />
                         {{/unless}}
                         <select name="system.activeDuration.unit">
-                            {{selectOptions config.effectDurationTypes selected=itemData.activeDuration.unit}}
+                            {{selectOptions (sfrpg "effectDurationTypes") selected=itemData.activeDuration.unit}}
                         </select>
                     </div>
                 </div>
@@ -48,7 +48,7 @@
                                     </optgroup>
                                 </select>
                                 <select name="system.activeDuration.endsOn">
-                                    {{selectOptions config.effectEndTypes selected=itemData.activeDuration.endsOn localize=true}}
+                                    {{selectOptions (sfrpg "effectEndTypes") selected=itemData.activeDuration.endsOn localize=true}}
                                 </select>
                             {{else if (eq itemData.activeDuration.expiryMode.type "init")}}
                                 <input name="system.activeDuration.expiryInit" type="number" data-dtype="Number"

--- a/src/templates/items/parts/item-modifiers.hbs
+++ b/src/templates/items/parts/item-modifiers.hbs
@@ -30,42 +30,42 @@
                     {{ellipsis modifier.modifier 12}}
                 </div>
                 <div class="item-detail modifier-type">
-                    {{lookup ../config.modifierTypes modifier.type}}
+                    {{sfrpg "modifierTypes" modifier.type}}
                 </div>
                 <div class="item-detail modifier-effect-type">
-                    {{lookup ../config.modifierEffectTypes modifier.effectType}}
+                    {{sfrpg "modifierEffectTypes" modifier.effectType}}
                 </div>
                 <div class="item-detail modifier-value-affected">
                     {{#if (eq modifier.effectType "ac")}}
-                        {{lookup ../config.modifierArmorClassAffectedValues modifier.valueAffected}}
+                        {{sfrpg "modifierArmorClassAffectedValues" modifier.valueAffected}}
                     {{else if (eq modifier.effectType "acp")}}
-                        {{lookup ../config.acpEffectingArmorType modifier.valueAffected}}
+                        {{sfrpg "acpEffectingArmorType" modifier.valueAffected}}
                     {{else if (eq modifier.effectType "ability-skills")}}
-                        {{lookup ../config.abilities modifier.valueAffected}}
+                        {{sfrpg "abilities" modifier.valueAffected}}
                     {{else if (eq modifier.effectType "ability-check")}}
-                        {{lookup ../config.abilities modifier.valueAffected}}
+                        {{sfrpg "abilities" modifier.valueAffected}}
                     {{else if (eq modifier.effectType "ability-score")}}
-                        {{lookup ../config.abilities modifier.valueAffected}}
+                        {{sfrpg "abilities" modifier.valueAffected}}
                     {{else if (eq modifier.effectType "skill")}}
-                        {{lookup ../config.skills modifier.valueAffected}}
+                        {{sfrpg "skills" modifier.valueAffected}}
                     {{else if (eq modifier.effectType "save")}}
                         {{#if (eq modifier.valueAffected "highest")}}
                             {{localize "SFRPG.ModifierSaveHighest"}}
                         {{else if (eq modifier.valueAffected "lowest")}}
                             {{localize "SFRPG.ModifierSaveLowest"}}
                         {{else}}
-                            {{lookup ../config.saves modifier.valueAffected}}
+                            {{sfrpg "saves" modifier.valueAffected}}
                         {{/if}}
                     {{else if (eq modifier.effectType "weapon-attacks")}}
-                        {{lookup ../config.weaponTypes modifier.valueAffected}}
+                        {{sfrpg "weaponTypes" modifier.valueAffected}}
                     {{else if (eq modifier.effectType "weapon-property-attacks")}}
-                        {{lookup ../config.weaponProperties modifier.valueAffected}}
+                        {{sfrpg "weaponProperties" modifier.valueAffected}}
                     {{else if (eq modifier.effectType "weapon-damage")}}
-                        {{lookup ../config.weaponTypes modifier.valueAffected}}
+                        {{sfrpg "weaponTypes" modifier.valueAffected}}
                     {{else if (eq modifier.effectType "weapon-property-damage")}}
-                        {{lookup ../config.weaponProperties modifier.valueAffected}}
+                        {{sfrpg "weaponProperties" modifier.valueAffected}}
                     {{else if (eq modifier.effectType "specific-speed")}}
-                        {{lookup ../../config.speeds modifier.valueAffected}}
+                        {{sfrpg "speeds" modifier.valueAffected}}
                     {{else if (eq modifier.effectType "actor-resource")}}
                         <h4>{{~modifier.valueAffected~}}</h4>
                     {{else}}

--- a/src/templates/items/parts/item-special-materials.hbs
+++ b/src/templates/items/parts/item-special-materials.hbs
@@ -1,8 +1,8 @@
 <div class="bubble">
     <h3 class="bubble-header">{{ localize "SFRPG.Items.SpecialMaterials.Title" }}</h3>
-    
+
     <div class="form-group stacked weapon-properties bubble-info">
-        {{#each config.specialMaterials as |name prop|}}
+        {{#each (sfrpg "specialMaterials") as |name prop|}}
         <label class="checkbox">
             <input type="checkbox" name="system.specialMaterials.{{prop}}" {{checked (lookup ../itemData.specialMaterials prop)}} /> {{ name }}
         </label>

--- a/src/templates/items/parts/physical-item-details.hbs
+++ b/src/templates/items/parts/physical-item-details.hbs
@@ -18,7 +18,7 @@
             <label>{{ localize "SFRPG.ItemSheet.PhysicalProperties.Size" }}</label>
             <div class="form-fields">
                 <select class="actor-size" name="system.attributes.size">
-                    {{selectOptions config.actorSizes selected=selectedSize}}
+                    {{selectOptions (sfrpg "actorSizes") selected=selectedSize}}
                 </select>
             </div>
         </div>

--- a/src/templates/items/parts/weapon-properties.hbs
+++ b/src/templates/items/parts/weapon-properties.hbs
@@ -1,11 +1,11 @@
 <div class="bubble">
     <h3 class="bubble-header">{{ localize "SFRPG.Items.Weapon.Properties" }}</h3>
-    
+
     <div class="form-group stacked weapon-properties bubble-info">
         <label></label>
-        {{#each config.weaponProperties as |name prop|}}
+        {{#each (sfrpg "weaponProperties") as |name prop|}}
             <!-- If there's a tooltip entry set for this weapon property we set a Tippy tooltip -->
-            <label class="checkbox" {{#if (lookup ../config.weaponPropertiesTooltips prop)}} data-tooltip='<strong>{{ name }}</strong><br/>{{lookup ../config.weaponPropertiesTooltips prop}}' {{/if}}>
+            <label class="checkbox" {{#if (sfrpg "weaponPropertiesTooltips" prop)}} data-tooltip='<strong>{{ name }}</strong><br/>{{sfrpg "weaponPropertiesTooltips" prop}}' {{/if}}>
                 <input type="checkbox" name="system.properties.{{prop}}" {{checked (lookup ../itemData.properties prop)}} /> {{ name }}
             </label>
         {{/each}}

--- a/src/templates/items/race.hbs
+++ b/src/templates/items/race.hbs
@@ -61,7 +61,7 @@
                         <label>{{localize "SFRPG.RaceSize"}}</label>
                         <div class="form-fields">
                             <select name="system.size">
-                                {{selectOptions config.actorSizes selected=itemData.size}}
+                                {{selectOptions (sfrpg "actorSizes") selected=itemData.size}}
                             </select>
                         </div>
                     </div>
@@ -84,7 +84,7 @@
                             <input type="text" name="system.abilityMods.parts.{{i}}.0" data-dtype="Number" value="{{numberFormat part.[0] decimals=0 sign=true}}"/>
                             <select name="system.abilityMods.parts.{{i}}.1">
                                 {{selectOption "" "SFRPG.None" selected=part.[1] localize=true}}
-                                {{selectOptions ../config.abilities selected=part.[1]}}
+                                {{selectOptions (sfrpg "abilities") selected=part.[1]}}
                                 {{selectOption "any" "SFRPG.RaceAbilityAdjustmentAny" selected=part.[1] localize=true}}
                             </select>
                             <a class="ability-adjustments-control delete-ability-adjustment"><i class="fas fa-minus"></i></a>

--- a/src/templates/items/spell.hbs
+++ b/src/templates/items/spell.hbs
@@ -75,7 +75,7 @@
                             <div class="form-group">
                                 <label>{{ localize "SFRPG.Items.Spell.AllowedClasses" }}</label>
                                 <div class="form-fields">
-                                    {{#each config.spellcastingClasses as |name key|}}
+                                    {{#each (sfrpg "spellcastingClasses") as |name key|}}
                                     <label class="checkbox">
                                         <input type="checkbox" name="system.allowedClasses.{{key}}" {{checked (lookup ../itemData.allowedClasses key)}} /> {{name}}
                                     </label>
@@ -88,7 +88,7 @@
                                 <label>{{ localize "SFRPG.Items.Spell.Level" }}</label>
                                 <div class="form-fields">
                                     <select name="system.level" data-dtype="Number">
-                                        {{selectOptions config.spellLevels selected=itemData.level localize=true}}
+                                        {{selectOptions (sfrpg "spellLevels") selected=itemData.level localize=true}}
                                     </select>
                                     <span>&nbsp;</span>
                                     <label class="checkbox">
@@ -102,7 +102,7 @@
                                 <label>{{ localize "SFRPG.Items.Spell.School" }}</label>
                                 <div class="form-fields">
                                     <select name="system.school">
-                                        {{selectOptions config.spellSchools selected=itemData.school localize=true}}
+                                        {{selectOptions (sfrpg "spellSchools") selected=itemData.school localize=true}}
                                     </select>
                                 </div>
                             </div>
@@ -133,7 +133,7 @@
                                     <span>&nbsp;</span>
                                     <select name="system.preparation.mode">
                                         {{selectOption "" "" selected=itemData.preparation.mode}}
-                                        {{selectOptions config.spellPreparationModes selected=itemData.preparation.mode}}
+                                        {{selectOptions (sfrpg "spellPreparationModes") selected=itemData.preparation.mode}}
                                     </select>
                                 </div>
                             </div>

--- a/src/templates/items/starshipAction.hbs
+++ b/src/templates/items/starshipAction.hbs
@@ -39,7 +39,7 @@
                             <div class="form-group">
                                 <label>{{ localize "SFRPG.ItemSheet.StarshipAction.CrewRole" }}</label>
                                 <select name="system.role">
-                                    {{selectOptions config.starshipRoleNames selected=itemData.role localize=true}}
+                                    {{selectOptions (sfrpg "starshipRoleNames") selected=itemData.role localize=true}}
                                 </select>
                             </div>
 

--- a/src/templates/items/starshipDriftEngine.hbs
+++ b/src/templates/items/starshipDriftEngine.hbs
@@ -37,7 +37,7 @@
                     <div class="form-group" data-tooltip="<b>{{ localize "SFRPG.ItemSheet.StarshipDriftEngine.MaxSize" }}</b><br/>{{ localize "SFRPG.ItemSheet.StarshipDriftEngine.MaxSizeTooltip" }}">
                         <label>{{ localize "SFRPG.ItemSheet.StarshipDriftEngine.MaxSize" }}</label>
                         <select name="system.maxSize">
-                            {{selectOptions config.starshipSizes selected=itemData.maxSize localize=true}}
+                            {{selectOptions (sfrpg "starshipSizes") selected=itemData.maxSize localize=true}}
                         </select>
                     </div>
 

--- a/src/templates/items/starshipFrame.hbs
+++ b/src/templates/items/starshipFrame.hbs
@@ -42,7 +42,7 @@
                                 <label>{{ localize "SFRPG.ItemSheet.StarshipFrame.Details.Size" }}</label>
                                 <div class="form-fields">
                                     <select class="actor-size" name="system.size">
-                                        {{selectOptions config.starshipSizes selected=itemData.size}}
+                                        {{selectOptions (sfrpg "starshipSizes") selected=itemData.size}}
                                     </select>
                                 </div>
                             </div>
@@ -52,7 +52,7 @@
                                 <label>{{ localize "SFRPG.ItemSheet.StarshipFrame.Details.Maneuverability" }}</label>
                                 <div class="form-fields">
                                     <select class="actor-size" name="system.maneuverability">
-                                        {{selectOptions config.maneuverability selected=itemData.maneuverability}}
+                                        {{selectOptions (sfrpg "maneuverability") selected=itemData.maneuverability}}
                                     </select>
                                 </div>
                             </div>

--- a/src/templates/items/starshipPowerCore.hbs
+++ b/src/templates/items/starshipPowerCore.hbs
@@ -26,7 +26,7 @@
                 <h3 class="bubble-header">{{ localize "SFRPG.ItemSheet.StarshipPowerCore.Header" }}</h3>
 
                 <div class="bubble-info">
-                    
+
                     {{!-- Power Provided --}}
                     <div class="form-group" data-tooltip="<b>{{ localize "SFRPG.ItemSheet.StarshipPowerCore.ProvidedPower" }}</b><br/>{{ localize "SFRPG.ItemSheet.StarshipPowerCore.ProvidedPowerTooltip" }}">
                         <label>{{ localize "SFRPG.ItemSheet.StarshipPowerCore.ProvidedPower" }}</label>
@@ -38,7 +38,7 @@
             {{!-- Supported Sizes --}}
             <div class="form-group stacked weapon-properties" data-tooltip="<strong>{{ localize "SFRPG.ItemSheet.StarshipPowerCore.Sizes" }}</strong><br/>{{ localize "SFRPG.ItemSheet.StarshipPowerCore.SizesTooltip" }}">
                 <label>{{ localize "SFRPG.ItemSheet.StarshipPowerCore.Sizes" }}</label>
-                {{#each config.starshipSizes as |typeName typeKey|}}
+                {{#each (sfrpg "starshipSizes") as |typeName typeKey|}}
                 <label class="checkbox">
                     <input type="checkbox" class="system.supportedSizes" data-size="{{typeKey}}" {{checked (contains ../itemData.supportedSizes typeKey)}}/>{{localize typeName}}
                 </label>

--- a/src/templates/items/starshipSensor.hbs
+++ b/src/templates/items/starshipSensor.hbs
@@ -39,7 +39,7 @@
                     <div class="form-group" data-tooltip="<b>{{ localize "SFRPG.ItemSheet.StarshipSensor.Range" }}</b><br/>{{ localize "SFRPG.ItemSheet.StarshipSensor.RangeTooltip" }}">
                         <label>{{ localize "SFRPG.ItemSheet.StarshipSensor.Range" }}</label>
                         <select name="system.range">
-                            {{selectOptions config.starshipWeaponRanges selected=itemData.range localize=true}}
+                            {{selectOptions (sfrpg "starshipWeaponRanges") selected=itemData.range localize=true}}
                         </select>
                     </div>
 

--- a/src/templates/items/starshipThruster.hbs
+++ b/src/templates/items/starshipThruster.hbs
@@ -31,7 +31,7 @@
                     <div class="form-group" data-tooltip="<b>{{ localize "SFRPG.ItemSheet.StarshipThruster.Size" }}</b><br/>{{ localize "SFRPG.ItemSheet.StarshipThruster.SizeTooltip" }}">
                         <label>{{ localize "SFRPG.ItemSheet.StarshipThruster.Size" }}</label>
                         <select name="system.supportedSize">
-                            {{selectOptions config.starshipSizes selected=itemData.supportedSize localize=true}}
+                            {{selectOptions (sfrpg "starshipSizes") selected=itemData.supportedSize localize=true}}
                         </select>
                     </div>
 

--- a/src/templates/items/starshipWeapon.hbs
+++ b/src/templates/items/starshipWeapon.hbs
@@ -16,10 +16,10 @@
 
             <ul class="summary">
                 <li>
-                    {{lookup config.starshipWeaponTypes itemData.weaponType }}
+                    {{sfrpg "starshipWeaponTypes" itemData.weaponType }}
                 </li>
                 <li>
-                    {{lookup config.starshipWeaponClass itemData.class }}
+                    {{sfrpg "starshipWeaponClass" itemData.class }}
                 </li>
                 <li>
                     <input type="text" name="system.source" value="{{itemData.source}}" placeholder="{{ localize "SFRPG.Items.ShipWeapon.Source" }}" />
@@ -69,7 +69,7 @@
                                 <label>{{ localize "SFRPG.Items.Weapon.Type" }}</label>
                                 <div class="form-fields">
                                     <select name="system.weaponType">
-                                        {{selectOptions config.starshipWeaponTypes selected=itemData.weaponType}}
+                                        {{selectOptions (sfrpg "starshipWeaponTypes") selected=itemData.weaponType}}
                                     </select>
                                 </div>
                             </div>
@@ -79,7 +79,7 @@
                                 <label>{{ localize "SFRPG.Items.ShipWeapon.WeaponClass" }}</label>
                                 <div class="form-fields">
                                     <select name="system.class">
-                                        {{selectOptions config.starshipWeaponClass selected=itemData.class}}
+                                        {{selectOptions (sfrpg "starshipWeaponClass") selected=itemData.class}}
                                     </select>
                                 </div>
                             </div>
@@ -94,7 +94,7 @@
                                     <span class="sep"> </span>
                                     <select name="system.mount.arc">
                                         {{selectOption "" "SFRPG.ItemSheet.StarshipWeapon.Unmounted" selected=itemData.mount.arc localize=true}}
-                                        {{selectOptions config.starshipArcs selected=itemData.mount.arc}}
+                                        {{selectOptions (sfrpg "starshipArcs") selected=itemData.mount.arc}}
                                     </select>
                                 </div>
                             </div>
@@ -127,7 +127,7 @@
                                 <h3 class="bubble-header">{{ localize "SFRPG.Items.Weapon.Properties" }}</h3>
 
                                 <div class="form-group stacked weapon-properties bubble-info">
-                                    {{#each config.starshipWeaponProperties as |name prop|}}
+                                    {{#each (sfrpg "starshipWeaponProperties") as |name prop|}}
                                     <label class="checkbox">
                                         <input type="checkbox" name="system.special.{{prop}}" {{checked (lookup ../itemData.special prop)}} />
                                         {{ name }}
@@ -157,7 +157,7 @@
                             <div class="form-group select" {{createTippy title="SFRPG.Items.Action.ActionTarget.Title" subtitle="SFRPG.Items.Action.ActionTarget.Tooltip"}}>
                                 <label>{{ localize "SFRPG.Items.Action.ActionTarget.Title" }}</label>
                                 <select name="system.actionTarget">
-                                    {{selectOptions config.actionTargetsStarship selected=itemData.actionTarget}}
+                                    {{selectOptions (sfrpg "actionTargetsStarship") selected=itemData.actionTarget}}
                                 </select>
                             </div>
 
@@ -166,7 +166,7 @@
                                 <label>{{ localize "SFRPG.Items.ShipWeapon.Range" }}</label>
                                 <div class="form-fields">
                                     <select name="system.range">
-                                        {{selectOptions config.starshipWeaponRanges selected=itemData.range}}
+                                        {{selectOptions (sfrpg "starshipWeaponRanges") selected=itemData.range}}
                                     </select>
                                 </div>
                             </div>

--- a/src/templates/items/theme.hbs
+++ b/src/templates/items/theme.hbs
@@ -45,7 +45,7 @@
                         <label>{{ localize "SFRPG.Items.Theme.AbilityAdjustment" }}</label>
                         <div class="form-fields">
                             <select name="system.abilityMod.ability">
-                                {{selectOptions config.abilities selected=itemData.abilityMod.ability}}
+                                {{selectOptions (sfrpg "abilities") selected=itemData.abilityMod.ability}}
                             </select>
                             <input type="text" name="system.abilityMod.mod" value="{{itemData.abilityMod.mod}}" data-dtype="Number" />
                         </div>
@@ -54,7 +54,7 @@
                     <div class="form-group">
                         <label>{{ localize "SFRPG.Items.Theme.Skill" }}</label>
                         <select name="system.skill">
-                            {{selectOptions config.skills selected=itemData.skill}}
+                            {{selectOptions (sfrpg "skills") selected=itemData.skill}}
                         </select>
                     </div>
                 </div>

--- a/src/templates/items/upgrade.hbs
+++ b/src/templates/items/upgrade.hbs
@@ -45,7 +45,7 @@
                                 <label>{{ localize "SFRPG.Items.Upgrade.AllowedArmorType" }}</label>
                                 <select name="system.allowedArmorType">
                                     {{selectOption "any" "SFRPG.Items.Upgrade.Any" selected=itemData.allowedArmorType localize=true}}
-                                    {{selectOptions config.allowedArmorTypes selected=itemData.allowedArmorType}}
+                                    {{selectOptions (sfrpg "allowedArmorTypes") selected=itemData.allowedArmorType}}
                                 </select>
                             </div>
                         </div>

--- a/src/templates/items/vehicleAttack.hbs
+++ b/src/templates/items/vehicleAttack.hbs
@@ -69,10 +69,10 @@
                             <input type="text" name="system.save.dc" value="{{itemData.save.dc}}" data-dtype="String" placeholder="{{placeholders.saveDC.formula}}"/>
                             <select name="system.save.type">
                                 {{selectOption "" "" selected=itemData.save.type}}
-                                {{selectOptions config.saves selected=itemData.save.type}}
+                                {{selectOptions (sfrpg "saves") selected=itemData.save.type}}
                             </select>
                             <select name="system.save.descriptor">
-                                {{selectOptions config.saveDescriptors selected=itemData.save.descriptor}}
+                                {{selectOptions (sfrpg "saveDescriptors") selected=itemData.save.descriptor}}
                             </select>
                         </div>
                     </div>

--- a/src/templates/items/weapon.hbs
+++ b/src/templates/items/weapon.hbs
@@ -40,7 +40,7 @@
                             <div class="form-group">
                                 <label>{{ localize "SFRPG.Items.Weapon.Type" }}</label>
                                 <select name="system.weaponType">
-                                    {{selectOptions config.weaponTypes selected=itemData.weaponType}}
+                                    {{selectOptions (sfrpg "weaponTypes") selected=itemData.weaponType}}
                                 </select>
                             </div>
 
@@ -49,7 +49,7 @@
                                 <label>{{ localize "SFRPG.Items.Weapon.Category" }}</label>
                                 <select name="system.weaponCategory">
                                     {{selectOption "" "Unspecified" selected=itemData.weaponCategory}}
-                                    {{selectOptions config.weaponCategories selected=itemData.weaponCategory}}
+                                    {{selectOptions (sfrpg "weaponCategories") selected=itemData.weaponCategory}}
                                 </select>
                             </div>
 

--- a/src/templates/items/weaponAccessory.hbs
+++ b/src/templates/items/weaponAccessory.hbs
@@ -36,7 +36,7 @@
                             <div class="form-group">
                                 <div class="form-fields">
                                     <select name="system.weaponType">
-                                        {{selectOptions config.weaponAccessoriesSupportedTypes selected=itemData.weaponType}}
+                                        {{selectOptions (sfrpg "weaponAccessoriesSupportedTypes") selected=itemData.weaponType}}
                                     </select>
                                 </div>
                             </div>


### PR DESCRIPTION
Extension to #1401. In that PR I originally introduced the `config` helper, but it was preferred that SFRPG not mix the `config` variable and a `config` helper. It was suggested that a different PR could introduce the helper and replace all the variables at once.

I took the opportunity to also assimilate and extend the behavior of `lookup` into the helper, as `(lookup config.<value> variable)` was a common pattern.