### PR TITLE
Fix a lot of mistakes with grenade items in the compendium

### DIFF
--- a/src/items/equipment/antigravity_grenade_mk_1.json
+++ b/src/items/equipment/antigravity_grenade_mk_1.json
@@ -14,8 +14,8 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
-    "actionType": "",
+    "actionTarget": "ac5",
+    "actionType": "rwak",
     "activation": {
       "type": "action",
       "condition": "",
@@ -240,7 +240,7 @@
       "value": 1
     },
     "uses": {
-      "max": "1",
+      "max": 1,
       "per": "charges",
       "value": 1
     },

--- a/src/items/equipment/antigravity_grenade_mk_2.json
+++ b/src/items/equipment/antigravity_grenade_mk_2.json
@@ -14,8 +14,8 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
-    "actionType": "",
+    "actionTarget": "ac5",
+    "actionType": "rwak",
     "activation": {
       "type": "action",
       "condition": "",
@@ -240,7 +240,7 @@
       "value": 1
     },
     "uses": {
-      "max": "1",
+      "max": 1,
       "per": "charges",
       "value": 1
     },

--- a/src/items/equipment/antigravity_grenade_mk_3.json
+++ b/src/items/equipment/antigravity_grenade_mk_3.json
@@ -14,8 +14,8 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
-    "actionType": "",
+    "actionTarget": "ac5",
+    "actionType": "rwak",
     "activation": {
       "type": "action",
       "condition": "",
@@ -240,7 +240,7 @@
       "value": 1
     },
     "uses": {
-      "max": "1",
+      "max": 1,
       "per": "charges",
       "value": 1
     },

--- a/src/items/equipment/antigravity_grenade_mk_4.json
+++ b/src/items/equipment/antigravity_grenade_mk_4.json
@@ -14,8 +14,8 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
-    "actionType": "",
+    "actionTarget": "ac5",
+    "actionType": "rwak",
     "activation": {
       "type": "action",
       "condition": "",
@@ -240,7 +240,7 @@
       "value": 1
     },
     "uses": {
-      "max": "1",
+      "max": 1,
       "per": "charges",
       "value": 1
     },

--- a/src/items/equipment/antigravity_grenade_mk_5.json
+++ b/src/items/equipment/antigravity_grenade_mk_5.json
@@ -14,8 +14,8 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
-    "actionType": "",
+    "actionTarget": "ac5",
+    "actionType": "rwak",
     "activation": {
       "type": "action",
       "condition": "",
@@ -240,7 +240,7 @@
       "value": 1
     },
     "uses": {
-      "max": "1",
+      "max": 1,
       "per": "charges",
       "value": 1
     },

--- a/src/items/equipment/antimagic_grenade_i_(hybrid).json
+++ b/src/items/equipment/antimagic_grenade_i_(hybrid).json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "eac",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",
@@ -51,8 +51,8 @@
     "attuned": false,
     "bulk": "L",
     "capacity": {
-      "max": null,
-      "value": 0
+      "max": 1,
+      "value": 1
     },
     "chatFlavor": "",
     "container": {
@@ -95,7 +95,7 @@
       "gmnotes": "",
       "short": "<p>Nicknamed the “hole-maker,” this raw thasteron-packed&nbsp;explosive is a favored room-clearing device for special&nbsp;forces.</p>",
       "unidentified": "",
-      "value": "<p>Anantimagic grenadecreates a temporary field that inhibits magic in its radius. Upon detonation, everything in the grenade’s radius is affected by an area dispel as @UUID[Compendium.sfrpg.spells.Item.1FfFraWlxCu1L4rL]{Dispel Magic, Greater}, using the grenade’s item level as the caster level. Second, each creature in the explosion radius must make a Will save each time they attempt to cast a spell or use a spell-like ability for a number of rounds equal to the grenade’s model number, or lose the spell or spell-like ability. A creature, object, or area can be affected by only oneantimagic grenadeevery 24 hours.</p>"
+      "value": "<p>An antimagic grenade creates a temporary field that inhibits magic in its radius. Upon detonation, everything in the grenade’s radius is affected by an area dispel as @UUID[Compendium.sfrpg.spells.Item.1FfFraWlxCu1L4rL]{Dispel Magic, Greater}, using the grenade’s item level as the caster level. Second, each creature in the explosion radius must make a Will save each time they attempt to cast a spell or use a spell-like ability for a number of rounds equal to the grenade’s model number, or lose the spell or spell-like ability. A creature, object, or area can be affected by only one antimagic grenade every 24 hours.</p>"
     },
     "descriptors": [],
     "duration": {
@@ -152,7 +152,7 @@
       "guided": false,
       "harrying": false,
       "holyWater": false,
-      "hybrid": false,
+      "hybrid": true,
       "ignite": false,
       "indirect": false,
       "injection": false,
@@ -166,7 +166,7 @@
       "modal": false,
       "necrotic": false,
       "nonlethal": false,
-      "one": false,
+      "one": true,
       "operative": false,
       "penetrating": false,
       "polarize": false,
@@ -196,7 +196,7 @@
       "teleportive": false,
       "thought": false,
       "throttle": false,
-      "thrown": false,
+      "thrown": true,
       "thruster": false,
       "trip": false,
       "two": false,
@@ -243,8 +243,8 @@
       "value": "Staggered"
     },
     "usage": {
-      "per": "",
-      "value": null
+      "per": "shot",
+      "value": 1
     },
     "uses": {
       "max": 1,

--- a/src/items/equipment/antimagic_grenade_ii_(hybrid).json
+++ b/src/items/equipment/antimagic_grenade_ii_(hybrid).json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "eac",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",
@@ -51,8 +51,8 @@
     "attuned": false,
     "bulk": "L",
     "capacity": {
-      "max": null,
-      "value": 0
+      "max": 1,
+      "value": 1
     },
     "chatFlavor": "",
     "container": {
@@ -95,7 +95,7 @@
       "gmnotes": "",
       "short": "<p>Nicknamed the “hole-maker,” this raw thasteron-packed&nbsp;explosive is a favored room-clearing device for special&nbsp;forces.</p>",
       "unidentified": "",
-      "value": "<p>Anantimagic grenadecreates a temporary field that inhibits magic in its radius. Upon detonation, everything in the grenade’s radius is affected by an area dispel as @UUID[Compendium.sfrpg.spells.Item.1FfFraWlxCu1L4rL]{Dispel Magic, Greater}, using the grenade’s item level as the caster level. Second, each creature in the explosion radius must make a Will save each time they attempt to cast a spell or use a spell-like ability for a number of rounds equal to the grenade’s model number, or lose the spell or spell-like ability. A creature, object, or area can be affected by only oneantimagic grenadeevery 24 hours.</p>"
+      "value": "<p>An antimagic grenade creates a temporary field that inhibits magic in its radius. Upon detonation, everything in the grenade’s radius is affected by an area dispel as @UUID[Compendium.sfrpg.spells.Item.1FfFraWlxCu1L4rL]{Dispel Magic, Greater}, using the grenade’s item level as the caster level. Second, each creature in the explosion radius must make a Will save each time they attempt to cast a spell or use a spell-like ability for a number of rounds equal to the grenade’s model number, or lose the spell or spell-like ability. A creature, object, or area can be affected by only one antimagic grenade every 24 hours.</p>"
     },
     "descriptors": [],
     "duration": {
@@ -152,7 +152,7 @@
       "guided": false,
       "harrying": false,
       "holyWater": false,
-      "hybrid": false,
+      "hybrid": true,
       "ignite": false,
       "indirect": false,
       "injection": false,
@@ -166,7 +166,7 @@
       "modal": false,
       "necrotic": false,
       "nonlethal": false,
-      "one": false,
+      "one": true,
       "operative": false,
       "penetrating": false,
       "polarize": false,
@@ -196,7 +196,7 @@
       "teleportive": false,
       "thought": false,
       "throttle": false,
-      "thrown": false,
+      "thrown": true,
       "thruster": false,
       "trip": false,
       "two": false,
@@ -243,8 +243,8 @@
       "value": "Staggered"
     },
     "usage": {
-      "per": "",
-      "value": null
+      "per": "shot",
+      "value": 1
     },
     "uses": {
       "max": 1,

--- a/src/items/equipment/barbed_shrapnel_grenade_mk_1.json
+++ b/src/items/equipment/barbed_shrapnel_grenade_mk_1.json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",

--- a/src/items/equipment/barbed_shrapnel_grenade_mk_2.json
+++ b/src/items/equipment/barbed_shrapnel_grenade_mk_2.json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",

--- a/src/items/equipment/barbed_shrapnel_grenade_mk_3.json
+++ b/src/items/equipment/barbed_shrapnel_grenade_mk_3.json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",

--- a/src/items/equipment/barbed_shrapnel_grenade_mk_4.json
+++ b/src/items/equipment/barbed_shrapnel_grenade_mk_4.json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",

--- a/src/items/equipment/concussion_grenade_mk_1.json
+++ b/src/items/equipment/concussion_grenade_mk_1.json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",
@@ -230,7 +230,7 @@
       "value": 1
     },
     "uses": {
-      "max": "1",
+      "max": 1,
       "per": "charges",
       "value": 1
     },

--- a/src/items/equipment/concussion_grenade_mk_2.json
+++ b/src/items/equipment/concussion_grenade_mk_2.json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",
@@ -248,7 +248,7 @@
       "value": 1
     },
     "uses": {
-      "max": "1",
+      "max": 1,
       "per": "charges",
       "value": 1
     },

