### PR TITLE
Consumable field rations

### DIFF
--- a/src/items/equipment/field_ration.json
+++ b/src/items/equipment/field_ration.json
@@ -1,7 +1,7 @@
 {
   "_id": "rAOula25Uqzzpsx1",
-  "name": "Field Ration (1/Week)",
-  "type": "goods",
+  "name": "Field Ration",
+  "type": "consumable",
   "_stats": {
     "coreVersion": 12,
     "systemId": "sfrpg",
@@ -10,6 +10,11 @@
   "img": "systems/sfrpg/icons/equipment/goods/field-ration.webp",
   "system": {
     "type": "",
+    "activation": {
+      "type": "none",
+      "condition": "",
+      "cost": 0
+    },
     "attributes": {
       "ac": {
         "value": ""
@@ -30,6 +35,7 @@
     },
     "attuned": false,
     "bulk": "1",
+    "consumableType": "foodDrink",
     "damage": {
       "parts": []
     },
@@ -38,7 +44,11 @@
       "gmnotes": "",
       "short": "",
       "unidentified": "",
-      "value": "<p>A field ration is prepackaged food that can easily sustain you but lacks flavor and visual appeal. Field rations generally consist of chewy, brownish blocks of processed nutrients, which contain enough moisture to provide a day’s worth of water intake. While it is possible to survive for weeks on nothing but field rations, it’s not a pleasant experience.</p>"
+      "value": "<p><strong>Usage:</strong> 1 / week</p>\n<p>A field ration is prepackaged food that can easily sustain you but lacks flavor and visual appeal. Field rations generally consist of chewy, brownish blocks of processed nutrients, which contain enough moisture to provide a day’s worth of water intake. While it is possible to survive for weeks on nothing but field rations, it’s not a pleasant experience.</p>"
+    },
+    "duration": {
+      "units": "day",
+      "value": "1"
     },
     "equippable": false,
     "equipped": false,
@@ -49,6 +59,13 @@
     "price": 1,
     "quantity": 1,
     "quantityPerPack": 1,
-    "source": "Core Rulebook"
+    "source": "Core Rulebook",
+    "uses": {
+      "autoDestroy": true,
+      "autoUse": true,
+      "max": "7",
+      "per": "charges",
+      "value": 7
+    }
   }
 }


### PR DESCRIPTION
Change the field ration into a consumable with 7 charges, one charge used per day.
This makes it possible to track ration usage.