### PR TITLE
Fix hybrid property missing from Eoxian Wrackstaff

### DIFF
--- a/src/items/equipment/eoxian_wrackstaff.json
+++ b/src/items/equipment/eoxian_wrackstaff.json
@@ -101,7 +101,7 @@
       "gmnotes": "",
       "short": "",
       "unidentified": "",
-      "value": "<h2>Hybrid item</h2>\n<p>Consisting of a long metallic shaft capped with a two-pronged head, an Eoxian wrackstaff is a two-handed basic melee weapon that deals 6d4 bludgeoning damage and has the block weapon special property. On a critical hit, the target is affected by @UUID[Compendium.sfrpg.spells.Item.2AYPwSy7I0Ar8yAH]{Inflict Pain} (CL 13th). Undead creatures are immune to this critical hit effect.</p>"
+      "value": "<p>Consisting of a long metallic shaft capped with a two-pronged head, an Eoxian wrackstaff is a two-handed basic melee weapon that deals 6d4 bludgeoning damage and has the block weapon special property. On a critical hit, the target is affected by @UUID[Compendium.sfrpg.spells.Item.2AYPwSy7I0Ar8yAH]{Inflict Pain} (CL 13th). Undead creatures are immune to this critical hit effect.</p>"
     },
     "descriptors": [],
     "duration": {
@@ -158,7 +158,7 @@
       "guided": false,
       "harrying": false,
       "holyWater": false,
-      "hybrid": false,
+      "hybrid": true,
       "ignite": false,
       "indirect": false,
       "injection": false,


### PR DESCRIPTION
Eoxian Wrackstaff is a hybrid item. This was being represented with a bold string in the description, and the property tick box was missing. I added the missing tick box and removed the now-superfluous string from the description.