### PR TITLE
fix draft release settings that are incorrect

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -27,7 +27,7 @@ jobs:
               with:
                   file: static/system.json
                   field: manifest
-                  value: https://github.com/${{github.repository}}/releases/latest/download/system.json
+                  value: https://github.com/${{github.repository}}/releases/download/${{github.event.release.tag_name}}/system.json
 
             - name: Update system.json version number
               uses: jossef/action-set-json-field@v2.1

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -69,7 +69,7 @@ jobs:
                   makeLatest: false
                   allowUpdates: true # Set this to false if you want to prevent updating existing releases
                   name: ${{ github.event.release.name }}
-                  draft: true
+                  draft: false
                   prerelease: true
                   token: ${{ secrets.GITHUB_TOKEN }}
                   artifacts: "./package/system.json, ./package/sfrpg-${{github.event.release.tag_name}}.zip"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,11 +66,11 @@ jobs:
               id: create_version_release
               uses: ncipollo/release-action@v1
               with:
-                  makeLatest: false
+                  makeLatest: true
                   allowUpdates: true # Set this to false if you want to prevent updating existing releases
                   name: ${{ github.event.release.name }}
-                  draft: true
-                  prerelease: true
+                  draft: false
+                  prerelease: false
                   token: ${{ secrets.GITHUB_TOKEN }}
                   artifacts: "./package/system.json, ./package/sfrpg-${{github.event.release.tag_name}}.zip"
                   tag: ${{ github.event.release.tag_name }}


### PR DESCRIPTION
Changes the draft/pre-release/latest release settings to be correct based on the type of workflow that runs. Additionally, for prereleases, sets the manifest link to download the specific version of the prerelease rather than latest (which would be incorrect for prerelease testing).