### PR TITLE
Fix incorrect usage deduction for consumables such as serum of healing

### DIFF
--- a/src/module/item/item.js
+++ b/src/module/item/item.js
@@ -1626,25 +1626,27 @@ export class ItemSFRPG extends Mix(Item).with(ItemActivationMixin, ItemCapacityM
         // Deduct consumed charges from the item
         if (itemData.uses.autoUse && !overrideUsage) {
             let quantity = itemData.quantity;
-            const remainingUses = this.getRemainingUses();
+            let remainingUses = Math.max(this.getRemainingUses() - 1, 0);
 
-            // Deduct an item quantity
-            if (remainingUses <= 1 && quantity >= 1) {
-                quantity -= 1;
-                this.update({
-                    'system.quantity': Math.max(quantity, 0),
-                    'system.uses.value': (quantity === 0) ? 0 : this.getMaxUses()
-                });
-            }
-
-            // Optionally destroy the item
-            else if (remainingUses <= 1 && quantity === 0 && itemData.uses.autoDestroy) {
-                this.actor.deleteEmbeddedDocuments("Item", [this.id]);
-            }
-
-            // Deduct the remaining charges
-            else {
-                this.update({'system.uses.value': Math.max(remainingUses - 1, 0) });
+            if (remainingUses < 1) {
+                // Deduct an item quantity
+                quantity = Math.max(quantity - 1, 0);
+                if (quantity < 1 && itemData.uses.autoDestroy) {
+                    // Destroy the item
+                    this.actor.deleteEmbeddedDocuments("Item", [this.id]);
+                } else {
+                    if (quantity > 0) {
+                        // Reset the remaining charges
+                        remainingUses = this.getMaxUses();
+                    }
+                    this.update({
+                        'system.quantity': quantity,
+                        'system.uses.value': remainingUses
+                    });
+                }
+            } else {
+                // Deduct the remaining charges
+                this.update({'system.uses.value': remainingUses});
             }
         }
     }


### PR DESCRIPTION
This fixes a bug where, when you have a consumable item with both "Consume on use" and "Destroy when empty" ticked, the last item is not destroyed when empty, and the player is just left with an unusable item in the inventory (this can be reproduced with Serum of Healing Mk 1).

I also rewrote the logic a little bit, because I found the original logic hard to follow when trying to fix this bug.