### PR TITLE
Fix unarmed strike proficiency issue

### DIFF
--- a/src/module/actor/actor.js
+++ b/src/module/actor/actor.js
@@ -193,6 +193,7 @@ export class ActorSFRPG extends Mix(Actor).with(ActorConditionsMixin, ActorCrewM
         if (this.type === "character" && game.settings.get("sfrpg", "autoAddUnarmedStrike")) {
             const ITEM_UUID = "Compendium.sfrpg.equipment.AWo4DU0s18agsFtJ"; // Unarmed strike
             const source = (await fromUuid(ITEM_UUID)).toObject();
+            source.system.proficient = true;
             source.flags = foundry.utils.mergeObject(source.flags ?? {}, { core: { sourceId: ITEM_UUID } });
 
             updates.items = [source];


### PR DESCRIPTION
This fixes an issue where "Unarmed strike" does not have "Proficient" ticked when automatically added to new characters