### PR TITLE
Only return a value or null not undefined.

### DIFF
--- a/src/module/item/mixins/item-capacity.js
+++ b/src/module/item/mixins/item-capacity.js
@@ -46,7 +46,7 @@ export const ItemCapacityMixin = (superclass) => class extends superclass {
         // Find child item
         const childItems = getChildItems(itemHelper, this);
         const loadedAmmunition = childItems.find(x => x.type === "ammunition");
-        return loadedAmmunition;
+        return loadedAmmunition ?? null;
     }
 
     /**


### PR DESCRIPTION
A change to item-capacity.js to accept specifically null values broke reloading capacity weapons. This changes getCapacityItem() to specifically return only null's or an item not null's items or undefined.