### PR TITLE
Fix incorrect price of Junk Camouflage

### DIFF
--- a/src/items/equipment/junk_camouflage.json
+++ b/src/items/equipment/junk_camouflage.json
@@ -52,7 +52,7 @@
     "identified": true,
     "level": 1,
     "modifiers": [],
-    "price": 503,
+    "price": 50,
     "quantity": 1,
     "quantityPerPack": 1,
     "source": "SA:JD pg. 56"


### PR DESCRIPTION
The price of Junk Camouflage was set to 503 when it should be 50.
https://www.aonsrd.com/OtherItemsDisplay.aspx?ItemName=Junk%20Camouflage&Family=None