### PR TITLE
More V13 changes

### DIFF
--- a/src/less/actors.less
+++ b/src/less/actors.less
@@ -899,7 +899,6 @@
             .crew-controls a.crew-create,
             .crew-controls a.skill-create {
                 flex: 0 0 100%;
-                text-wrap: nowrap;
             }
 
             .item-controls.item-controls-browser {

--- a/src/less/apps.less
+++ b/src/less/apps.less
@@ -7,7 +7,7 @@
 // Global background style
 h2 {
     .exo2();
-    font-size: var(--font-size-16);
+    font-size: var(--font-size-24);
     margin: 1rem 0 1rem;
 }
 

--- a/src/less/apps.less
+++ b/src/less/apps.less
@@ -7,6 +7,8 @@
 // Global background style
 h2 {
     .exo2();
+    font-size: var(--font-size-16);
+    margin: 1rem 0 1rem;
 }
 
 h3 {
@@ -165,6 +167,7 @@ img.icon-enricher {
         .exo2();
         background: rgba(0, 0, 0, 0.1);
         border: @borderGroove;
+        color: #000;
     }
 
     // Checkbox Labels

--- a/src/less/chat.less
+++ b/src/less/chat.less
@@ -49,18 +49,17 @@
         }
 
         p button {
-            margin: 5px 0px;
+            margin: 2px 0px;
             background-color: @sfrpgRed;
             border-color: #000000;
             color: #ffffff;
             font-size: var(--font-size-12);
             height: 20px;
-            width: 60px;
-            line-height: inherit;
+            width: 100px;
         }
 
         p button.chat-button-save {
-            margin: 5px 0px;
+            margin: 2px 0px;
             background-color: grey;
             border-color: black;
             color: #ffffff;
@@ -111,7 +110,6 @@
 
         &.card-label {
             font-size: var(--font-size-20);
-            margin-bottom: 4px;
         }
     }
 

--- a/src/module/combat/combat.js
+++ b/src/module/combat/combat.js
@@ -893,6 +893,10 @@ async function onConfigClicked(combat, direction) {
     await combat.update(update);
 }
 
+Hooks.on('combatStart', (combat) => {
+    combat.begin();
+});
+
 Hooks.on('renderCombatTracker', (app, html, data) => {
     const activeCombat = data.combat;
     if (!activeCombat) {
@@ -924,12 +928,6 @@ Hooks.on('renderCombatTracker', (app, html, data) => {
         configureButtonNext.addEventListener('click', ev => {
             ev.preventDefault();
             onConfigClicked(activeCombat, 1);
-        });
-
-        const beginButton = footer.querySelector('.combat-control[data-action=startCombat]');
-        beginButton.addEventListener('click', ev => {
-            ev.preventDefault();
-            activeCombat.begin();
         });
     }
 

--- a/src/module/system/settings.js
+++ b/src/module/system/settings.js
@@ -4,6 +4,21 @@ import { ItemSFRPG } from "../item/item.js";
 import { rerenderApps } from "../utils/utilities.js";
 
 export const registerSystemSettings = function() {
+    game.settings.register("sfrpg", "chatNotificationDuration", {
+        name: "SFRPG.Settings.ChatNotificationDuration.Name",
+        hint: "SFRPG.Settings.ChatNotificationDuration.Hint",
+        scope: "client",
+        config: true,
+        default: 5000,
+        type: Number,
+        range: {
+            min: 1000,
+            max: 60000,
+            step: 1000
+        },
+        requiresReload: true
+    });
+
     game.settings.register("sfrpg", "disableExperienceTracking", {
         name: "SFRPG.Settings.ExperienceTracking.Name",
         hint: "SFRPG.Settings.ExperienceTracking.Hint",

--- a/src/module/tooltip.js
+++ b/src/module/tooltip.js
@@ -60,7 +60,12 @@ export default class TooltipManagerSFRPG extends foundry.helpers.interaction.Too
         if (Tour.tourInProgress) return; // Don't activate tooltips during a tour
 
         const element = event.target;
-        if (!element.dataset.tooltip) {
+        if (!element.dataset.tooltip && element.getAttribute("aria-label")) {
+            // If the element has an aria-label but no tooltip, set the tooltip to the aria-label value
+            element.setAttribute("data-tooltip", element.getAttribute("aria-label"));
+        }
+
+        if (!element.dataset.tooltip && !element.dataset.tooltipHtml) {
         // Check if the element has moved out from underneath the cursor and pointerenter has fired on a non-child of the
         // tooltipped element.
             if (this.#active && !this.element.contains(element)) this.#startDeactivation();

--- a/src/sfrpg.js
+++ b/src/sfrpg.js
@@ -391,6 +391,9 @@ Hooks.once('init', async function() {
         "weaponAccessory": "fas fa-gears"
     };
 
+    console.log("Starfinder | [INIT] Overriding chat message duration");
+    CONFIG.ui.chat.NOTIFY_DURATION = game.settings.get("sfrpg", "chatNotificationDuration") ?? 5000; // Default to foundry's 5 seconds;
+
     console.log("Starfinder | [INIT] Adding math functions");
     SFRPGRoll.registerMathFunctions();
 

--- a/static/lang/de.json
+++ b/static/lang/de.json
@@ -2323,6 +2323,10 @@
             "AutoRollCritEffect": {
                 "Hint": "Wird ein Raumschiff durch eine Chatkarte beschädigt, wird automatisch ein Wurf auf der Tabelle Kritische Schadenseffekte (GRB S. 321) durchgeführt, wenn dieser Schaden eine kritische Schwelle überschreitet.",
                 "Name": "Automatisch kritische Schadenseffekte für Raumschiffe würfeln"
+            },            
+            "ChatNotificationDuration": {
+                "Hint": "How long (in MS) to display chat notifications before they are dismissed.",
+                "Name": "Chat Notification Duration"
             },
             "CombatCards": {
                 "NormalHint": "Lege fest, welche Chatkarten für Kämpfe im normalen Kampf angezeigt werden.",

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -2317,6 +2317,10 @@
                 "Hint": "When applying damage to a starship from a chat card, if the damage crossses a Critical Threshold, the Critical Damage Effects (CRB pg. 320) table will automatically be rolled.",
                 "Name": "Automatically roll starship critical damage effects"
             },
+            "ChatNotificationDuration": {
+                "Hint": "How long (in MS) to display chat notifications before they are dismissed.",
+                "Name": "Chat Notification Duration"
+            },
             "CombatCards": {
                 "NormalHint": "Change which combat chat cards should be displayed during normal combat.",
                 "NormalName": "Normal combat",

--- a/static/lang/fr.json
+++ b/static/lang/fr.json
@@ -2316,6 +2316,10 @@
             "AutoRollCritEffect": {
                 "Hint": "When applying damage to a starship from a chat card, if the damage crossses a Critical Threshold, the Critical Damage Effects (CRB pg. 320) table will automatically be rolled.",
                 "Name": "Automatically roll starship critical damage effects"
+            },            
+            "ChatNotificationDuration": {
+                "Hint": "How long (in MS) to display chat notifications before they are dismissed.",
+                "Name": "Chat Notification Duration"
             },
             "CombatCards": {
                 "NormalHint": "Modifier les cartes de chat de combat qui doivent être affichées pendant les combat normaux.",

--- a/static/lang/it.json
+++ b/static/lang/it.json
@@ -2323,6 +2323,10 @@
             "AutoRollCritEffect": {
                 "Hint": "When applying damage to a starship from a chat card, if the damage crossses a Critical Threshold, the Critical Damage Effects (CRB pg. 320) table will automatically be rolled.",
                 "Name": "Automatically roll starship critical damage effects"
+            },            
+            "ChatNotificationDuration": {
+                "Hint": "How long (in MS) to display chat notifications before they are dismissed.",
+                "Name": "Chat Notification Duration"
             },
             "CombatCards": {
                 "NormalHint": "Modifica le schede di chat di battaglia che dovrebbero essere visualizzate durante le normali battaglie.",

--- a/static/lang/ja.json
+++ b/static/lang/ja.json
@@ -2323,6 +2323,10 @@
             "AutoRollCritEffect": {
                 "Hint": "When applying damage to a starship from a chat card, if the damage crossses a Critical Threshold, the Critical Damage Effects (CRB pg. 320) table will automatically be rolled.",
                 "Name": "Automatically roll starship critical damage effects"
+            },            
+            "ChatNotificationDuration": {
+                "Hint": "How long (in MS) to display chat notifications before they are dismissed.",
+                "Name": "Chat Notification Duration"
             },
             "CombatCards": {
                 "NormalHint": "Change which combat chat cards should be displayed during normal combat.",

--- a/static/lang/pt-BR.json
+++ b/static/lang/pt-BR.json
@@ -2323,6 +2323,10 @@
             "AutoRollCritEffect": {
                 "Hint": "When applying damage to a starship from a chat card, if the damage crossses a Critical Threshold, the Critical Damage Effects (CRB pg. 320) table will automatically be rolled.",
                 "Name": "Automatically roll starship critical damage effects"
+            },            
+            "ChatNotificationDuration": {
+                "Hint": "How long (in MS) to display chat notifications before they are dismissed.",
+                "Name": "Chat Notification Duration"
             },
             "CombatCards": {
                 "NormalHint": "Alterar quais cartões de bate-papo de combate devem ser exibidos durante o combate normal.",


### PR DESCRIPTION
CSS changes
  - Updates to h2 and h3 because foundry caused them to inherit
  - Removed text-wrap from actors skill-create
  - Updated chat button margins and width
  
Combat
  - Removed event listener from start combat button. This looks like it was attempting to prevent the default foundry start from running but it would have needed stopPropagation as well not preventDefault. Since we were allowing it to run anyways I removed the listener and simply trigger it off of combatStart as this will allow modules like combat carousel to actually run the sfrpg begin combat properly.
 
Settings
  - Added new client chatNotificationDuration that allows users to override the base default 5 second dismiss timeout. 

Tooltips
  - Copy aria-label over to the old tooltip attribute if tooltip is absent and aria-label is not. 
  - Modify tooltip prevention only if tooltip and tooltipHtml are both absent