--- a/src/items/equipment/concussion_grenade_mk_3.json
+++ b/src/items/equipment/concussion_grenade_mk_3.json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",
@@ -248,7 +248,7 @@
       "value": 1
     },
     "uses": {
-      "max": "1",
+      "max": 1,
       "per": "charges",
       "value": 1
     },

--- a/src/items/equipment/concussion_grenade_mk_4.json
+++ b/src/items/equipment/concussion_grenade_mk_4.json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",
@@ -248,7 +248,7 @@
       "value": 1
     },
     "uses": {
-      "max": "1",
+      "max": 1,
       "per": "charges",
       "value": 1
     },

--- a/src/items/equipment/concussion_grenade_mk_5.json
+++ b/src/items/equipment/concussion_grenade_mk_5.json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",
@@ -248,7 +248,7 @@
       "value": 1
     },
     "uses": {
-      "max": "1",
+      "max": 1,
       "per": "charges",
       "value": 1
     },

--- a/src/items/equipment/containment_grenade_(hybrid).json
+++ b/src/items/equipment/containment_grenade_(hybrid).json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",

--- a/src/items/equipment/cryo_grenade_i.json
+++ b/src/items/equipment/cryo_grenade_i.json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",

--- a/src/items/equipment/cryo_grenade_ii.json
+++ b/src/items/equipment/cryo_grenade_ii.json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",

--- a/src/items/equipment/cryo_grenade_iii.json
+++ b/src/items/equipment/cryo_grenade_iii.json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",

--- a/src/items/equipment/cryo_grenade_iv.json
+++ b/src/items/equipment/cryo_grenade_iv.json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",

--- a/src/items/equipment/darkwater_grenade.json
+++ b/src/items/equipment/darkwater_grenade.json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",
@@ -137,7 +137,7 @@
       "drainCharge": false,
       "echo": false,
       "entangle": false,
-      "explode": false,
+      "explode": true,
       "extinguish": false,
       "feint": false,
       "fiery": false,
@@ -166,7 +166,7 @@
       "modal": false,
       "necrotic": false,
       "nonlethal": false,
-      "one": false,
+      "one": true,
       "operative": false,
       "penetrating": false,
       "polarize": false,
@@ -196,7 +196,7 @@
       "teleportive": false,
       "thought": false,
       "throttle": false,
-      "thrown": false,
+      "thrown": true,
       "thruster": false,
       "trip": false,
       "two": false,
@@ -243,7 +243,7 @@
       "value": ""
     },
     "usage": {
-      "per": "round",
+      "per": "shot",
       "value": 1
     },
     "uses": {

--- a/src/items/equipment/decoupler_grenade_i.json
+++ b/src/items/equipment/decoupler_grenade_i.json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",

--- a/src/items/equipment/decoupler_grenade_ii.json
+++ b/src/items/equipment/decoupler_grenade_ii.json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",

--- a/src/items/equipment/decoupler_grenade_iii.json
+++ b/src/items/equipment/decoupler_grenade_iii.json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",

--- a/src/items/equipment/decoupler_grenade_iv.json
+++ b/src/items/equipment/decoupler_grenade_iv.json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",

--- a/src/items/equipment/decoupler_grenade_v.json
+++ b/src/items/equipment/decoupler_grenade_v.json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",

--- a/src/items/equipment/defoliant_grenade_mk_1.json
+++ b/src/items/equipment/defoliant_grenade_mk_1.json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",
@@ -225,9 +225,9 @@
       "value": 1
     },
     "uses": {
-      "max": 0,
-      "per": "",
-      "value": 0
+      "max": 1,
+      "per": "charges",
+      "value": 1
     },
     "weaponCategory": "uncategorized",
     "weaponType": "grenade"

--- a/src/items/equipment/defoliant_grenade_mk_2.json
+++ b/src/items/equipment/defoliant_grenade_mk_2.json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",
@@ -225,9 +225,9 @@
       "value": 1
     },
     "uses": {
-      "max": 0,
-      "per": "",
-      "value": 0
+      "max": 1,
+      "per": "charges",
+      "value": 1
     },
     "weaponCategory": "uncategorized",
     "weaponType": "grenade"

--- a/src/items/equipment/defoliant_grenade_mk_3.json
+++ b/src/items/equipment/defoliant_grenade_mk_3.json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",
@@ -225,9 +225,9 @@
       "value": 1
     },
     "uses": {
-      "max": 0,
-      "per": "",
-      "value": 0
+      "max": 1,
+      "per": "charges",
+      "value": 1
     },
     "weaponCategory": "uncategorized",
     "weaponType": "grenade"

--- a/src/items/equipment/defoliant_grenade_mk_4.json
+++ b/src/items/equipment/defoliant_grenade_mk_4.json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",
@@ -225,9 +225,9 @@
       "value": 1
     },
     "uses": {
-      "max": 0,
-      "per": "",
-      "value": 0
+      "max": 1,
+      "per": "charges",
+      "value": 1
     },
     "weaponCategory": "uncategorized",
     "weaponType": "grenade"

--- a/src/items/equipment/degeneration_grenade_(hybrid).json
+++ b/src/items/equipment/degeneration_grenade_(hybrid).json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",
@@ -232,9 +232,9 @@
       "value": 1
     },
     "uses": {
-      "max": 0,
-      "per": "",
-      "value": 0
+      "max": 1,
+      "per": "charges",
+      "value": 1
     },
     "weaponCategory": "",
     "weaponType": "grenade"

--- a/src/items/equipment/diminisher_grenade_mk_1_(hybrid).json
+++ b/src/items/equipment/diminisher_grenade_mk_1_(hybrid).json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",

--- a/src/items/equipment/diminisher_grenade_mk_2_(hybrid).json
+++ b/src/items/equipment/diminisher_grenade_mk_2_(hybrid).json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",

--- a/src/items/equipment/diminisher_grenade_mk_3_(hybrid).json
+++ b/src/items/equipment/diminisher_grenade_mk_3_(hybrid).json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",

--- a/src/items/equipment/diminisher_grenade_mk_4_(hybrid).json
+++ b/src/items/equipment/diminisher_grenade_mk_4_(hybrid).json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",

--- a/src/items/equipment/diminisher_grenade_mk_5_(hybrid).json
+++ b/src/items/equipment/diminisher_grenade_mk_5_(hybrid).json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",

--- a/src/items/equipment/diminisher_grenade_mk_6_(hybrid).json
+++ b/src/items/equipment/diminisher_grenade_mk_6_(hybrid).json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",

--- a/src/items/equipment/disruption_grenade.json
+++ b/src/items/equipment/disruption_grenade.json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",
@@ -234,9 +234,9 @@
       "value": 1
     },
     "uses": {
-      "max": 0,
-      "per": "",
-      "value": 0
+      "max": 1,
+      "per": "charges",
+      "value": 1
     },
     "weaponCategory": "",
     "weaponType": "grenade"

--- a/src/items/equipment/disruption_grenade_temporal.json
+++ b/src/items/equipment/disruption_grenade_temporal.json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",
@@ -217,9 +217,9 @@
       "value": 1
     },
     "uses": {
-      "max": 0,
-      "per": "",
-      "value": 0
+      "max": 1,
+      "per": "charges",
+      "value": 1
     },
     "weaponCategory": "",
     "weaponType": "grenade"

--- a/src/items/equipment/drain_grenade.json
+++ b/src/items/equipment/drain_grenade.json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",

