### PR TITLE
Rubbish Cannon fixes

### DIFF
--- a/src/items/equipment/junk.json
+++ b/src/items/equipment/junk.json
@@ -1,0 +1,33 @@
+{
+  "_id": "Lhdt4ioOuAIX2GQt",
+  "name": "Junk",
+  "type": "ammunition",
+  "_stats": {
+    "coreVersion": 12,
+    "systemId": "sfrpg",
+    "systemVersion": "0.28.0"
+  },
+  "img": "icons/commodities/tech/metal-barrel.webp",
+  "system": {
+    "type": "",
+    "ammunitionType": "junk",
+    "attuned": false,
+    "bulk": "1",
+    "damage": {
+      "parts": []
+    },
+    "description": {
+      "chat": "",
+      "unidentified": "",
+      "value": "<p>1 bulk of junk - useless trash found in most urban environments.</p>"
+    },
+    "equipped": false,
+    "identified": true,
+    "level": 1,
+    "price": 0,
+    "quantity": 1,
+    "quantityPerPack": 1,
+    "source": "SA:JD",
+    "useCapacity": false
+  }
+}

--- a/src/items/equipment/rubbish_cannon_heavy.json
+++ b/src/items/equipment/rubbish_cannon_heavy.json
@@ -7,7 +7,7 @@
     "systemId": "sfrpg",
     "systemVersion": "0.28.0"
   },
-  "img": "systems/sfrpg/icons/equipment/weapons/nil-grenade-launcher-merc.jpg",
+  "img": "systems/sfrpg/icons/equipment/weapons/nil-grenade-launcher-merc.webp",
   "system": {
     "type": "",
     "ability": "dex",
@@ -21,7 +21,7 @@
       "condition": "",
       "cost": null
     },
-    "ammunitionType": "flare",
+    "ammunitionType": "junk",
     "area": {
       "effect": "",
       "shapable": false,

--- a/src/items/equipment/rubbish_cannon_light.json
+++ b/src/items/equipment/rubbish_cannon_light.json
@@ -7,7 +7,7 @@
     "systemId": "sfrpg",
     "systemVersion": "0.28.0"
   },
-  "img": "systems/sfrpg/icons/equipment/weapons/nil-grenade-launcher-merc.jpg",
+  "img": "systems/sfrpg/icons/equipment/weapons/nil-grenade-launcher-merc.webp",
   "system": {
     "type": "",
     "ability": "dex",
@@ -21,7 +21,7 @@
       "condition": "",
       "cost": null
     },
-    "ammunitionType": "flare",
+    "ammunitionType": "junk",
     "area": {
       "effect": "",
       "shapable": false,

--- a/src/items/equipment/rubbish_cannon_standard.json
+++ b/src/items/equipment/rubbish_cannon_standard.json
@@ -1,13 +1,13 @@
 {
   "_id": "vX3ph7TVBVwo63bR",
-  "name": "Rubbish Cannon,Standard",
+  "name": "Rubbish Cannon, Standard",
   "type": "weapon",
   "_stats": {
     "coreVersion": 12,
     "systemId": "sfrpg",
     "systemVersion": "0.28.0"
   },
-  "img": "systems/sfrpg/icons/equipment/weapons/nil-grenade-launcher-merc.jpg",
+  "img": "systems/sfrpg/icons/equipment/weapons/nil-grenade-launcher-merc.webp",
   "system": {
     "type": "",
     "ability": "dex",
@@ -21,7 +21,7 @@
       "condition": "",
       "cost": null
     },
-    "ammunitionType": "flare",
+    "ammunitionType": "junk",
     "area": {
       "effect": "",
       "shapable": false,

--- a/src/module/config.js
+++ b/src/module/config.js
@@ -303,6 +303,7 @@ SFRPG.ammunitionTypes = {
     "flare": "SFRPG.Items.Ammunition.Type.Flares",
     "flechettes": "SFRPG.Items.Ammunition.Type.Flechettes",
     "nanite": "SFRPG.Items.Ammunition.Type.Nanites",
+    "junk": "SFRPG.Items.Ammunition.Type.Junk",
     "caustrol": "SFRPG.Items.Ammunition.Type.Caustrol",
     "sclerite": "SFRPG.Items.Ammunition.Type.Sclerites",
     "moodGoo": "SFRPG.Items.Ammunition.Type.MoodGoo",

--- a/static/lang/de.json
+++ b/static/lang/de.json
@@ -1567,6 +1567,7 @@
                     "Flechettes": "Flechettes",
                     "Fuel": "Benzin",
                     "HeavyRounds": "Patronen für schwere Waffen",
+                    "Junk": "Junk",
                     "LongarmAndSniperRounds": "Patronen für Lang- und Scharfschützenwaffen",
                     "Missiles": "Missiles",
                     "MoodGoo": "Mood Goo",

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -1561,6 +1561,7 @@
                     "Flechettes": "Flechettes",
                     "Fuel": "Petrol",
                     "HeavyRounds": "Heavy Rounds",
+                    "Junk": "Junk",
                     "LongarmAndSniperRounds": "Longarm and Sniper Rounds",
                     "Missiles": "Missiles",
                     "MoodGoo": "Mood Goo",

--- a/static/lang/fr.json
+++ b/static/lang/fr.json
@@ -1561,6 +1561,7 @@
                     "Flechettes": "Flechettes",
                     "Fuel": "Combustible",
                     "HeavyRounds": "Balles pour armes lourdes",
+                    "Junk": "Junk",
                     "LongarmAndSniperRounds": "Balles pour armes longues et de précisions",
                     "Missiles": "Missiles",
                     "MoodGoo": "Mood Goo",

--- a/static/lang/it.json
+++ b/static/lang/it.json
@@ -1567,6 +1567,7 @@
                     "Flechettes": "Flechettes",
                     "Fuel": "Fuel",
                     "HeavyRounds": "Heavy Rounds",
+                    "Junk": "Junk",
                     "LongarmAndSniperRounds": "Longarm and Sniper Rounds",
                     "Missiles": "Missiles",
                     "MoodGoo": "Mood Goo",

--- a/static/lang/ja.json
+++ b/static/lang/ja.json
@@ -1567,6 +1567,7 @@
                     "Flechettes": "Flechettes",
                     "Fuel": "Fuel",
                     "HeavyRounds": "Heavy Rounds",
+                    "Junk": "Junk",
                     "LongarmAndSniperRounds": "Longarm and Sniper Rounds",
                     "Missiles": "Missiles",
                     "MoodGoo": "Mood Goo",

--- a/static/lang/pt-BR.json
+++ b/static/lang/pt-BR.json
@@ -1567,6 +1567,7 @@
                     "Flechettes": "Flechettes",
                     "Fuel": "Fuel",
                     "HeavyRounds": "Heavy Rounds",
+                    "Junk": "Junk",
                     "LongarmAndSniperRounds": "Longarm and Sniper Rounds",
                     "Missiles": "Missiles",
                     "MoodGoo": "Mood Goo",


### PR DESCRIPTION
- Fix icons
- Add missing space to Rubbish Cannon, Standard
- Add junk ammunition type and item
- Rubbish Cannons now uses junk ammo instead of flares