### PR TITLE
Fix mistake in swift kick phase tooltip

### DIFF
--- a/src/items/starship-actions/swift_kick.json
+++ b/src/items/starship-actions/swift_kick.json
@@ -33,7 +33,7 @@
     "order": 31,
     "phase": {
       "name": "Engineering phase",
-      "tooltip": "This action can be taken only during the gunnery phase."
+      "tooltip": "This action can be taken only during the engineering phase."
     },
     "resolvePointCost": 0,
     "role": "minorCrew",


### PR DESCRIPTION
Fixes a mistake in the tooltip of Swift Kick which says gunnery phase instead of engineering phase.