--- a/src/items/equipment/dye_grenade_i.json
+++ b/src/items/equipment/dye_grenade_i.json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",
@@ -51,8 +51,8 @@
     "attuned": false,
     "bulk": "L",
     "capacity": {
-      "max": 0,
-      "value": 0
+      "max": 1,
+      "value": 1
     },
     "chatFlavor": "",
     "container": {
@@ -162,7 +162,7 @@
       "modal": false,
       "necrotic": false,
       "nonlethal": false,
-      "one": false,
+      "one": true,
       "operative": false,
       "penetrating": false,
       "polarize": false,
@@ -220,8 +220,8 @@
       "value": ""
     },
     "usage": {
-      "per": "",
-      "value": 0
+      "per": "shot",
+      "value": 1
     },
     "uses": {
       "max": 1,

--- a/src/items/equipment/dye_grenade_ii.json
+++ b/src/items/equipment/dye_grenade_ii.json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",
@@ -51,8 +51,8 @@
     "attuned": false,
     "bulk": "L",
     "capacity": {
-      "max": 0,
-      "value": 0
+      "max": 1,
+      "value": 1
     },
     "chatFlavor": "",
     "container": {
@@ -162,7 +162,7 @@
       "modal": false,
       "necrotic": false,
       "nonlethal": false,
-      "one": false,
+      "one": true,
       "operative": false,
       "penetrating": false,
       "polarize": false,
@@ -220,8 +220,8 @@
       "value": ""
     },
     "usage": {
-      "per": "",
-      "value": 0
+      "per": "shot",
+      "value": 1
     },
     "uses": {
       "max": 1,

--- a/src/items/equipment/dye_grenade_iii.json
+++ b/src/items/equipment/dye_grenade_iii.json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",
@@ -51,8 +51,8 @@
     "attuned": false,
     "bulk": "L",
     "capacity": {
-      "max": 0,
-      "value": 0
+      "max": 1,
+      "value": 1
     },
     "chatFlavor": "",
     "container": {
@@ -162,7 +162,7 @@
       "modal": false,
       "necrotic": false,
       "nonlethal": false,
-      "one": false,
+      "one": true,
       "operative": false,
       "penetrating": false,
       "polarize": false,
@@ -220,8 +220,8 @@
       "value": ""
     },
     "usage": {
-      "per": "",
-      "value": 0
+      "per": "shot",
+      "value": 1
     },
     "uses": {
       "max": 1,

--- a/src/items/equipment/dye_grenade_iv.json
+++ b/src/items/equipment/dye_grenade_iv.json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",
@@ -51,8 +51,8 @@
     "attuned": false,
     "bulk": "L",
     "capacity": {
-      "max": 0,
-      "value": 0
+      "max": 1,
+      "value": 1
     },
     "chatFlavor": "",
     "container": {
@@ -162,7 +162,7 @@
       "modal": false,
       "necrotic": false,
       "nonlethal": false,
-      "one": false,
+      "one": true,
       "operative": false,
       "penetrating": false,
       "polarize": false,
@@ -220,8 +220,8 @@
       "value": ""
     },
     "usage": {
-      "per": "",
-      "value": 0
+      "per": "shot",
+      "value": 1
     },
     "uses": {
       "max": 1,

--- a/src/items/equipment/flash_grenade_i.json
+++ b/src/items/equipment/flash_grenade_i.json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",

--- a/src/items/equipment/flash_grenade_ii.json
+++ b/src/items/equipment/flash_grenade_ii.json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",

--- a/src/items/equipment/flash_grenade_iii.json
+++ b/src/items/equipment/flash_grenade_iii.json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",

--- a/src/items/equipment/flash_grenade_iv.json
+++ b/src/items/equipment/flash_grenade_iv.json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",

--- a/src/items/equipment/foam_grenade_i.json
+++ b/src/items/equipment/foam_grenade_i.json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",
@@ -249,9 +249,9 @@
       "value": 1
     },
     "uses": {
-      "max": 0,
-      "per": "",
-      "value": 0
+      "max": 1,
+      "per": "charges",
+      "value": 1
     },
     "weaponCategory": "",
     "weaponType": "grenade"

--- a/src/items/equipment/foam_grenade_ii.json
+++ b/src/items/equipment/foam_grenade_ii.json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",
@@ -249,9 +249,9 @@
       "value": 1
     },
     "uses": {
-      "max": 0,
-      "per": "",
-      "value": 0
+      "max": 1,
+      "per": "charges",
+      "value": 1
     },
     "weaponCategory": "",
     "weaponType": "grenade"

--- a/src/items/equipment/foam_grenade_iii.json
+++ b/src/items/equipment/foam_grenade_iii.json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",
@@ -249,9 +249,9 @@
       "value": 1
     },
     "uses": {
-      "max": 0,
-      "per": "",
-      "value": 0
+      "max": 1,
+      "per": "charges",
+      "value": 1
     },
     "weaponCategory": "",
     "weaponType": "grenade"

--- a/src/items/equipment/frag_grenade_i.json
+++ b/src/items/equipment/frag_grenade_i.json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",

--- a/src/items/equipment/frag_grenade_ii.json
+++ b/src/items/equipment/frag_grenade_ii.json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",

--- a/src/items/equipment/frag_grenade_iii.json
+++ b/src/items/equipment/frag_grenade_iii.json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",

--- a/src/items/equipment/frag_grenade_iv.json
+++ b/src/items/equipment/frag_grenade_iv.json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",

--- a/src/items/equipment/frag_grenade_v.json
+++ b/src/items/equipment/frag_grenade_v.json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",

--- a/src/items/equipment/frag_grenade_vi.json
+++ b/src/items/equipment/frag_grenade_vi.json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",

--- a/src/items/equipment/frag_grenade_vii.json
+++ b/src/items/equipment/frag_grenade_vii.json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",

--- a/src/items/equipment/frag_grenade_viii.json
+++ b/src/items/equipment/frag_grenade_viii.json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",

--- a/src/items/equipment/gravity_grenade_i.json
+++ b/src/items/equipment/gravity_grenade_i.json
@@ -14,8 +14,8 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
-    "actionType": "mwak",
+    "actionTarget": "ac5",
+    "actionType": "rwak",
     "activation": {
       "type": "action",
       "condition": "",
@@ -164,7 +164,7 @@
       "modal": false,
       "necrotic": false,
       "nonlethal": false,
-      "one": false,
+      "one": true,
       "operative": false,
       "penetrating": false,
       "polarize": false,
@@ -191,7 +191,7 @@
       "teleportive": false,
       "thought": false,
       "throttle": false,
-      "thrown": false,
+      "thrown": true,
       "trip": false,
       "two": false,
       "unbalancing": false,

--- a/src/items/equipment/gravity_grenade_ii.json
+++ b/src/items/equipment/gravity_grenade_ii.json
@@ -14,8 +14,8 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
-    "actionType": "mwak",
+    "actionTarget": "ac5",
+    "actionType": "rwak",
     "activation": {
       "type": "action",
       "condition": "",
@@ -164,7 +164,7 @@
       "modal": false,
       "necrotic": false,
       "nonlethal": false,
-      "one": false,
+      "one": true,
       "operative": false,
       "penetrating": false,
       "polarize": false,
@@ -191,7 +191,7 @@
       "teleportive": false,
       "thought": false,
       "throttle": false,
-      "thrown": false,
+      "thrown": true,
       "trip": false,
       "two": false,
       "unbalancing": false,

--- a/src/items/equipment/gravity_grenade_iii.json
+++ b/src/items/equipment/gravity_grenade_iii.json
@@ -14,8 +14,8 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
-    "actionType": "mwak",
+    "actionTarget": "ac5",
+    "actionType": "rwak",
     "activation": {
       "type": "action",
       "condition": "",
@@ -164,7 +164,7 @@
       "modal": false,
       "necrotic": false,
       "nonlethal": false,
-      "one": false,
+      "one": true,
       "operative": false,
       "penetrating": false,
       "polarize": false,
@@ -191,7 +191,7 @@
       "teleportive": false,
       "thought": false,
       "throttle": false,
-      "thrown": false,
+      "thrown": true,
       "trip": false,
       "two": false,
       "unbalancing": false,

--- a/src/items/equipment/holo_grenade_mk_1_(hybrid).json
+++ b/src/items/equipment/holo_grenade_mk_1_(hybrid).json
@@ -14,12 +14,12 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
-      "type": "none",
+      "type": "action",
       "condition": "",
-      "cost": null
+      "cost": 1
     },
     "ammunitionType": "",
     "area": {
@@ -51,8 +51,8 @@
     "attuned": false,
     "bulk": "L",
     "capacity": {
-      "max": 0,
-      "value": 0
+      "max": 1,
+      "value": 1
     },
     "chatFlavor": "",
     "container": {
@@ -142,7 +142,7 @@
       "guided": false,
       "harrying": false,
       "holyWater": false,
-      "hybrid": false,
+      "hybrid": true,
       "ignite": false,
       "indirect": false,
       "injection": false,
@@ -156,7 +156,7 @@
       "modal": false,
       "necrotic": false,
       "nonlethal": false,
-      "one": false,
+      "one": true,
       "operative": false,
       "penetrating": false,
       "polarize": false,
@@ -233,8 +233,8 @@
       "value": ""
     },
     "usage": {
-      "per": "",
-      "value": 0
+      "per": "shot",
+      "value": 1
     },
     "uses": {
       "max": 1,

--- a/src/items/equipment/holo_grenade_mk_2_(hybrid).json
+++ b/src/items/equipment/holo_grenade_mk_2_(hybrid).json
@@ -14,12 +14,12 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
-      "type": "none",
+      "type": "action",
       "condition": "",
-      "cost": null
+      "cost": 1
     },
     "ammunitionType": "",
     "area": {
@@ -51,8 +51,8 @@
     "attuned": false,
     "bulk": "L",
     "capacity": {
-      "max": 0,
-      "value": 0
+      "max": 1,
+      "value": 1
     },
     "chatFlavor": "",
     "container": {
@@ -142,7 +142,7 @@
       "guided": false,
       "harrying": false,
       "holyWater": false,
-      "hybrid": false,
+      "hybrid": true,
       "ignite": false,
       "indirect": false,
       "injection": false,
@@ -156,7 +156,7 @@
       "modal": false,
       "necrotic": false,
       "nonlethal": false,
-      "one": false,
+      "one": true,
       "operative": false,
       "penetrating": false,
       "polarize": false,
@@ -233,8 +233,8 @@
       "value": ""
     },
     "usage": {
-      "per": "",
-      "value": 0
+      "per": "shot",
+      "value": 1
     },
     "uses": {
       "max": 1,

--- a/src/items/equipment/holo_grenade_mk_3_(hybrid).json
+++ b/src/items/equipment/holo_grenade_mk_3_(hybrid).json
@@ -14,12 +14,12 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
-      "type": "none",
+      "type": "action",
       "condition": "",
-      "cost": null
+      "cost": 1
     },
     "ammunitionType": "",
     "area": {
@@ -51,8 +51,8 @@
     "attuned": false,
     "bulk": "L",
     "capacity": {
-      "max": 0,
-      "value": 0
+      "max": 1,
+      "value": 1
     },
     "chatFlavor": "",
     "container": {
@@ -142,7 +142,7 @@
       "guided": false,
       "harrying": false,
       "holyWater": false,
-      "hybrid": false,
+      "hybrid": true,
       "ignite": false,
       "indirect": false,
       "injection": false,
@@ -156,7 +156,7 @@
       "modal": false,
       "necrotic": false,
       "nonlethal": false,
-      "one": false,
+      "one": true,
       "operative": false,
       "penetrating": false,
       "polarize": false,
@@ -233,8 +233,8 @@
       "value": ""
     },
     "usage": {
-      "per": "",
-      "value": 0
+      "per": "shot",
+      "value": 1
     },
     "uses": {
       "max": 1,

--- a/src/items/equipment/holy_water_grenade_i.json
+++ b/src/items/equipment/holy_water_grenade_i.json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",
@@ -234,9 +234,9 @@
       "value": 1
     },
     "uses": {
-      "max": 0,
-      "per": "",
-      "value": 0
+      "max": 1,
+      "per": "charges",
+      "value": 1
     },
     "weaponCategory": "",
     "weaponType": "grenade"

--- a/src/items/equipment/holy_water_grenade_ii.json
+++ b/src/items/equipment/holy_water_grenade_ii.json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",
@@ -234,9 +234,9 @@
       "value": 1
     },
     "uses": {
-      "max": 0,
-      "per": "",
-      "value": 0
+      "max": 1,
+      "per": "charges",
+      "value": 1
     },
     "weaponCategory": "",
     "weaponType": "grenade"

--- a/src/items/equipment/holy_water_grenade_iii.json
+++ b/src/items/equipment/holy_water_grenade_iii.json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",
@@ -234,9 +234,9 @@
       "value": 1
     },
     "uses": {
-      "max": 0,
-      "per": "",
-      "value": 0
+      "max": 1,
+      "per": "charges",
+      "value": 1
     },
     "weaponCategory": "",
     "weaponType": "grenade"

--- a/src/items/equipment/holy_water_grenade_iv.json
+++ b/src/items/equipment/holy_water_grenade_iv.json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",
@@ -234,9 +234,9 @@
       "value": 1
     },
     "uses": {
-      "max": 0,
-      "per": "",
-      "value": 0
+      "max": 1,
+      "per": "charges",
+      "value": 1
     },
     "weaponCategory": "",
     "weaponType": "grenade"

--- a/src/items/equipment/incendiary_grenade_i.json
+++ b/src/items/equipment/incendiary_grenade_i.json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",

--- a/src/items/equipment/incendiary_grenade_ii.json
+++ b/src/items/equipment/incendiary_grenade_ii.json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",

--- a/src/items/equipment/incendiary_grenade_iii.json
+++ b/src/items/equipment/incendiary_grenade_iii.json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",

--- a/src/items/equipment/incendiary_grenade_iv.json
+++ b/src/items/equipment/incendiary_grenade_iv.json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",

--- a/src/items/equipment/incendiary_grenade_v.json
+++ b/src/items/equipment/incendiary_grenade_v.json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",

--- a/src/items/equipment/incendiary_grenade_vi.json
+++ b/src/items/equipment/incendiary_grenade_vi.json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",

--- a/src/items/equipment/junkbot_grenade_(hybrid).json
+++ b/src/items/equipment/junkbot_grenade_(hybrid).json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",

--- a/src/items/equipment/meduza_grenade_i.json
+++ b/src/items/equipment/meduza_grenade_i.json
@@ -14,12 +14,12 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",
       "condition": "",
-      "cost": 0
+      "cost": 1
     },
     "ammunitionType": "",
     "area": {
@@ -219,7 +219,7 @@
       "teleportive": false,
       "thought": false,
       "throttle": false,
-      "thrown": false,
+      "thrown": true,
       "thruster": false,
       "trip": false,
       "two": false,

--- a/src/items/equipment/meduza_grenade_ii.json
+++ b/src/items/equipment/meduza_grenade_ii.json
@@ -14,12 +14,12 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",
       "condition": "",
-      "cost": 0
+      "cost": 1
     },
     "ammunitionType": "",
     "area": {
@@ -219,7 +219,7 @@
       "teleportive": false,
       "thought": false,
       "throttle": false,
-      "thrown": false,
+      "thrown": true,
       "thruster": false,
       "trip": false,
       "two": false,

--- a/src/items/equipment/meduza_grenade_iii.json
+++ b/src/items/equipment/meduza_grenade_iii.json
@@ -14,12 +14,12 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",
       "condition": "",
-      "cost": 0
+      "cost": 1
     },
     "ammunitionType": "",
     "area": {
@@ -219,7 +219,7 @@
       "teleportive": false,
       "thought": false,
       "throttle": false,
-      "thrown": false,
+      "thrown": true,
       "thruster": false,
       "trip": false,
       "two": false,

--- a/src/items/equipment/meduza_grenade_iv.json
+++ b/src/items/equipment/meduza_grenade_iv.json
@@ -14,12 +14,12 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",
       "condition": "",
-      "cost": 0
+      "cost": 1
     },
     "ammunitionType": "",
     "area": {
@@ -219,7 +219,7 @@
       "teleportive": false,
       "thought": false,
       "throttle": false,
-      "thrown": false,
+      "thrown": true,
       "thruster": false,
       "trip": false,
       "two": false,

--- a/src/items/equipment/microbot_grenade_mk_1_(hybrid).json
+++ b/src/items/equipment/microbot_grenade_mk_1_(hybrid).json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",

--- a/src/items/equipment/microbot_grenade_mk_2_(hybrid).json
+++ b/src/items/equipment/microbot_grenade_mk_2_(hybrid).json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",

--- a/src/items/equipment/microbot_grenade_mk_3_(hybrid).json
+++ b/src/items/equipment/microbot_grenade_mk_3_(hybrid).json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",

--- a/src/items/equipment/microbot_grenade_mk_4_(hybrid).json
+++ b/src/items/equipment/microbot_grenade_mk_4_(hybrid).json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",

--- a/src/items/equipment/microbot_grenade_mk_5_(hybrid).json
+++ b/src/items/equipment/microbot_grenade_mk_5_(hybrid).json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",

--- a/src/items/equipment/mindspike_grenade_mk_1.json
+++ b/src/items/equipment/mindspike_grenade_mk_1.json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",
@@ -225,9 +225,9 @@
       "value": 1
     },
     "uses": {
-      "max": 0,
-      "per": "",
-      "value": 0
+      "max": 1,
+      "per": "charges",
+      "value": 1
     },
     "weaponCategory": "uncategorized",
     "weaponType": "grenade"

--- a/src/items/equipment/mindspike_grenade_mk_2.json
+++ b/src/items/equipment/mindspike_grenade_mk_2.json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",
@@ -225,9 +225,9 @@
       "value": 1
     },
     "uses": {
-      "max": 0,
-      "per": "",
-      "value": 0
+      "max": 1,
+      "per": "charges",
+      "value": 1
     },
     "weaponCategory": "uncategorized",
     "weaponType": "grenade"

--- a/src/items/equipment/mindspike_grenade_mk_3.json
+++ b/src/items/equipment/mindspike_grenade_mk_3.json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",
@@ -225,9 +225,9 @@
       "value": 1
     },
     "uses": {
-      "max": 0,
-      "per": "",
-      "value": 0
+      "max": 1,
+      "per": "charges",
+      "value": 1
     },
     "weaponCategory": "uncategorized",
     "weaponType": "grenade"

