### PR TITLE
Fix mistakes in prismatic nimbus DC formula

### DIFF
--- a/src/items/class-features/prismatic_nimbus_(su).json
+++ b/src/items/class-features/prismatic_nimbus_(su).json
@@ -108,7 +108,7 @@
     "rollNotes": "",
     "save": {
       "type": "fort",
-      "dc": "10 + abilities.wis.mod + floor(classes.mystic.level / 2)",
+      "dc": "10 + @abilities.wis.mod + floor(@classes.mystic.levels / 2)",
       "descriptor": "negate"
     },
     "source": "DC pg. 42",


### PR DESCRIPTION
The DC formula for Prismatic Nimbus was missing the @ symbols and the s from levels.