### PR TITLE
Only calculate equipped bulk modifier on characters

### DIFF
--- a/src/module/rules/actions/actor/calculate-bulk-and-wealth.js
+++ b/src/module/rules/actions/actor/calculate-bulk-and-wealth.js
@@ -55,7 +55,7 @@ function computeCompoundBulkForItem(item, contents) {
             personalBulk *= packs;
         }
 
-        if (itemData.equipped) {
+        if (itemData.equipped && item.parent.type === "character") {
             let bulkMultiplier = Number.parseInt(itemData.equippedBulkMultiplier);
             if (itemData.armor?.type === 'power') {
                 item.getCurrentCapacity() ? bulkMultiplier = 0 : "";


### PR DESCRIPTION
When doing item.getCurrentCapacity() it creates a helper actor and then proceeds to look infinitely attempting to calculate the bulk if the item is inside a container but still marked as equipped.