--- a/src/items/equipment/mindspike_grenade_mk_4.json
+++ b/src/items/equipment/mindspike_grenade_mk_4.json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",
@@ -225,9 +225,9 @@
       "value": 1
     },
     "uses": {
-      "max": 0,
-      "per": "",
-      "value": 0
+      "max": 1,
+      "per": "charges",
+      "value": 1
     },
     "weaponCategory": "uncategorized",
     "weaponType": "grenade"

--- a/src/items/equipment/mindspike_grenade_mk_5.json
+++ b/src/items/equipment/mindspike_grenade_mk_5.json
@@ -1,6 +1,6 @@
 {
   "_id": "9jMFJOPNwCMlalDi",
-  "name": "Mindspike grenade, Mk 5)",
+  "name": "Mindspike grenade, Mk 5",
   "type": "weapon",
   "_stats": {
     "coreVersion": 12,
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",
@@ -225,9 +225,9 @@
       "value": 1
     },
     "uses": {
-      "max": 0,
-      "per": "",
-      "value": 0
+      "max": 1,
+      "per": "charges",
+      "value": 1
     },
     "weaponCategory": "uncategorized",
     "weaponType": "grenade"

--- a/src/items/equipment/mutation_bomb_(hybrid).json
+++ b/src/items/equipment/mutation_bomb_(hybrid).json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",
@@ -225,9 +225,9 @@
       "value": 1
     },
     "uses": {
-      "max": 0,
-      "per": "",
-      "value": 0
+      "max": 1,
+      "per": "charges",
+      "value": 1
     },
     "weaponCategory": "",
     "weaponType": "grenade"

