### PR TITLE
Package release updates

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -168,3 +168,26 @@ Don't use this, just run `npm ci` instead.
 ### Getting Foundry Intellisense in Visual Studio Code
 
 If you would like some basic Intellisense for the Foundry types when using Visual Studio Code, all you have to do is copy `foundry.js` into the projects root folder. The `foundry.js` can be found in your Foundry installation folder e.g. '\Foundry Virtual Tabletop\resources\app\public\scripts'. Once you do this, restart VS Code, and you should now see proper Intellisense.
+
+### Package Release Process (for maintainers only)
+
+The steps below indicate step-by-step what to do to release a new version of the game system. This should only need to be done by package maintainers.
+
+1. In the `development` branch:
+    1. Update `changelist.md` with the changes included in the version. For major changes, try to indicate the contributor when possible (it's nice to give people credit :D ).
+    2. Run `npm run copyLocalization` to make sure no localization changes were missed.
+2. Merge the `development` branch into the `master` branch.
+3. In the `master` branch:
+    1. Run `npm run clean` to clean the `dist` folder.
+    2. Run `npm run cook` to compile the source .json files for actors and items into the compendiums.
+    3. Run `npm run build` to build the system into the `dist` folder.
+    4. Run `npm run package` to generate the files to attach to the github release.
+    5. Commit all changes, including the compendium files, to master.
+4. On github:
+    1. Create a new release with the version number as the tag (don't include a `v` in front of the version number).
+    2. Attach the files in the `package` folder to the release. This should be `system.json` and `sfrpg-x.xx.x.zip`
+5. On the Foundry package admin website, add the new system version and the appropriate links.
+6. On the `development` branch:
+    1. Update the version number in `system.json` to the next version number (change both `version` and `download`).
+    2. Run `npm run cook` to update the version numbers in the compendium `.json` files.
+    3. Commit the `.json` files (but not the compendium database files).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -184,7 +184,7 @@ The steps below indicate step-by-step what to do to release a new version of the
     4. Run `npm run package` to generate the files to attach to the github release.
     5. Commit all changes, including the compendium files, to master.
 4. On github:
-    1. Create a new release with the version number as the tag (don't include a `v` in front of the version number).
+    1. Create a new release with the version number as the tag (don't include a `v` in front of the version number). Include the changelist for this version in the release notes.
     2. Attach the files in the `package` folder to the release. This should be `system.json` and `sfrpg-x.xx.x.zip`
 5. On the Foundry package admin website, add the new system version and the appropriate links.
 6. On the `development` branch:

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1759,7 +1759,7 @@ async function packageBuild() {
         await fs.ensureDir('package');
 
         // Initialize the zip file
-        const zipName = `${manifest.file.id}-v${manifest.file.version}.zip`;
+        const zipName = `${manifest.file.id}-${manifest.file.version}.zip`;
         const zipFile = fs.createWriteStream(path.join('package', zipName));
         const zip = archiver('zip', { zlib: { level: 9 } });
 
@@ -1779,6 +1779,16 @@ async function packageBuild() {
         zip.directory('dist/', manifest.file.id);
 
         zip.finalize();
+
+        // Copy the system.json file to the package directory
+        fs.copyFile('src/system.json', 'package/system.json', (err) => {
+            if (err) {
+                console.log(chalk.red("Error Found:", err));
+            }
+            else {
+                console.log(chalk.green("system.json successfully copied."));
+            }
+        });
     } catch (err) {
         Promise.reject(err);
     }

--- a/src/system.json
+++ b/src/system.json
@@ -14,7 +14,7 @@
         "maximum": 12
     },
     "url": "https://github.com/foundryvtt-starfinder/foundryvtt-starfinder",
-    "manifest": "https://raw.githubusercontent.com/foundryvtt-starfinder/foundryvtt-starfinder/master/src/system.json",
+    "manifest": "https://github.com/foundryvtt-starfinder/foundryvtt-starfinder/releases/latest/download/system.json",
     "download": "https://github.com/foundryvtt-starfinder/foundryvtt-starfinder/releases/download/0.27.1/sfrpg-0.27.1.zip",
     "flags": {
         "sfrpg": {


### PR DESCRIPTION
This switches the manifest URL to be linked to a `system.json` file included with the release, rather than in the `master` branch. This will require a copy of `system.json` to be attached to the release along with the zip file when releasing, so I've modified the `package` gulp command to copy it as well when making the release `.zip` file.

In addition, I've written up a detailed process for all the steps required to make a new release, so that can be followed step-by-step in the future (and act as the basis for setting up github actions to automate release steps in the future).