### PR TITLE
Allow items with variable DC skill checks by hiding skill check DC on the item card

### DIFF
--- a/src/module/rules/actions/item/calculate-skill-dc.js
+++ b/src/module/rules/actions/item/calculate-skill-dc.js
@@ -16,6 +16,12 @@ export default function(engine) {
 
             if (data.skillCheck && data.skillCheck.type) {
                 const skillCheck = data.skillCheck || {};
+                const checkLabel = `${CONFIG.SFRPG.skills[skillCheck.type]} ${game.i18n.localize("SFRPG.ChatCard.ItemAction.Check")}`;
+
+                if (skillCheck.variable) {
+                    item.labels.skillCheck = checkLabel;
+                    return fact;
+                }
 
                 let dcFormula = skillCheck.dc?.toString();
                 if (!dcFormula) {
@@ -37,7 +43,7 @@ export default function(engine) {
 
                     const rollResult = DiceSFRPG.resolveFormulaWithoutDice(dcFormula, rollContext, {logErrors: false});
                     if (!rollResult.hadError) {
-                        item.labels.skillCheck = `DC ${rollResult.total >= 0 ? rollResult.total : ""} ${CONFIG.SFRPG.skills[skillCheck.type]} ${game.i18n.localize("SFRPG.ChatCard.ItemAction.Check")}`;
+                        item.labels.skillCheck = `DC ${rollResult.total} ${checkLabel}`;
                         item.labels.skillFormula = dcFormula;
                         computedSkill = true;
                     } else {

--- a/static/lang/de.json
+++ b/static/lang/de.json
@@ -1548,7 +1548,8 @@
                 "SavingThrow": "Rettungswurf",
                 "SkillCheck": "Fertigkeitswurf",
                 "TitleAction": "Handlung",
-                "TitleActivation": "Aktivierung"
+                "TitleActivation": "Aktivierung",
+                "VariableDC": "Variable DC"
             },
             "Activation": {
                 "Activation": "Aktivierung",

--- a/static/lang/de.json
+++ b/static/lang/de.json
@@ -1547,9 +1547,12 @@
                 "RollNotesTooltip": "Die Notizen für den Wurf werden auf der Nachricht der Handlung angezeigt. So können Erinnerungen und Notizen angezeigt werden, besonders nützlich bei kompliziereten NSCs.",
                 "SavingThrow": "Rettungswurf",
                 "SkillCheck": "Fertigkeitswurf",
+                "SkillCheckPlaceholderFormula": "e.g. 10 + floor(1.5*@details.cr)",
+                "SkillCheckPlaceholderTooltip": "A formula for the DC of the skill check",
                 "TitleAction": "Handlung",
                 "TitleActivation": "Aktivierung",
-                "VariableDC": "Variable DC"
+                "VariableDC": "Variable DC",
+                "VariableDCTooltip": "Check this to disable automatic skill check DC calculation for abilities with variable DCs."
             },
             "Activation": {
                 "Activation": "Aktivierung",

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -1541,9 +1541,12 @@
                 "RollNotesTooltip": "The roll notes are displayed on the action roll chat card. This is a great way to put helpful reminders, especially for GMs with complicated NPCs.",
                 "SavingThrow": "Saving Throw",
                 "SkillCheck": "Skill Check",
+                "SkillCheckPlaceholderFormula": "e.g. 10 + floor(1.5*@details.cr)",
+                "SkillCheckPlaceholderTooltip": "A formula for the DC of the skill check",
                 "TitleAction": "Action",
                 "TitleActivation": "Activation",
-                "VariableDC": "Variable DC"
+                "VariableDC": "Variable DC",
+                "VariableDCTooltip": "Check this to disable automatic skill check DC calculation for abilities with variable DCs."
             },
             "Activation": {
                 "Activation": "Activation",

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -1542,7 +1542,8 @@
                 "SavingThrow": "Saving Throw",
                 "SkillCheck": "Skill Check",
                 "TitleAction": "Action",
-                "TitleActivation": "Activation"
+                "TitleActivation": "Activation",
+                "VariableDC": "Variable DC"
             },
             "Activation": {
                 "Activation": "Activation",

--- a/static/lang/es.json
+++ b/static/lang/es.json
@@ -1541,8 +1541,12 @@
                 "RollNotesTooltip": "Las notas de la tirada se muestran en la tarjeta de tirada de acción en el chat. Es una excelente forma de poner recordatorios útiles, especialmente para los directores de juego con PNJs complicados.",
                 "SavingThrow": "Tirada de salvación",
                 "SkillCheck": "Chequeo de habilidad",
+                "SkillCheckPlaceholderFormula": "e.g. 10 + floor(1.5*@details.cr)",
+                "SkillCheckPlaceholderTooltip": "A formula for the DC of the skill check",
                 "TitleAction": "Acción",
-                "TitleActivation": "Activación"
+                "TitleActivation": "Activación",
+                "VariableDC": "Variable DC",
+                "VariableDCTooltip": "Check this to disable automatic skill check DC calculation for abilities with variable DCs."
             },
             "Activation": {
                 "Activation": "Activación",

--- a/static/lang/fr.json
+++ b/static/lang/fr.json
@@ -1542,7 +1542,8 @@
                 "SavingThrow": "Jet de Sauvegarde",
                 "SkillCheck": "Tests de Compétenes",
                 "TitleAction": "Action",
-                "TitleActivation": "Activation"
+                "TitleActivation": "Activation",
+                "VariableDC": "Variable DC"
             },
             "Activation": {
                 "Activation": "Activation",

--- a/static/lang/fr.json
+++ b/static/lang/fr.json
@@ -1541,9 +1541,12 @@
                 "RollNotesTooltip": "Les notes de jet de dés sont affichées sur le jet d'action dans la carte dans le Chat. C'est un bon moyen d'y mettre des rappels utiles, particulièrement pour les MJ pour des PNJ compliqués.",
                 "SavingThrow": "Jet de Sauvegarde",
                 "SkillCheck": "Tests de Compétenes",
+                "SkillCheckPlaceholderFormula": "e.g. 10 + floor(1.5*@details.cr)",
+                "SkillCheckPlaceholderTooltip": "A formula for the DC of the skill check",
                 "TitleAction": "Action",
                 "TitleActivation": "Activation",
-                "VariableDC": "Variable DC"
+                "VariableDC": "Variable DC",
+                "VariableDCTooltip": "Check this to disable automatic skill check DC calculation for abilities with variable DCs."
             },
             "Activation": {
                 "Activation": "Activation",

--- a/static/lang/it.json
+++ b/static/lang/it.json
@@ -1548,7 +1548,8 @@
                 "SavingThrow": "Tiro Salvezza",
                 "SkillCheck": "Skill Check",
                 "TitleAction": "Action",
-                "TitleActivation": "Activation"
+                "TitleActivation": "Activation",
+                "VariableDC": "Variable DC"
             },
             "Activation": {
                 "Activation": "Activation",

--- a/static/lang/it.json
+++ b/static/lang/it.json
@@ -1547,9 +1547,12 @@
                 "RollNotesTooltip": "The roll notes are displayed on the action roll chat card. This is a great way to put helpful reminders, especially for GMs with complicated NPCs.",
                 "SavingThrow": "Tiro Salvezza",
                 "SkillCheck": "Skill Check",
+                "SkillCheckPlaceholderFormula": "e.g. 10 + floor(1.5*@details.cr)",
+                "SkillCheckPlaceholderTooltip": "A formula for the DC of the skill check",
                 "TitleAction": "Action",
                 "TitleActivation": "Activation",
-                "VariableDC": "Variable DC"
+                "VariableDC": "Variable DC",
+                "VariableDCTooltip": "Check this to disable automatic skill check DC calculation for abilities with variable DCs."
             },
             "Activation": {
                 "Activation": "Activation",

--- a/static/lang/ja.json
+++ b/static/lang/ja.json
@@ -1547,9 +1547,12 @@
                 "RollNotesTooltip": "The roll notes are displayed on the action roll chat card. This is a great way to put helpful reminders, especially for GMs with complicated NPCs.",
                 "SavingThrow": "Saving Throw",
                 "SkillCheck": "Skill Check",
+                "SkillCheckPlaceholderFormula": "e.g. 10 + floor(1.5*@details.cr)",
+                "SkillCheckPlaceholderTooltip": "A formula for the DC of the skill check",
                 "TitleAction": "Action",
                 "TitleActivation": "Activation",
-                "VariableDC": "Variable DC"
+                "VariableDC": "Variable DC",
+                "VariableDCTooltip": "Check this to disable automatic skill check DC calculation for abilities with variable DCs."
             },
             "Activation": {
                 "Activation": "Activation",

--- a/static/lang/ja.json
+++ b/static/lang/ja.json
@@ -1548,7 +1548,8 @@
                 "SavingThrow": "Saving Throw",
                 "SkillCheck": "Skill Check",
                 "TitleAction": "Action",
-                "TitleActivation": "Activation"
+                "TitleActivation": "Activation",
+                "VariableDC": "Variable DC"
             },
             "Activation": {
                 "Activation": "Activation",

--- a/static/lang/pt-BR.json
+++ b/static/lang/pt-BR.json
@@ -1547,9 +1547,12 @@
                 "RollNotesTooltip": "The roll notes are displayed on the action roll chat card. This is a great way to put helpful reminders, especially for GMs with complicated NPCs.",
                 "SavingThrow": "Salvamento",
                 "SkillCheck": "Skill Check",
+                "SkillCheckPlaceholderFormula": "e.g. 10 + floor(1.5*@details.cr)",
+                "SkillCheckPlaceholderTooltip": "A formula for the DC of the skill check",
                 "TitleAction": "Action",
                 "TitleActivation": "Activation",
-                "VariableDC": "Variable DC"
+                "VariableDC": "Variable DC",
+                "VariableDCTooltip": "Check this to disable automatic skill check DC calculation for abilities with variable DCs."
             },
             "Activation": {
                 "Activation": "Activation",

--- a/static/lang/pt-BR.json
+++ b/static/lang/pt-BR.json
@@ -1548,7 +1548,8 @@
                 "SavingThrow": "Salvamento",
                 "SkillCheck": "Skill Check",
                 "TitleAction": "Action",
-                "TitleActivation": "Activation"
+                "TitleActivation": "Activation",
+                "VariableDC": "Variable DC"
             },
             "Activation": {
                 "Activation": "Activation",

--- a/static/templates/items/parts/item-action.hbs
+++ b/static/templates/items/parts/item-action.hbs
@@ -64,13 +64,13 @@
                 <label>{{localize "SFRPG.Items.Action.SkillCheck"}}</label>
                 <div class="form-fields">
                     {{#unless itemData.skillCheck.variable}}
-                        <input type="text" class="wide-form-field" name="system.skillCheck.dc" value="{{itemData.skillCheck.dc}}" data-dtype="String" placeholder="{{placeholders.saveDC.formula}}"/>
+                        <input type="text" class="wide-form-field" name="system.skillCheck.dc" value="{{itemData.skillCheck.dc}}" data-dtype="String" data-tooltip="{{localize "SFRPG.Items.Action.SkillCheckPlaceholderTooltip"}}" placeholder="{{localize "SFRPG.Items.Action.SkillCheckPlaceholderFormula"}}"/>
                     {{/unless}}
                     <select name="system.skillCheck.type">
                         {{selectOption "" "" selected=itemData.skillCheck.type}}
                         {{selectOptions (sfrpg "skills") selected=itemData.skillCheck.type}}
                     </select>
-                    <label class="checkbox">
+                    <label class="checkbox" style="text-wrap: nowrap" data-tooltip="{{localize "SFRPG.Items.Action.VariableDCTooltip"}}">
                         <input type="checkbox" name="system.skillCheck.variable" data-dtype="Boolean" {{checked itemData.skillCheck.variable}}/> {{ localize "SFRPG.Items.Action.VariableDC" }}
                     </label>
                 </div>

--- a/static/templates/items/parts/item-action.hbs
+++ b/static/templates/items/parts/item-action.hbs
@@ -63,11 +63,16 @@
             <div class="form-group input-select">
                 <label>{{localize "SFRPG.Items.Action.SkillCheck"}}</label>
                 <div class="form-fields">
-                    <input type="text" class="wide-form-field" name="system.skillCheck.dc" value="{{itemData.skillCheck.dc}}" data-dtype="String" placeholder="{{placeholders.saveDC.formula}}"/>
+                    {{#unless itemData.skillCheck.variable}}
+                        <input type="text" class="wide-form-field" name="system.skillCheck.dc" value="{{itemData.skillCheck.dc}}" data-dtype="String" placeholder="{{placeholders.saveDC.formula}}"/>
+                    {{/unless}}
                     <select name="system.skillCheck.type">
                         {{selectOption "" "" selected=itemData.skillCheck.type}}
                         {{selectOptions (sfrpg "skills") selected=itemData.skillCheck.type}}
                     </select>
+                    <label class="checkbox">
+                        <input type="checkbox" name="system.skillCheck.variable" data-dtype="Boolean" {{checked itemData.skillCheck.variable}}/> {{ localize "SFRPG.Items.Action.VariableDC" }}
+                    </label>
                 </div>
             </div>
 


### PR DESCRIPTION
This changes the label from e.g. "DC [x] Perception Check" to "Perception Check" if a variable DC box is checked, allowing for the easy creation of feats and other actions that have variable DC skill checks.