### PR TITLE
Fixes for v13 beta issues spotted during testing

### DIFF
--- a/src/less/document-browser.less
+++ b/src/less/document-browser.less
@@ -9,6 +9,11 @@
 
     .window-content {
         overflow-y: hidden !important;
+
+        dl dt {
+            color: black;
+            text-shadow: 1px 1px white;
+        }
     }
 
     .document-browser {

--- a/src/module/combat/combat.js
+++ b/src/module/combat/combat.js
@@ -752,14 +752,12 @@ export class CombatSFRPG extends foundry.documents.Combat {
             const preparedRollExplanationElement = document.createElement("div");
             preparedRollExplanationElement.innerHTML = preparedRollExplanation;
 
-            // Render the roll, getting the html output and parsing to DOM. Add the roll formula explanation and convert back to HTML text.
-            // const rollContentElement = document.createElement("div");
-            // rollContentElement.innerText = await roll.render();
-            const parser = new DOMParser(),
-                rollContentElement = parser.parseFromString(await roll.render(), "text/html");
+            // Created a div with the roll output sent to a div. Add the roll formula explanation to this div and convert back to text.
+            const rollContentElement = document.createElement("div");
+            rollContentElement.innerHTML = await roll.render();
             const tooltipPart = rollContentElement.querySelector(".tooltip-part");
             tooltipPart.prepend(preparedRollExplanationElement);
-            const explainedRollContent = rollContentElement.querySelector('body').innerHTML;
+            const explainedRollContent = rollContentElement.innerHTML;
 
             rollMode = roll.options?.rollMode ?? rollMode;
 

--- a/src/module/combat/combat.js
+++ b/src/module/combat/combat.js
@@ -747,10 +747,17 @@ export class CombatSFRPG extends foundry.documents.Combat {
                 flags: {"core.initiativeRoll": true}
             }, messageOptions);
 
+            // Prepare roll formula explanation
             const preparedRollExplanation = DiceSFRPG.formatFormula(roll.flags.sfrpg.finalFormula.formula);
-            const rollContent = await roll.render();
-            const insertIndex = rollContent.indexOf(`</div>\r\n            <section class="tooltip-part">`);
-            const explainedRollContent = rollContent.substring(0, insertIndex) + preparedRollExplanation + rollContent.substring(insertIndex);
+            const preparedRollExplanationElement = document.createElement("div");
+            preparedRollExplanationElement.innerHTML = preparedRollExplanation;
+
+            // Render the roll, getting the html output and parsing to DOM. Add the roll formula explanation and convert back to HTML text.
+            const parser = new DOMParser(),
+                rollContent = parser.parseFromString(await roll.render(), "text/html");
+            const tooltipPart = rollContent.getElementsByClassName('tooltip-part')[0];
+            tooltipPart.prepend(preparedRollExplanationElement);
+            const explainedRollContent = rollContent.getElementsByTagName('body')[0].innerHTML;
 
             rollMode = roll.options?.rollMode ?? rollMode;
 

--- a/src/module/combat/combat.js
+++ b/src/module/combat/combat.js
@@ -753,11 +753,13 @@ export class CombatSFRPG extends foundry.documents.Combat {
             preparedRollExplanationElement.innerHTML = preparedRollExplanation;
 
             // Render the roll, getting the html output and parsing to DOM. Add the roll formula explanation and convert back to HTML text.
+            // const rollContentElement = document.createElement("div");
+            // rollContentElement.innerText = await roll.render();
             const parser = new DOMParser(),
-                rollContent = parser.parseFromString(await roll.render(), "text/html");
-            const tooltipPart = rollContent.getElementsByClassName('tooltip-part')[0];
+                rollContentElement = parser.parseFromString(await roll.render(), "text/html");
+            const tooltipPart = rollContentElement.querySelector(".tooltip-part");
             tooltipPart.prepend(preparedRollExplanationElement);
-            const explainedRollContent = rollContent.getElementsByTagName('body')[0].innerHTML;
+            const explainedRollContent = rollContentElement.querySelector('body').innerHTML;
 
             rollMode = roll.options?.rollMode ?? rollMode;
 


### PR DESCRIPTION
Resolves two issues:
1. Fixes document browser text color errors (sets all `<dt>` and `<dl>` tags to use black font color).
2. Replaces the janky manual html string manipulation that happened in initiative rolls with DOM manipulation, fixing incorrectly placed roll explanations