### PR TITLE
Junk Drone and Spy Drone battery fix

### DIFF
--- a/src/items/equipment/junk_drone.json
+++ b/src/items/equipment/junk_drone.json
@@ -21,7 +21,7 @@
       "condition": "",
       "cost": 0
     },
-    "ammunitionType": "",
+    "ammunitionType": "charge",
     "area": {
       "effect": "",
       "shapable": false,
@@ -51,7 +51,7 @@
     "attuned": false,
     "bulk": "1",
     "capacity": {
-      "max": 0,
+      "max": 20,
       "value": 0
     },
     "chatFlavor": "",
@@ -59,7 +59,19 @@
       "contents": [],
       "includeContentsInWealthCalculation": true,
       "isOpen": true,
-      "storage": []
+      "storage": [
+        {
+          "type": "slot",
+          "acceptsType": [
+            "ammunition"
+          ],
+          "affectsEncumbrance": true,
+          "amount": 1,
+          "subtype": "",
+          "weightMultiplier": 1,
+          "weightProperty": ""
+        }
+      ]
     },
     "critical": {
       "effect": "",
@@ -112,8 +124,8 @@
       "value": null
     },
     "usage": {
-      "per": "",
-      "value": 0
+      "per": "minute",
+      "value": 1
     },
     "uses": {
       "max": null,

--- a/src/items/equipment/spy_drone.json
+++ b/src/items/equipment/spy_drone.json
@@ -21,7 +21,7 @@
       "condition": "",
       "cost": 0
     },
-    "ammunitionType": "",
+    "ammunitionType": "charge",
     "area": {
       "effect": "",
       "shapable": false,
@@ -51,7 +51,7 @@
     "attuned": false,
     "bulk": "L",
     "capacity": {
-      "max": 0,
+      "max": 20,
       "value": 0
     },
     "chatFlavor": "",
@@ -59,7 +59,19 @@
       "contents": [],
       "includeContentsInWealthCalculation": 1,
       "isOpen": true,
-      "storage": []
+      "storage": [
+        {
+          "type": "slot",
+          "acceptsType": [
+            "ammunition"
+          ],
+          "affectsEncumbrance": true,
+          "amount": 1,
+          "subtype": "",
+          "weightMultiplier": 1,
+          "weightProperty": ""
+        }
+      ]
     },
     "critical": {
       "effect": "",
@@ -112,8 +124,8 @@
       "value": null
     },
     "usage": {
-      "per": "",
-      "value": 0
+      "per": "minute",
+      "value": 1
     },
     "uses": {
       "max": null,


### PR DESCRIPTION
Junk Drone and Spy Drone are powered by batteries, capacity 20, usage 1/minute.
This sets the correct capacity and usage, and allows batteries to be attached and reloaded.