### PR TITLE
Fix incorrect icons on laser pistols

### DIFF
--- a/src/items/equipment/laser_pistol_aphelion.json
+++ b/src/items/equipment/laser_pistol_aphelion.json
@@ -7,7 +7,7 @@
     "systemId": "sfrpg",
     "systemVersion": "0.28.0"
   },
-  "img": "systems/sfrpg/icons/equipment/weapons/laser-pistol-azimuth.webp",
+  "img": "systems/sfrpg/icons/equipment/weapons/laser-pistol-aphelion.webp",
   "system": {
     "type": "",
     "ability": "dex",

--- a/src/items/equipment/laser_pistol_corona.json
+++ b/src/items/equipment/laser_pistol_corona.json
@@ -7,7 +7,7 @@
     "systemId": "sfrpg",
     "systemVersion": "0.28.0"
   },
-  "img": "systems/sfrpg/icons/equipment/weapons/laser-pistol-azimuth.webp",
+  "img": "systems/sfrpg/icons/equipment/weapons/laser-pistol-corona.webp",
   "system": {
     "type": "",
     "ability": "dex",

--- a/src/items/equipment/laser_pistol_parallax.json
+++ b/src/items/equipment/laser_pistol_parallax.json
@@ -7,7 +7,7 @@
     "systemId": "sfrpg",
     "systemVersion": "0.28.0"
   },
-  "img": "systems/sfrpg/icons/equipment/weapons/laser-pistol-azimuth.webp",
+  "img": "systems/sfrpg/icons/equipment/weapons/laser-pistol-parallax.webp",
   "system": {
     "type": "",
     "ability": "dex",

--- a/src/items/equipment/laser_pistol_perihelion.json
+++ b/src/items/equipment/laser_pistol_perihelion.json
@@ -7,7 +7,7 @@
     "systemId": "sfrpg",
     "systemVersion": "0.28.0"
   },
-  "img": "systems/sfrpg/icons/equipment/weapons/laser-pistol-azimuth.webp",
+  "img": "systems/sfrpg/icons/equipment/weapons/laser-pistol-perihelion.webp",
   "system": {
     "type": "",
     "ability": "dex",

--- a/src/items/equipment/laser_pistol_zenith.json
+++ b/src/items/equipment/laser_pistol_zenith.json
@@ -7,7 +7,7 @@
     "systemId": "sfrpg",
     "systemVersion": "0.28.0"
   },
-  "img": "systems/sfrpg/icons/equipment/weapons/laser-pistol-azimuth.webp",
+  "img": "systems/sfrpg/icons/equipment/weapons/laser-pistol-zenith.webp",
   "system": {
     "type": "",
     "ability": "dex",


### PR DESCRIPTION
The icons folder contains a different coloured icon for each laser pistol, but all of them were set to the azimuth icon in the json. This changes the icon fields in the json so that the different coloured icons are actually used.