--- a/src/items/equipment/necro_grenade_i.json
+++ b/src/items/equipment/necro_grenade_i.json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",
@@ -234,9 +234,9 @@
       "value": 1
     },
     "uses": {
-      "max": 0,
-      "per": "",
-      "value": 0
+      "max": 1,
+      "per": "charges",
+      "value": 1
     },
     "weaponCategory": "",
     "weaponType": "grenade"

--- a/src/items/equipment/necro_grenade_ii.json
+++ b/src/items/equipment/necro_grenade_ii.json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",
@@ -234,9 +234,9 @@
       "value": 1
     },
     "uses": {
-      "max": 0,
-      "per": "",
-      "value": 0
+      "max": 1,
+      "per": "charges",
+      "value": 1
     },
     "weaponCategory": "",
     "weaponType": "grenade"

--- a/src/items/equipment/necro_grenade_iii.json
+++ b/src/items/equipment/necro_grenade_iii.json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",
@@ -234,9 +234,9 @@
       "value": 1
     },
     "uses": {
-      "max": 0,
-      "per": "",
-      "value": 0
+      "max": 1,
+      "per": "charges",
+      "value": 1
     },
     "weaponCategory": "",
     "weaponType": "grenade"

--- a/src/items/equipment/necro_grenade_iv.json
+++ b/src/items/equipment/necro_grenade_iv.json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",
@@ -234,9 +234,9 @@
       "value": 1
     },
     "uses": {
-      "max": 0,
-      "per": "",
-      "value": 0
+      "max": 1,
+      "per": "charges",
+      "value": 1
     },
     "weaponCategory": "",
     "weaponType": "grenade"

--- a/src/items/equipment/panic_grenade_mk_1.json
+++ b/src/items/equipment/panic_grenade_mk_1.json
@@ -14,12 +14,12 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",
       "condition": "",
-      "cost": 0
+      "cost": 1
     },
     "ammunitionType": "",
     "area": {
@@ -187,7 +187,7 @@
       "teleportive": false,
       "thought": false,
       "throttle": false,
-      "thrown": false,
+      "thrown": true,
       "thruster": false,
       "trip": false,
       "two": false,

--- a/src/items/equipment/panic_grenade_mk_2.json
+++ b/src/items/equipment/panic_grenade_mk_2.json
@@ -14,12 +14,12 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",
       "condition": "",
-      "cost": 0
+      "cost": 1
     },
     "ammunitionType": "",
     "area": {
@@ -187,7 +187,7 @@
       "teleportive": false,
       "thought": false,
       "throttle": false,
-      "thrown": false,
+      "thrown": true,
       "thruster": false,
       "trip": false,
       "two": false,

--- a/src/items/equipment/panic_grenade_mk_3.json
+++ b/src/items/equipment/panic_grenade_mk_3.json
@@ -14,12 +14,12 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",
       "condition": "",
-      "cost": 0
+      "cost": 1
     },
     "ammunitionType": "",
     "area": {
@@ -187,7 +187,7 @@
       "teleportive": false,
       "thought": false,
       "throttle": false,
-      "thrown": false,
+      "thrown": true,
       "thruster": false,
       "trip": false,
       "two": false,

--- a/src/items/equipment/panic_grenade_mk_4.json
+++ b/src/items/equipment/panic_grenade_mk_4.json
@@ -14,12 +14,12 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",
       "condition": "",
-      "cost": 0
+      "cost": 1
     },
     "ammunitionType": "",
     "area": {
@@ -187,7 +187,7 @@
       "teleportive": false,
       "thought": false,
       "throttle": false,
-      "thrown": false,
+      "thrown": true,
       "thruster": false,
       "trip": false,
       "two": false,

--- a/src/items/equipment/pheromone_grenade_mk_1.json
+++ b/src/items/equipment/pheromone_grenade_mk_1.json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",

--- a/src/items/equipment/pheromone_grenade_mk_2.json
+++ b/src/items/equipment/pheromone_grenade_mk_2.json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",

--- a/src/items/equipment/pheromone_grenade_mk_3.json
+++ b/src/items/equipment/pheromone_grenade_mk_3.json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",

--- a/src/items/equipment/pheromone_grenade_mk_4.json
+++ b/src/items/equipment/pheromone_grenade_mk_4.json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",

--- a/src/items/equipment/pulse_grenade_i.json
+++ b/src/items/equipment/pulse_grenade_i.json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",
@@ -225,9 +225,9 @@
       "value": 1
     },
     "uses": {
-      "max": 0,
-      "per": "",
-      "value": 0
+      "max": 1,
+      "per": "charges",
+      "value": 1
     },
     "weaponCategory": "",
     "weaponType": "grenade"

--- a/src/items/equipment/pulse_grenade_ii.json
+++ b/src/items/equipment/pulse_grenade_ii.json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",
@@ -234,9 +234,9 @@
       "value": 1
     },
     "uses": {
-      "max": 0,
-      "per": "",
-      "value": 0
+      "max": 1,
+      "per": "charges",
+      "value": 1
     },
     "weaponCategory": "",
     "weaponType": "grenade"

--- a/src/items/equipment/pulse_grenade_iii.json
+++ b/src/items/equipment/pulse_grenade_iii.json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",
@@ -234,9 +234,9 @@
       "value": 1
     },
     "uses": {
-      "max": 0,
-      "per": "",
-      "value": 0
+      "max": 1,
+      "per": "charges",
+      "value": 1
     },
     "weaponCategory": "",
     "weaponType": "grenade"

--- a/src/items/equipment/pulse_grenade_iv.json
+++ b/src/items/equipment/pulse_grenade_iv.json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",
@@ -234,9 +234,9 @@
       "value": 1
     },
     "uses": {
-      "max": 0,
-      "per": "",
-      "value": 0
+      "max": 1,
+      "per": "charges",
+      "value": 1
     },
     "weaponCategory": "",
     "weaponType": "grenade"

--- a/src/items/equipment/riot_grenade_i.json
+++ b/src/items/equipment/riot_grenade_i.json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",
@@ -226,9 +226,9 @@
       "value": 1
     },
     "uses": {
-      "max": 0,
-      "per": "",
-      "value": 0
+      "max": 1,
+      "per": "charges",
+      "value": 1
     },
     "weaponCategory": "",
     "weaponType": "grenade"

--- a/src/items/equipment/riot_grenade_ii.json
+++ b/src/items/equipment/riot_grenade_ii.json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",
@@ -226,9 +226,9 @@
       "value": 1
     },
     "uses": {
-      "max": 0,
-      "per": "",
-      "value": 0
+      "max": 1,
+      "per": "charges",
+      "value": 1
     },
     "weaponCategory": "",
     "weaponType": "grenade"

--- a/src/items/equipment/riot_grenade_iii.json
+++ b/src/items/equipment/riot_grenade_iii.json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",
@@ -234,9 +234,9 @@
       "value": 1
     },
     "uses": {
-      "max": 0,
-      "per": "",
-      "value": 0
+      "max": 1,
+      "per": "charges",
+      "value": 1
     },
     "weaponCategory": "",
     "weaponType": "grenade"

