### PR TITLE
Fix name of "Shadow pistol, umbral" to make it consistent with the other shadow pistols

### DIFF
--- a/src/items/equipment/shadow_pistol_umbral.json
+++ b/src/items/equipment/shadow_pistol_umbral.json
@@ -1,6 +1,6 @@
 {
   "_id": "rmbAib1eKQU6uald",
-  "name": "Shadow pistol-umbral",
+  "name": "Shadow pistol, umbral",
   "type": "weapon",
   "_stats": {
     "coreVersion": 12,


### PR DESCRIPTION
This changes the separator in the name of the umbral shadow pistol from a hyphen to a comma so that it matches up with the others.