### PR TITLE
Improved roll simplification

### DIFF
--- a/src/module/apps/roll-dialog.js
+++ b/src/module/apps/roll-dialog.js
@@ -102,29 +102,6 @@ export default class RollDialog extends Dialog {
         data.damageGroups = this.damageGroups;
 
         for (const modifier of data.availableModifiers) {
-
-            // Make a simplified roll
-            const simplerRoll = Roll.create(modifier.modifier, data.contexts.getRollData()).simplifiedFormula;
-
-            if (modifier.modifier[0] === "+") modifier.modifier = modifier.modifier.slice(1);
-
-            /* If it actually was simplified, append the original modifier for use on the tooltip.
-            *
-            * If the formulas are different with whitespace, that means the original likely has some weird whitespace, so let's correct that, bu we don't need to tell the user.
-            */
-            if (modifier.modifier !== simplerRoll) {
-                modifier.originalFormula = modifier.modifier;
-
-                // If the formulas are still different without whitespace, then FunctionTerms must have been simplifed, so let's tell the user.
-                if (modifier.originalFormula.replace(/\s/g, "") !== simplerRoll.replace(/\s/g, "")) {
-                    modifier.originalFormulaTooltip = true;
-                }
-            }
-
-            // Sign that string
-            const numMod = Number(simplerRoll);
-            modifier.modifier = numMod ? numMod.signedString() : simplerRoll;
-
             if (Object.keys(CONFIG.SFRPG.modifierTypes).includes(modifier.type)) {
                 modifier.localizedType = game.i18n.localize(`${CONFIG.SFRPG.modifierTypes[modifier.type]}`);
             }

--- a/src/module/dice.js
+++ b/src/module/dice.js
@@ -187,8 +187,9 @@ export class DiceSFRPG {
 
         const partMapper = (part) => {
             if (part instanceof Object) {
+                const simplifiedFormula = this._simplifyFormula(part.score || "0", rollContext);
                 const explanation = part.explanation ? `[${part.explanation}]` : "";
-                return `${part.score || "0"}${explanation}`;
+                return `${simplifiedFormula}${explanation}`;
             }
             return part;
         };
@@ -458,8 +459,9 @@ export class DiceSFRPG {
                     });
                     part.formula = rollInfo.rolls[0].formula.finalRoll;
                 } else {
+                    const simplifiedFormula = this._simplifyFormula(part.formula || "0", rollContext);
                     const explanation = part.explanation ? `[${part.explanation}]` : "";
-                    finalParts.push(`${part.formula || "0"}${explanation}`);
+                    finalParts.push(`${simplifiedFormula}${explanation}`);
                 }
             } else {
                 finalParts.push(formula);
@@ -991,6 +993,20 @@ export class DiceSFRPG {
         finalFormula.rollDices = rollDices;
 
         return finalFormula;
+    }
+
+    /**
+     * Simplifies a formula using a roll context
+     * @param {string} formula The formula you want to simplify
+     * @param {RollContext} rollContext The roll context to use
+     * @returns {string} A simplified version of the formula
+     */
+    static _simplifyFormula(formula, rollContext) {
+        try {
+            return Roll.create(formula, rollContext.getRollData()).simplifiedFormula;
+        } catch {
+            return formula;
+        }
     }
 
     /**

--- a/src/module/rolls/rollnode.js
+++ b/src/module/rolls/rollnode.js
@@ -64,7 +64,20 @@ export default class RollNode {
 
                 let existingNode = nodes[modKey];
                 if (!existingNode) {
-                    const childNode = new RollNode(bonus.modifier, this, this.options, {
+                    // Make a simplified roll
+                    let originalFormula = bonus.modifier.trim();
+                    if (originalFormula.startsWith("+")) originalFormula = originalFormula.slice(1);
+                    const simplifiedFormula = Roll.create(originalFormula, contexts.getRollData()).simplifiedFormula;
+
+                    // Store the simplified version to display in the roll dialog, appending a sign for numeric values (e.g. 2 is shown as +2)
+                    const numMod = Number(simplifiedFormula);
+                    bonus.simplifiedFormula = numMod ? numMod.signedString() : simplifiedFormula;
+
+                    // If the formulas are different without whitespace, then FunctionTerms must have been simplified; add a tooltip to the roll dialog showing the original formula
+                    bonus.originalFormulaTooltip = (originalFormula.replace(/\s/g, "") !== simplifiedFormula.replace(/\s/g, ""));
+
+                    // Append child node
+                    const childNode = new RollNode(simplifiedFormula, this, this.options, {
                         referenceModifier: bonus,
                         isEnabled: bonus.enabled
                     });

--- a/static/templates/chat/roll-dialog.hbs
+++ b/static/templates/chat/roll-dialog.hbs
@@ -86,9 +86,9 @@
         <li class="modifier flexrow toggle-modifier" data-modifier-index="{{id}}" data-modifier-type="{{modifier.type}}" data-modifier-value="{{modifier.max}}" {{#if modifier.notes}}data-tooltip="<b>{{modifier.name}}</b><br/>{{modifier.notes}}"{{/if}}>
             <a class="modifier-enabled" title="{{modifier.name}}">{{#if modifier.enabled}}<i class="far fa-check-square"></i>{{else}}<i class="far fa-square"></i>{{/if}}</a>
             <h4 class="modifier-name">{{modifier.name}}</h4>
-            <span class="modifier-modifier">{{modifier.modifier}}
+            <span class="modifier-modifier">{{modifier.simplifiedFormula}}
             {{#if modifier.originalFormulaTooltip}}
-                <i class="fas fa-info-circle" data-tooltip="{{localize "SFRPG.Rolls.Dialog.SimplifiedFormulaTooltip" formula=modifier.originalFormula}}"></i>
+                <i class="fas fa-info-circle" data-tooltip="{{localize "SFRPG.Rolls.Dialog.SimplifiedFormulaTooltip" formula=modifier.modifier}}"></i>
             {{/if}}
             </span>
             {{#if modifier.localizedType}}


### PR DESCRIPTION
A common complaint from my players is that they get confused by long formulas with brackets and inline math functions that get shown on roll dialogs and chat cards.

The objective of this PR is to try to simplify many of these formulas earlier, so that the end user sees what they're expecting (e.g. for Weapon Focus they will see `+1` or `+2` rather than `+ternary(gte((3 - 2),3),2,1)`).