--- a/src/items/equipment/riot_grenade_iv.json
+++ b/src/items/equipment/riot_grenade_iv.json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",
@@ -234,9 +234,9 @@
       "value": 1
     },
     "uses": {
-      "max": 0,
-      "per": "",
-      "value": 0
+      "max": 1,
+      "per": "charges",
+      "value": 1
     },
     "weaponCategory": "",
     "weaponType": "grenade"

--- a/src/items/equipment/riot_grenade_v.json
+++ b/src/items/equipment/riot_grenade_v.json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",
@@ -234,9 +234,9 @@
       "value": 1
     },
     "uses": {
-      "max": 0,
-      "per": "",
-      "value": 0
+      "max": 1,
+      "per": "charges",
+      "value": 1
     },
     "weaponCategory": "",
     "weaponType": "grenade"

--- a/src/items/equipment/riot_grenade_vi.json
+++ b/src/items/equipment/riot_grenade_vi.json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",
@@ -234,9 +234,9 @@
       "value": 1
     },
     "uses": {
-      "max": 0,
-      "per": "",
-      "value": 0
+      "max": 1,
+      "per": "charges",
+      "value": 1
     },
     "weaponCategory": "",
     "weaponType": "grenade"

--- a/src/items/equipment/riot_grenade_vii.json
+++ b/src/items/equipment/riot_grenade_vii.json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",
@@ -234,9 +234,9 @@
       "value": 1
     },
     "uses": {
-      "max": 0,
-      "per": "",
-      "value": 0
+      "max": 1,
+      "per": "charges",
+      "value": 1
     },
     "weaponCategory": "",
     "weaponType": "grenade"

--- a/src/items/equipment/screamer_grenade_i.json
+++ b/src/items/equipment/screamer_grenade_i.json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",

--- a/src/items/equipment/screamer_grenade_ii.json
+++ b/src/items/equipment/screamer_grenade_ii.json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",

--- a/src/items/equipment/screamer_grenade_iii.json
+++ b/src/items/equipment/screamer_grenade_iii.json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",

--- a/src/items/equipment/screamer_grenade_iv.json
+++ b/src/items/equipment/screamer_grenade_iv.json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",

--- a/src/items/equipment/shock_grenade_i.json
+++ b/src/items/equipment/shock_grenade_i.json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",

--- a/src/items/equipment/shock_grenade_ii.json
+++ b/src/items/equipment/shock_grenade_ii.json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",

--- a/src/items/equipment/shock_grenade_iii.json
+++ b/src/items/equipment/shock_grenade_iii.json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",

--- a/src/items/equipment/shock_grenade_iv.json
+++ b/src/items/equipment/shock_grenade_iv.json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",
@@ -235,7 +235,7 @@
     },
     "uses": {
       "max": 1,
-      "per": "",
+      "per": "charges",
       "value": 1
     },
     "weaponCategory": "shock",

--- a/src/items/equipment/shock_grenade_v.json
+++ b/src/items/equipment/shock_grenade_v.json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",

--- a/src/items/equipment/short-circuit_grenade.json
+++ b/src/items/equipment/short-circuit_grenade.json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",
@@ -51,8 +51,8 @@
     "attuned": false,
     "bulk": "-",
     "capacity": {
-      "max": 0,
-      "value": 0
+      "max": 1,
+      "value": 1
     },
     "chatFlavor": "",
     "container": {
@@ -221,13 +221,13 @@
       "value": ""
     },
     "usage": {
-      "per": "",
-      "value": 0
+      "per": "shot",
+      "value": 1
     },
     "uses": {
-      "max": 0,
-      "per": "",
-      "value": 0
+      "max": 1,
+      "per": "charges",
+      "value": 1
     },
     "weaponCategory": "uncategorized",
     "weaponType": "grenade"

--- a/src/items/equipment/smoke_grenade.json
+++ b/src/items/equipment/smoke_grenade.json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",

--- a/src/items/equipment/solar_flare_grenade_i_(hybrid).json
+++ b/src/items/equipment/solar_flare_grenade_i_(hybrid).json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",
@@ -235,9 +235,9 @@
       "value": 1
     },
     "uses": {
-      "max": 0,
-      "per": "",
-      "value": 0
+      "max": 1,
+      "per": "charges",
+      "value": 1
     },
     "weaponCategory": "",
     "weaponType": "grenade"

--- a/src/items/equipment/solar_flare_grenade_ii_(hybrid).json
+++ b/src/items/equipment/solar_flare_grenade_ii_(hybrid).json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",
@@ -235,9 +235,9 @@
       "value": 1
     },
     "uses": {
-      "max": 0,
-      "per": "",
-      "value": 0
+      "max": 1,
+      "per": "charges",
+      "value": 1
     },
     "weaponCategory": "",
     "weaponType": "grenade"

--- a/src/items/equipment/solar_flare_grenade_iii_(hybrid).json
+++ b/src/items/equipment/solar_flare_grenade_iii_(hybrid).json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",
@@ -235,9 +235,9 @@
       "value": 1
     },
     "uses": {
-      "max": 0,
-      "per": "",
-      "value": 0
+      "max": 1,
+      "per": "charges",
+      "value": 1
     },
     "weaponCategory": "",
     "weaponType": "grenade"

--- a/src/items/equipment/solar_flare_grenade_iv_(hybrid).json
+++ b/src/items/equipment/solar_flare_grenade_iv_(hybrid).json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",
@@ -235,9 +235,9 @@
       "value": 1
     },
     "uses": {
-      "max": 0,
-      "per": "",
-      "value": 0
+      "max": 1,
+      "per": "charges",
+      "value": 1
     },
     "weaponCategory": "",
     "weaponType": "grenade"

--- a/src/items/equipment/solar_flare_grenade_v_(hybrid).json
+++ b/src/items/equipment/solar_flare_grenade_v_(hybrid).json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",
@@ -235,9 +235,9 @@
       "value": 1
     },
     "uses": {
-      "max": 0,
-      "per": "",
-      "value": 0
+      "max": 1,
+      "per": "charges",
+      "value": 1
     },
     "weaponCategory": "",
     "weaponType": "grenade"

--- a/src/items/equipment/stickybomb_grenade_i.json
+++ b/src/items/equipment/stickybomb_grenade_i.json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",

--- a/src/items/equipment/stickybomb_grenade_ii.json
+++ b/src/items/equipment/stickybomb_grenade_ii.json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",

--- a/src/items/equipment/stickybomb_grenade_iii.json
+++ b/src/items/equipment/stickybomb_grenade_iii.json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",

--- a/src/items/equipment/summoning_grenade_mk_1_(hybrid).json
+++ b/src/items/equipment/summoning_grenade_mk_1_(hybrid).json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",
@@ -255,7 +255,7 @@
       "value": 1
     },
     "uses": {
-      "max": "1",
+      "max": 1,
       "per": "charges",
       "value": 1
     },

--- a/src/items/equipment/summoning_grenade_mk_2_(hybrid).json
+++ b/src/items/equipment/summoning_grenade_mk_2_(hybrid).json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",
@@ -255,7 +255,7 @@
       "value": 1
     },
     "uses": {
-      "max": "1",
+      "max": 1,
       "per": "charges",
       "value": 1
     },

--- a/src/items/equipment/summoning_grenade_mk_3_(hybrid).json
+++ b/src/items/equipment/summoning_grenade_mk_3_(hybrid).json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",
@@ -255,7 +255,7 @@
       "value": 1
     },
     "uses": {
-      "max": "1",
+      "max": 1,
       "per": "charges",
       "value": 1
     },

--- a/src/items/equipment/summoning_grenade_mk_4_(hybrid).json
+++ b/src/items/equipment/summoning_grenade_mk_4_(hybrid).json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",
@@ -255,7 +255,7 @@
       "value": 1
     },
     "uses": {
-      "max": "1",
+      "max": 1,
       "per": "charges",
       "value": 1
     },

--- a/src/items/equipment/summoning_grenade_mk_5_(hybrid).json
+++ b/src/items/equipment/summoning_grenade_mk_5_(hybrid).json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",
@@ -255,7 +255,7 @@
       "value": 1
     },
     "uses": {
-      "max": "1",
+      "max": 1,
       "per": "charges",
       "value": 1
     },

--- a/src/items/equipment/summoning_grenade_mk_6_(hybrid).json
+++ b/src/items/equipment/summoning_grenade_mk_6_(hybrid).json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",
@@ -255,7 +255,7 @@
       "value": 1
     },
     "uses": {
-      "max": "1",
+      "max": 1,
       "per": "charges",
       "value": 1
     },

