### PR TITLE
Add proper evaluation of power armor speed override

### DIFF
--- a/src/templates/items/equipment.hbs
+++ b/src/templates/items/equipment.hbs
@@ -112,7 +112,8 @@
                             <div class="form-group">
                                 <label>{{ localize "SFRPG.Speed" }}</label>
                                 <div class="form-fields">
-                                    <input type="text" name="system.speed" value="{{itemData.speed}}" placeholder="30 {{ localize "SFRPG.Units.Speed" }}" />
+                                    <input type="text" name="system.speed" value="{{itemData.speed}}" placeholder="30" data-dtype="Number"/>
+                                    <span>{{ localize "SFRPG.Ft" }}</span>
                                 </div>
                             </div>
 


### PR DESCRIPTION
This is to add an override for actor speeds if they're wearing power armor. I think to properly address this, though, we need to include the option to add each speed type to the armor, which will then require updating all the power armor items in the compendiums (and any NPCs using power armor items). For now just including as a draft as it's still a WIP.