### PR TITLE
Unarmed strike is a natural weapon and should not be marked as equipment

### DIFF
--- a/src/items/equipment/unarmed_strike.json
+++ b/src/items/equipment/unarmed_strike.json
@@ -106,7 +106,7 @@
     "formula": "",
     "identified": true,
     "isActive": null,
-    "isEquipment": true,
+    "isEquipment": false,
     "level": 0,
     "modifiers": [],
     "price": 0,


### PR DESCRIPTION
The "Weapon Is Equipment" tick box on the weapon properties editing form states that the box should be unchecked for natural weapons, however the "Unarmed strike" currently has this box ticked. This change fixes that issue.