--- a/src/items/equipment/taserweb_grenade.json
+++ b/src/items/equipment/taserweb_grenade.json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",
@@ -226,9 +226,9 @@
       "value": 1
     },
     "uses": {
-      "max": 0,
-      "per": "",
-      "value": 0
+      "max": 1,
+      "per": "charges",
+      "value": 1
     },
     "weaponCategory": "",
     "weaponType": "grenade"

--- a/src/items/equipment/temporal_disruption_grenade.json
+++ b/src/items/equipment/temporal_disruption_grenade.json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",
@@ -226,9 +226,9 @@
       "value": 1
     },
     "uses": {
-      "max": 0,
-      "per": "",
-      "value": 0
+      "max": 1,
+      "per": "charges",
+      "value": 1
     },
     "weaponCategory": "",
     "weaponType": "grenade"

--- a/src/items/equipment/thasphalt_grenade_i.json
+++ b/src/items/equipment/thasphalt_grenade_i.json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "eac",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",
@@ -51,8 +51,8 @@
     "attuned": false,
     "bulk": "L",
     "capacity": {
-      "max": null,
-      "value": 0
+      "max": 1,
+      "value": 1
     },
     "chatFlavor": "",
     "container": {
@@ -182,7 +182,7 @@
       "modal": false,
       "necrotic": false,
       "nonlethal": false,
-      "one": false,
+      "one": true,
       "operative": false,
       "penetrating": false,
       "polarize": false,
@@ -212,7 +212,7 @@
       "teleportive": false,
       "thought": false,
       "throttle": false,
-      "thrown": false,
+      "thrown": true,
       "thruster": false,
       "trip": false,
       "two": false,
@@ -259,11 +259,11 @@
       "value": ""
     },
     "usage": {
-      "per": "",
-      "value": null
+      "per": "shot",
+      "value": 1
     },
     "uses": {
-      "max": 0,
+      "max": 1,
       "per": "charges",
       "value": 1
     },

