### PR TITLE
Fix uninitialized variable error when doing `npm run unpack`

### DIFF
--- a/build/unpack.js
+++ b/build/unpack.js
@@ -19,7 +19,6 @@ if (path.resolve(modulePath) === path.resolve(process.argv[1])) {
     });
 }
 
-const limitToPack = null;
 async function unpack({packName, filePath, outputDirectory, partOfCook = false}) {
     console.log(`> Starting unpack of ${packName} into ${outputDirectory}`);
     fs.mkdir(`${outputDirectory}`, { recursive: true }, (err) => {
@@ -83,6 +82,8 @@ async function unpack({packName, filePath, outputDirectory, partOfCook = false})
 }
 
 export async function unpackPacks(partOfCook = false) {
+    // For now, there is no limitToPack functionality, but the bones of it have been left in
+    // and it could be re-added in the future
     const limitToPack = null;
     const sourceDir = partOfCook ? "src/packs" : 'dist/packs';
     console.log(chalk.blueBright(`Unpacking ${partOfCook ? "" : "and sanitizing "}all packs from ${sourceDir}`));

--- a/build/unpack.js
+++ b/build/unpack.js
@@ -83,6 +83,7 @@ async function unpack({packName, filePath, outputDirectory, partOfCook = false})
 }
 
 export async function unpackPacks(partOfCook = false) {
+    const limitToPack = null;
     const sourceDir = partOfCook ? "src/packs" : 'dist/packs';
     console.log(chalk.blueBright(`Unpacking ${partOfCook ? "" : "and sanitizing "}all packs from ${sourceDir}`));
 


### PR DESCRIPTION
When running `npm run unpack` in terminal, it throws an error saying `limitToPack` is accessed before initialization. This tweak sets that variable explicitly to `null` to fix the error.