### PR TITLE
Update vite config

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -60,7 +60,7 @@ const config = Vite.defineConfig(async ({ command }) => {
                         return chunk.fileName.endsWith(".js")
                             ? esbuild.transform(code, {
                                 keepNames: true,
-                                minifyIdentifiers: false,
+                                minifyIdentifiers: true,
                                 minifySyntax: true,
                                 minifyWhitespace: true,
                                 sourcemap: true

--- a/vite.config.js
+++ b/vite.config.js
@@ -59,7 +59,7 @@ const config = Vite.defineConfig(async ({ command }) => {
                     async handler(code, chunk) {
                         return chunk.fileName.endsWith(".js")
                             ? esbuild.transform(code, {
-                                keepNames: true,
+                                keepNames: false,
                                 minifyIdentifiers: true,
                                 minifySyntax: true,
                                 minifyWhitespace: true,

--- a/vite.config.js
+++ b/vite.config.js
@@ -43,6 +43,7 @@ const config = Vite.defineConfig(async ({ command }) => {
             emptyOutDir: false,
             sourcemap: true,
             brotliSize: true,
+            minify: false,
             lib: {
                 name: "sfrpg",
                 entry: path.resolve(__dirname, "index.js"),

--- a/vite.config.js
+++ b/vite.config.js
@@ -59,7 +59,7 @@ const config = Vite.defineConfig(async ({ command }) => {
                     async handler(code, chunk) {
                         return chunk.fileName.endsWith(".js")
                             ? esbuild.transform(code, {
-                                keepNames: false,
+                                keepNames: true,
                                 minifyIdentifiers: true,
                                 minifySyntax: true,
                                 minifyWhitespace: true,


### PR DESCRIPTION
Disable parent minify, it was overriding the settings in plugins. This would result in class names being minimized and in some instances causing issues with code like CONFIG.Dice.rolls.unshift(SFRPGRoll); as it's already created messages in games with one name registered in chat messages and will change to CONFIG.Dice.rolls.unshift(Oe) which will then throw errors when chat messages look of SFRPGRoll or some other different minimized variable name.