--- a/src/items/equipment/thasphalt_grenade_ii.json
+++ b/src/items/equipment/thasphalt_grenade_ii.json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "eac",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",
@@ -51,8 +51,8 @@
     "attuned": false,
     "bulk": "L",
     "capacity": {
-      "max": null,
-      "value": 0
+      "max": 1,
+      "value": 1
     },
     "chatFlavor": "",
     "container": {
@@ -182,7 +182,7 @@
       "modal": false,
       "necrotic": false,
       "nonlethal": false,
-      "one": false,
+      "one": true,
       "operative": false,
       "penetrating": false,
       "polarize": false,
@@ -212,7 +212,7 @@
       "teleportive": false,
       "thought": false,
       "throttle": false,
-      "thrown": false,
+      "thrown": true,
       "thruster": false,
       "trip": false,
       "two": false,
@@ -259,8 +259,8 @@
       "value": ""
     },
     "usage": {
-      "per": "",
-      "value": null
+      "per": "shot",
+      "value": 1
     },
     "uses": {
       "max": 1,

--- a/src/items/equipment/thasphalt_grenade_iii.json
+++ b/src/items/equipment/thasphalt_grenade_iii.json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "eac",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",
@@ -51,8 +51,8 @@
     "attuned": false,
     "bulk": "L",
     "capacity": {
-      "max": null,
-      "value": 0
+      "max": 1,
+      "value": 1
     },
     "chatFlavor": "",
     "container": {
@@ -182,7 +182,7 @@
       "modal": false,
       "necrotic": false,
       "nonlethal": false,
-      "one": false,
+      "one": true,
       "operative": false,
       "penetrating": false,
       "polarize": false,
@@ -212,7 +212,7 @@
       "teleportive": false,
       "thought": false,
       "throttle": false,
-      "thrown": false,
+      "thrown": true,
       "thruster": false,
       "trip": false,
       "two": false,
@@ -259,8 +259,8 @@
       "value": ""
     },
     "usage": {
-      "per": "",
-      "value": null
+      "per": "shot",
+      "value": 1
     },
     "uses": {
       "max": 1,

--- a/src/items/equipment/thasphalt_grenade_iv.json
+++ b/src/items/equipment/thasphalt_grenade_iv.json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "eac",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",
@@ -51,8 +51,8 @@
     "attuned": false,
     "bulk": "L",
     "capacity": {
-      "max": null,
-      "value": 0
+      "max": 1,
+      "value": 1
     },
     "chatFlavor": "",
     "container": {
@@ -182,7 +182,7 @@
       "modal": false,
       "necrotic": false,
       "nonlethal": false,
-      "one": false,
+      "one": true,
       "operative": false,
       "penetrating": false,
       "polarize": false,
@@ -212,7 +212,7 @@
       "teleportive": false,
       "thought": false,
       "throttle": false,
-      "thrown": false,
+      "thrown": true,
       "thruster": false,
       "trip": false,
       "two": false,
@@ -259,8 +259,8 @@
       "value": ""
     },
     "usage": {
-      "per": "",
-      "value": null
+      "per": "shot",
+      "value": 1
     },
     "uses": {
       "max": 1,

--- a/src/items/equipment/thasphalt_grenade_v.json
+++ b/src/items/equipment/thasphalt_grenade_v.json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "eac",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",
@@ -51,8 +51,8 @@
     "attuned": false,
     "bulk": "L",
     "capacity": {
-      "max": null,
-      "value": 0
+      "max": 1,
+      "value": 1
     },
     "chatFlavor": "",
     "container": {
@@ -182,7 +182,7 @@
       "modal": false,
       "necrotic": false,
       "nonlethal": false,
-      "one": false,
+      "one": true,
       "operative": false,
       "penetrating": false,
       "polarize": false,
@@ -212,7 +212,7 @@
       "teleportive": false,
       "thought": false,
       "throttle": false,
-      "thrown": false,
+      "thrown": true,
       "thruster": false,
       "trip": false,
       "two": false,
@@ -259,8 +259,8 @@
       "value": ""
     },
     "usage": {
-      "per": "",
-      "value": null
+      "per": "shot",
+      "value": 1
     },
     "uses": {
       "max": 1,

--- a/src/items/equipment/thasteron_grenade_i.json
+++ b/src/items/equipment/thasteron_grenade_i.json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "eac",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",
@@ -51,8 +51,8 @@
     "attuned": false,
     "bulk": "L",
     "capacity": {
-      "max": null,
-      "value": 0
+      "max": 1,
+      "value": 1
     },
     "chatFlavor": "",
     "container": {
@@ -168,7 +168,7 @@
       "modal": false,
       "necrotic": false,
       "nonlethal": false,
-      "one": false,
+      "one": true,
       "operative": false,
       "penetrating": false,
       "polarize": false,
@@ -198,7 +198,7 @@
       "teleportive": false,
       "thought": false,
       "throttle": false,
-      "thrown": false,
+      "thrown": true,
       "thruster": false,
       "trip": false,
       "two": false,
@@ -245,8 +245,8 @@
       "value": "Staggered"
     },
     "usage": {
-      "per": "",
-      "value": null
+      "per": "shot",
+      "value": 1
     },
     "uses": {
       "max": 1,

--- a/src/items/equipment/thasteron_grenade_ii.json
+++ b/src/items/equipment/thasteron_grenade_ii.json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "eac",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",
@@ -51,8 +51,8 @@
     "attuned": false,
     "bulk": "L",
     "capacity": {
-      "max": null,
-      "value": 0
+      "max": 1,
+      "value": 1
     },
     "chatFlavor": "",
     "container": {
@@ -168,7 +168,7 @@
       "modal": false,
       "necrotic": false,
       "nonlethal": false,
-      "one": false,
+      "one": true,
       "operative": false,
       "penetrating": false,
       "polarize": false,
@@ -198,7 +198,7 @@
       "teleportive": false,
       "thought": false,
       "throttle": false,
-      "thrown": false,
+      "thrown": true,
       "thruster": false,
       "trip": false,
       "two": false,
@@ -245,8 +245,8 @@
       "value": "Staggered"
     },
     "usage": {
-      "per": "",
-      "value": null
+      "per": "shot",
+      "value": 1
     },
     "uses": {
       "max": 1,

--- a/src/items/equipment/thasteron_grenade_iii.json
+++ b/src/items/equipment/thasteron_grenade_iii.json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "eac",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",
@@ -51,8 +51,8 @@
     "attuned": false,
     "bulk": "L",
     "capacity": {
-      "max": null,
-      "value": 0
+      "max": 1,
+      "value": 1
     },
     "chatFlavor": "",
     "container": {
@@ -168,7 +168,7 @@
       "modal": false,
       "necrotic": false,
       "nonlethal": false,
-      "one": false,
+      "one": true,
       "operative": false,
       "penetrating": false,
       "polarize": false,
@@ -198,7 +198,7 @@
       "teleportive": false,
       "thought": false,
       "throttle": false,
-      "thrown": false,
+      "thrown": true,
       "thruster": false,
       "trip": false,
       "two": false,
@@ -245,8 +245,8 @@
       "value": "Staggered"
     },
     "usage": {
-      "per": "",
-      "value": null
+      "per": "shot",
+      "value": 1
     },
     "uses": {
       "max": 1,

--- a/src/items/equipment/thasteron_grenade_iv.json
+++ b/src/items/equipment/thasteron_grenade_iv.json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "eac",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",
@@ -51,8 +51,8 @@
     "attuned": false,
     "bulk": "L",
     "capacity": {
-      "max": null,
-      "value": 0
+      "max": 1,
+      "value": 1
     },
     "chatFlavor": "",
     "container": {
@@ -168,7 +168,7 @@
       "modal": false,
       "necrotic": false,
       "nonlethal": false,
-      "one": false,
+      "one": true,
       "operative": false,
       "penetrating": false,
       "polarize": false,
@@ -198,7 +198,7 @@
       "teleportive": false,
       "thought": false,
       "throttle": false,
-      "thrown": false,
+      "thrown": true,
       "thruster": false,
       "trip": false,
       "two": false,
@@ -245,8 +245,8 @@
       "value": "Staggered"
     },
     "usage": {
-      "per": "",
-      "value": null
+      "per": "shot",
+      "value": 1
     },
     "uses": {
       "max": 1,

--- a/src/items/equipment/thasteron_grenade_v.json
+++ b/src/items/equipment/thasteron_grenade_v.json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "eac",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",
@@ -51,8 +51,8 @@
     "attuned": false,
     "bulk": "L",
     "capacity": {
-      "max": null,
-      "value": 0
+      "max": 1,
+      "value": 1
     },
     "chatFlavor": "",
     "container": {
@@ -168,7 +168,7 @@
       "modal": false,
       "necrotic": false,
       "nonlethal": false,
-      "one": false,
+      "one": true,
       "operative": false,
       "penetrating": false,
       "polarize": false,
@@ -198,7 +198,7 @@
       "teleportive": false,
       "thought": false,
       "throttle": false,
-      "thrown": false,
+      "thrown": true,
       "thruster": false,
       "trip": false,
       "two": false,
@@ -245,8 +245,8 @@
       "value": "Staggered"
     },
     "usage": {
-      "per": "",
-      "value": null
+      "per": "shot",
+      "value": 1
     },
     "uses": {
       "max": 1,

--- a/src/items/equipment/web_grenade_i.json
+++ b/src/items/equipment/web_grenade_i.json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",
@@ -226,9 +226,9 @@
       "value": 1
     },
     "uses": {
-      "max": 0,
-      "per": "",
-      "value": 0
+      "max": 1,
+      "per": "charges",
+      "value": 1
     },
     "weaponCategory": "",
     "weaponType": "grenade"

--- a/src/items/equipment/web_grenade_ii.json
+++ b/src/items/equipment/web_grenade_ii.json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",
@@ -226,9 +226,9 @@
       "value": 1
     },
     "uses": {
-      "max": 0,
-      "per": "",
-      "value": 0
+      "max": 1,
+      "per": "charges",
+      "value": 1
     },
     "weaponCategory": "",
     "weaponType": "grenade"

--- a/src/items/equipment/web_grenade_iii.json
+++ b/src/items/equipment/web_grenade_iii.json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",
@@ -226,9 +226,9 @@
       "value": 1
     },
     "uses": {
-      "max": 0,
-      "per": "",
-      "value": 0
+      "max": 1,
+      "per": "charges",
+      "value": 1
     },
     "weaponCategory": "",
     "weaponType": "grenade"

--- a/src/items/equipment/web_grenade_iv.json
+++ b/src/items/equipment/web_grenade_iv.json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",
@@ -226,9 +226,9 @@
       "value": 1
     },
     "uses": {
-      "max": 0,
-      "per": "",
-      "value": 0
+      "max": 1,
+      "per": "charges",
+      "value": 1
     },
     "weaponCategory": "",
     "weaponType": "grenade"

--- a/src/items/equipment/wonder_grenade_(hybrid).json
+++ b/src/items/equipment/wonder_grenade_(hybrid).json
@@ -14,7 +14,7 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rwak",
     "activation": {
       "type": "action",

--- a/src/items/spells/conjure_grenade.json
+++ b/src/items/spells/conjure_grenade.json
@@ -14,12 +14,12 @@
     "abilityMods": {
       "parts": []
     },
-    "actionTarget": "",
+    "actionTarget": "ac5",
     "actionType": "rsak",
     "activation": {
       "type": "action",
       "condition": "",
-      "cost": 0
+      "cost": 1
     },
     "allowedClasses": {
       "myst": false,
@@ -34,7 +34,7 @@
       "units": "ft",
       "value": "5"
     },
-    "attackBonus": 0,
+    "attackBonus": null,
     "chatFlavor": "",
     "concentration": false,
     "critical": {
@@ -137,7 +137,7 @@
     "rollNotes": "",
     "save": {
       "type": "reflex",
-      "dc": "",
+      "dc": "10+floor(@item.level/2)+@abilities.dex.mod",
       "descriptor": "half"
     },
     "school": "con",

--- a/src/module/config.js
+++ b/src/module/config.js
@@ -2179,6 +2179,8 @@ SFRPG.actionTargets = {
     "kac": "SFRPG.Items.Action.ActionTarget.KAC",
     "kac8": "SFRPG.Items.Action.ActionTarget.KAC8",
     "eac": "SFRPG.Items.Action.ActionTarget.EAC",
+    "ac5": "SFRPG.Items.Action.ActionTarget.AC5",
+    "ac15": "SFRPG.Items.Action.ActionTarget.AC15",
     "other": "SFRPG.Items.Action.ActionTarget.Other"
 };
 

--- a/static/lang/de.json
+++ b/static/lang/de.json
@@ -1502,6 +1502,8 @@
             "Action": {
                 "AbilityModifier": "Attributsmodifikator",
                 "ActionTarget": {
+                    "AC5": "RK 5",
+                    "AC15": "RK 15",
                     "ChatMessage": " gegen {actionTarget}",
                     "EAC": "ERK",
                     "KAC": "KRK",

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -1496,6 +1496,8 @@
             "Action": {
                 "AbilityModifier": "Ability Modifier",
                 "ActionTarget": {
+                    "AC5": "AC 5",
+                    "AC15": "AC 15",
                     "ChatMessage": " against {actionTarget}",
                     "EAC": "EAC",
                     "KAC": "KAC",

--- a/static/lang/fr.json
+++ b/static/lang/fr.json
@@ -1497,6 +1497,8 @@
                 "AbilityModifier": "Modificateur de capacité",
                 "ActionTarget": {
                     "ChatMessage": " contre {actionTarget}",
+                    "AC5": "CA 5",
+                    "AC15": "CA 15",
                     "EAC": "CAE",
                     "KAC": "CAC",
                     "KAC8": "CAC +8",

--- a/static/lang/it.json
+++ b/static/lang/it.json
@@ -1502,6 +1502,8 @@
             "Action": {
                 "AbilityModifier": "Modificatore di caratteristica",
                 "ActionTarget": {
+                    "AC5": "AC 5",
+                    "AC15": "AC 15",
                     "ChatMessage": " against {actionTarget}",
                     "EAC": "EAC",
                     "KAC": "KAC",

--- a/static/lang/ja.json
+++ b/static/lang/ja.json
@@ -1502,6 +1502,8 @@
             "Action": {
                 "AbilityModifier": "Ability Modifier",
                 "ActionTarget": {
+                    "AC5": "AC 5",
+                    "AC15": "AC 15",
                     "ChatMessage": " against {actionTarget}",
                     "EAC": "EAC",
                     "KAC": "KAC",

--- a/static/lang/pt-BR.json
+++ b/static/lang/pt-BR.json
@@ -1502,6 +1502,8 @@
             "Action": {
                 "AbilityModifier": "Modificador Habilidade",
                 "ActionTarget": {
+                    "AC5": "AC 5",
+                    "AC15": "AC 15",
                     "ChatMessage": " against {actionTarget}",
                     "EAC": "EAC",
                     "KAC": "KAC",


### PR DESCRIPTION
* Add missing action targets for AC 5 and AC 15
* Set the action target of all grenades to AC 5 (as per CRB pg. 245 "Targeting a Grid Intersection")
* Fix capacity, usage and uses for all grenades
* Set all grenades to be one-handed thrown weapons
* Set action type of all grenades to ranged weapon attack
* Set activation cost of all grenades to 1 standard action
* Fix saving throw of conjure grenade spell
* Fix quotes on max uses on some grenades
* Remove bracket from end of Mindspike grenade, Mk 5
* Fix missing spaces in antimagic grenade descriptions
* Fix missing hybrid property on antimagic grenades and holo grenades