### PR TITLE
Danimrath/item collection bugs

### DIFF
--- a/src/module/actor/actor-inventory-utils.js
+++ b/src/module/actor/actor-inventory-utils.js
@@ -575,7 +575,7 @@ export async function onCreateItemCollection(message) {
         // We can make this payload.itemData[0].img to have the image be of the item
         // If so we should make it also update when you add or remove more items to make it a bag
         texture: {
-            src: "icons/svg/item-bag.svg"
+            src: "systems/sfrpg/icons/default/" + SFRPG.defaultItemIcons.container
         },
         hidden: false,
         locked: true,
@@ -632,7 +632,7 @@ async function onItemDraggedToCollection(message) {
             const containersToTest = [sourceItemData];
             while (containersToTest.length > 0) {
                 const container = containersToTest.shift();
-                const children = source.filterItems(x => container.system.container.contents.find(y => y.id === x.id));
+                const children = source.filterItems(x => container.system.container?.contents.find(y => y.id === x.id));
                 if (children) {
                     for (const child of children) {
                         newItems.push(child);

--- a/src/module/actor/actor-inventory-utils.js
+++ b/src/module/actor/actor-inventory-utils.js
@@ -569,7 +569,7 @@ export async function onCreateItemCollection(message) {
     }
 
     const createdTokenPromise = canvas.scene.createEmbeddedDocuments("Token", [{
-        name: payload.itemData[0].name,
+        name: "Item Collection",
         x: payload.position.x,
         y: payload.position.y,
         // We can make this payload.itemData[0].img to have the image be of the item

--- a/src/module/actor/actor-inventory-utils.js
+++ b/src/module/actor/actor-inventory-utils.js
@@ -572,7 +572,11 @@ export async function onCreateItemCollection(message) {
         name: payload.itemData[0].name,
         x: payload.position.x,
         y: payload.position.y,
-        img: payload.itemData[0].img,
+        // We can make this payload.itemData[0].img to have the image be of the item
+        // If so we should make it also update when you add or remove more items to make it a bag
+        texture: {
+            src: "icons/svg/item-bag.svg"
+        },
         hidden: false,
         locked: true,
         disposition: 0,
@@ -631,11 +635,11 @@ async function onItemDraggedToCollection(message) {
                 const children = source.filterItems(x => container.system.container.contents.find(y => y.id === x.id));
                 if (children) {
                     for (const child of children) {
-                        newItems.push(child.data);
+                        newItems.push(child);
                         itemIdsToDelete.push(child.id);
 
                         if (child.system.container?.contents && child.system.container.contents.length > 0) {
-                            containersToTest.push(child.data);
+                            containersToTest.push(child);
                         }
                     }
                 }
@@ -651,9 +655,10 @@ async function onItemDraggedToCollection(message) {
         }
     }
 
-    for (const item of newItems) {
-        item._id = generateUUID();
-    }
+    // Seems to be broken you cannot edit a readonly field?
+    // for (const item of newItems) {
+    //     item._id = generateUUID();
+    // }
 
     if (newItems.length > 0) {
         if (targetContainer && targetContainer.system.container?.contents) {
@@ -663,6 +668,7 @@ async function onItemDraggedToCollection(message) {
             }
         }
         newItems = items.concat(newItems);
+        // can force updates to the image here potentially. texture.src = "icons/svg/item-bag.svg";
         const update = {
             "flags.sfrpg.itemCollection.items": newItems
         };

--- a/src/module/apps/item-collection-sheet.js
+++ b/src/module/apps/item-collection-sheet.js
@@ -121,7 +121,12 @@ export class ItemCollectionSheet extends DocumentSheet {
         // Ensure containers are always open in loot collection tokens
         for (const itemData of data.items) {
             if (itemData.contents && itemData.contents.length > 0) {
-                itemData.item.isOpen = true;
+                itemData.item.config = { "isOpen": true};
+                for (const child of itemData.contents) {
+                    if (child.contents && child.contents.length > 0) {
+                        child.item.config = { "isOpen": true};
+                    }
+                }
             }
         }
 

--- a/src/module/canvas/canvas.js
+++ b/src/module/canvas/canvas.js
@@ -139,7 +139,7 @@ async function handleCanvasDropAsync(canvas, data, targetActor) {
             const containersToTest = [sourceItemData];
             while (containersToTest.length > 0) {
                 const container = containersToTest.shift();
-                const children = sourceActor.filterItems(x => container.container.contents.find(y => y.id === x.id));
+                const children = sourceActor.filterItems(x => container.container?.contents.find(y => y.id === x.id));
                 if (children) {
                     for (const child of children) {
                         transferringItems.push(child);

--- a/src/module/canvas/canvas.js
+++ b/src/module/canvas/canvas.js
@@ -136,16 +136,16 @@ async function handleCanvasDropAsync(canvas, data, targetActor) {
     if (targetActor === null) {
         const transferringItems = [sourceItem];
         if (sourceActor !== null && sourceItemData.container?.contents && sourceItemData.container.contents.length > 0) {
-            const containersToTest = [sourceItemData];
+            const containersToTest = [sourceItemData.container];
             while (containersToTest.length > 0) {
                 const container = containersToTest.shift();
-                const children = sourceActor.filterItems(x => container.container?.contents.find(y => y.id === x.id));
+                const children = sourceActor.filterItems(x => container.contents?.find(y => y.id === x.id));
                 if (children) {
                     for (const child of children) {
                         transferringItems.push(child);
 
                         if (child.system.container?.contents && child.system.container.contents.length > 0) {
-                            containersToTest.push(child);
+                            containersToTest.push(child.system.container);
                         }
                     }
                 }


### PR DESCRIPTION
Canvas.js handleCanvasDropAsync has similar code and also needs updates.

Using collections in collections is the biggest bug left. null space with items inside that have upgrades or ammo as an example.
Dropping on canvas will crash and transferring to an existing container will work but attach items to different items than they were originally attached to. (Fixed)

Remaining Work:

Change name of item collection if we are going with the briefcase to be something other than the name of the dropped item
Fix bug with dropping containers in containers on canvas. It works fine when dropping them onto an already created loot container but it messes up the items if it's straight to canvas.