### PR TITLE
Display spell school on chat card

### DIFF
--- a/src/module/item/item.js
+++ b/src/module/item/item.js
@@ -792,6 +792,13 @@ export class ItemSFRPG extends Mix(Item).with(ItemActivationMixin, ItemCapacityM
         props.push(
             {name: labels.level, tooltip: null}
         );
+
+        // Spell school
+        if (CONFIG.SFRPG.spellSchools[data.school]) {
+            props.push(
+                {name: game.i18n.localize(SFRPG.spellSchools[data.school]), tooltip: null}
+            );
+        }
     }
 
     /* -------------------------------------------- */


### PR DESCRIPTION
This adds the spell school to the list of chat card properties so that it appears in the chat area when spells are being cast. This can be useful in certain situations (e.g. if you have Technomantic Talent)