### PR TITLE
Journal and table coreVersion updates

### DIFF
--- a/src/items/rules/actions_in_combat.json
+++ b/src/items/rules/actions_in_combat.json
@@ -15,7 +15,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -53,7 +53,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -91,7 +91,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -129,7 +129,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -167,7 +167,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -205,7 +205,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -243,7 +243,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/rules/afflictions.json
+++ b/src/items/rules/afflictions.json
@@ -14,7 +14,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": "JournalEntry.9MGbDwywZJk2j4TZ.JournalEntryPage.Oape2psyxKExOrHF",
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -54,7 +54,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -92,7 +92,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": "JournalEntry.9MGbDwywZJk2j4TZ.JournalEntryPage.gBhZDjh30JEyh7DY",
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -132,7 +132,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/rules/archetypes.json
+++ b/src/items/rules/archetypes.json
@@ -14,7 +14,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -52,7 +52,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -90,7 +90,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -128,7 +128,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -166,7 +166,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -204,7 +204,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -242,7 +242,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -280,7 +280,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -318,7 +318,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -356,7 +356,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -394,7 +394,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -432,7 +432,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -470,7 +470,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -508,7 +508,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/rules/armor.json
+++ b/src/items/rules/armor.json
@@ -14,7 +14,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -52,7 +52,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -90,7 +90,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/rules/artifacts.json
+++ b/src/items/rules/artifacts.json
@@ -14,7 +14,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/rules/augmentations.json
+++ b/src/items/rules/augmentations.json
@@ -14,7 +14,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -52,7 +52,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -90,7 +90,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -128,7 +128,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -166,7 +166,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -204,7 +204,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -242,7 +242,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -280,7 +280,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/rules/bonuses_and_penalties.json
+++ b/src/items/rules/bonuses_and_penalties.json
@@ -15,7 +15,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": 1689566975024,
         "duplicateSource": null,
         "exportSource": null,
@@ -54,7 +54,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": 1689567065235,
         "duplicateSource": null,
         "exportSource": null,
@@ -93,7 +93,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": 1689567228463,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/rules/charter_development.json
+++ b/src/items/rules/charter_development.json
@@ -14,7 +14,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": 1689222637832,
         "duplicateSource": null,
         "exportSource": null,
@@ -53,7 +53,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": 1689222699156,
         "duplicateSource": null,
         "exportSource": null,
@@ -91,7 +91,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": 1689222851725,
         "duplicateSource": null,
         "exportSource": null,
@@ -130,7 +130,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": 1689223035274,
         "duplicateSource": null,
         "exportSource": null,
@@ -168,7 +168,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": 1689223072254,
         "duplicateSource": null,
         "exportSource": null,
@@ -206,7 +206,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": 1689223223373,
         "duplicateSource": null,
         "exportSource": null,
@@ -244,7 +244,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": 1689223283816,
         "duplicateSource": null,
         "exportSource": null,
@@ -282,7 +282,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": 1689226619231,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/rules/combat_basics.json
+++ b/src/items/rules/combat_basics.json
@@ -15,7 +15,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": 1686005170712,
         "duplicateSource": null,
         "exportSource": null,
@@ -53,7 +53,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": 1686005204738,
         "duplicateSource": null,
         "exportSource": null,
@@ -91,7 +91,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": 1686005297539,
         "duplicateSource": null,
         "exportSource": null,
@@ -130,7 +130,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": 1686005448856,
         "duplicateSource": null,
         "exportSource": null,
@@ -168,7 +168,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": 1686005711892,
         "duplicateSource": null,
         "exportSource": null,
@@ -206,7 +206,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": 1686005779709,
         "duplicateSource": null,
         "exportSource": null,
@@ -245,7 +245,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": 1686005807758,
         "duplicateSource": null,
         "exportSource": null,
@@ -283,7 +283,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": 1686005885733,
         "duplicateSource": null,
         "exportSource": null,
@@ -321,7 +321,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": 1686006051766,
         "duplicateSource": null,
         "exportSource": null,
@@ -360,7 +360,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": 1686006079056,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/rules/combat_modifiers.json
+++ b/src/items/rules/combat_modifiers.json
@@ -15,7 +15,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -53,7 +53,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -91,7 +91,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -129,7 +129,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -167,7 +167,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/rules/computers.json
+++ b/src/items/rules/computers.json
@@ -14,7 +14,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/rules/conditions.json
+++ b/src/items/rules/conditions.json
@@ -14,7 +14,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -52,7 +52,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": "JournalEntry.V2jEIIb6Aj78D4qK.JournalEntryPage.qtS73Nr2s2OvQadu",
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -92,7 +92,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/rules/creature_companions.json
+++ b/src/items/rules/creature_companions.json
@@ -14,7 +14,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -52,7 +52,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -90,7 +90,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -128,7 +128,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -166,7 +166,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/rules/critical_hit_effects.json
+++ b/src/items/rules/critical_hit_effects.json
@@ -14,7 +14,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -52,7 +52,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/rules/critical_hitfumble_cards.json
+++ b/src/items/rules/critical_hitfumble_cards.json
@@ -14,7 +14,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -52,7 +52,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": "JournalEntry.RXwIs8lDxiS9qA9o.JournalEntryPage.Uald5b8wjMo5ko0j",
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/rules/defining_effects.json
+++ b/src/items/rules/defining_effects.json
@@ -15,7 +15,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -53,7 +53,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -91,7 +91,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -129,7 +129,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -167,7 +167,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -205,7 +205,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -243,7 +243,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -281,7 +281,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -319,7 +319,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/rules/demolitions.json
+++ b/src/items/rules/demolitions.json
@@ -14,7 +14,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": "JournalEntry.oBuB9OvCmbL4HU2K.JournalEntryPage.ciQEWvmGLPNeOrxb",
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -54,7 +54,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": "JournalEntry.oBuB9OvCmbL4HU2K.JournalEntryPage.TmE9rf9dDSvRMOeD",
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -94,7 +94,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": "JournalEntry.oBuB9OvCmbL4HU2K.JournalEntryPage.oMZo3soyDWOVqq8X",
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -134,7 +134,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/rules/downtime.json
+++ b/src/items/rules/downtime.json
@@ -14,7 +14,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -52,7 +52,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -90,7 +90,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": "JournalEntry.ZIANTGBO4vvztvhS.JournalEntryPage.I9owFlphD5594pJh",
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -130,7 +130,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": "JournalEntry.ZIANTGBO4vvztvhS.JournalEntryPage.cxIyFLVUYM3tCHZJ",
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -170,7 +170,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": "JournalEntry.ZIANTGBO4vvztvhS.JournalEntryPage.xtKWQjdWDZXVNupi",
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -210,7 +210,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -248,7 +248,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -286,7 +286,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -324,7 +324,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -362,7 +362,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -400,7 +400,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -438,7 +438,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -476,7 +476,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -514,7 +514,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -552,7 +552,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -590,7 +590,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -628,7 +628,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -666,7 +666,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": "JournalEntry.ZIANTGBO4vvztvhS.JournalEntryPage.2onk0uPJ23sQ8ea6",
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -706,7 +706,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -744,7 +744,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -782,7 +782,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -820,7 +820,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -858,7 +858,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -896,7 +896,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -934,7 +934,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -972,7 +972,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1010,7 +1010,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1048,7 +1048,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1086,7 +1086,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1124,7 +1124,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1162,7 +1162,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1200,7 +1200,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1238,7 +1238,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": "JournalEntry.ZIANTGBO4vvztvhS.JournalEntryPage.f0y3Xxhl7LgUOy6F",
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1278,7 +1278,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1316,7 +1316,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1354,7 +1354,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1392,7 +1392,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1430,7 +1430,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1468,7 +1468,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1506,7 +1506,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1544,7 +1544,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1582,7 +1582,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1620,7 +1620,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1658,7 +1658,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1696,7 +1696,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1734,7 +1734,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1772,7 +1772,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1810,7 +1810,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1848,7 +1848,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1886,7 +1886,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1924,7 +1924,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1962,7 +1962,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -2000,7 +2000,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -2038,7 +2038,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -2076,7 +2076,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -2114,7 +2114,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -2152,7 +2152,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -2190,7 +2190,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -2228,7 +2228,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -2266,7 +2266,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -2304,7 +2304,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -2342,7 +2342,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -2380,7 +2380,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/rules/dynamic_hacking.json
+++ b/src/items/rules/dynamic_hacking.json
@@ -14,7 +14,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": "JournalEntry.Ges3z74s5SBh1ZX2.JournalEntryPage.NdFdBb7m8LGSjUOD",
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -54,7 +54,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -92,7 +92,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -130,7 +130,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": "JournalEntry.Ges3z74s5SBh1ZX2.JournalEntryPage.DPDODtlVNEAabX7u",
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -170,7 +170,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -208,7 +208,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -246,7 +246,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -284,7 +284,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -322,7 +322,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/rules/environment.json
+++ b/src/items/rules/environment.json
@@ -14,7 +14,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": "JournalEntry.Yv0sYlPqJmwLak2w.JournalEntryPage.cnRD7BeHA2Ny4YNh",
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -54,7 +54,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": "Compendium.sfrpg.rules.9x8PApRh6UoP466l.JournalEntryPage.BWuAh3NeW0Dcnjon",
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -94,7 +94,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": "Compendium.sfrpg.rules.pzOC4ojLo7Y5U9MV.JournalEntryPage.Q6do0HyZeIowTDq8",
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -134,7 +134,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": "Compendium.sfrpg.rules.z2JnsaHKE5QvwVSQ.JournalEntryPage.NOrSFYXShdxot60k",
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -174,7 +174,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": "JournalEntry.Yv0sYlPqJmwLak2w.JournalEntryPage.Gf0dltAXIpCzjMl0",
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -214,7 +214,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": "JournalEntry.Yv0sYlPqJmwLak2w.JournalEntryPage.llyS6o5YJKCTqKkG",
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -254,7 +254,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": "JournalEntry.Yv0sYlPqJmwLak2w.JournalEntryPage.n461i9lDXw303SiY",
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -294,7 +294,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -332,7 +332,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": "JournalEntry.Yv0sYlPqJmwLak2w.JournalEntryPage.pkHPhnLbWXWTx4V9",
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -372,7 +372,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -410,7 +410,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": "JournalEntry.izziFaAH1UnyR0I1.JournalEntryPage.ftqreMQkNpYDxpxY",
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/rules/feats.json
+++ b/src/items/rules/feats.json
@@ -14,7 +14,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": 1689221264764,
         "duplicateSource": null,
         "exportSource": null,
@@ -52,7 +52,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": 1689222446887,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/rules/galactic_trade.json
+++ b/src/items/rules/galactic_trade.json
@@ -14,7 +14,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -52,7 +52,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -90,7 +90,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -128,7 +128,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -166,7 +166,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -204,7 +204,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/rules/injury_and_death.json
+++ b/src/items/rules/injury_and_death.json
@@ -15,7 +15,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": 1689540173751,
         "duplicateSource": null,
         "exportSource": null,
@@ -54,7 +54,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": 1689540229448,
         "duplicateSource": null,
         "exportSource": null,
@@ -93,7 +93,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": 1689540409381,
         "duplicateSource": null,
         "exportSource": null,
@@ -131,7 +131,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": 1689540438339,
         "duplicateSource": null,
         "exportSource": null,
@@ -169,7 +169,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": "JournalEntry.Ge9rQmJLfsPhtjFz.JournalEntryPage.8YWsus7B5Kmxaeww",
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": 1689540491705,
         "duplicateSource": null,
         "exportSource": null,
@@ -209,7 +209,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": 1689540900642,
         "duplicateSource": null,
         "exportSource": null,
@@ -247,7 +247,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": "JournalEntry.Ge9rQmJLfsPhtjFz.JournalEntryPage.xcFYq2QnisFjMDTG",
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": 1689540927870,
         "duplicateSource": null,
         "exportSource": null,
@@ -287,7 +287,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": 1689541041345,
         "duplicateSource": null,
         "exportSource": null,
@@ -325,7 +325,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": "JournalEntry.Ge9rQmJLfsPhtjFz.JournalEntryPage.BcdImHavMvZMHtoR",
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": 1689541066167,
         "duplicateSource": null,
         "exportSource": null,
@@ -365,7 +365,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": "JournalEntry.Ge9rQmJLfsPhtjFz.JournalEntryPage.zSOvU10TKOXvr6JG",
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": 1689541152592,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/rules/interstellar_travel.json
+++ b/src/items/rules/interstellar_travel.json
@@ -14,7 +14,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -52,7 +52,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -90,7 +90,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/rules/movement_and_position.json
+++ b/src/items/rules/movement_and_position.json
@@ -15,7 +15,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -53,7 +53,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -91,7 +91,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -129,7 +129,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -167,7 +167,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -205,7 +205,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -243,7 +243,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -281,7 +281,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -319,7 +319,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -357,7 +357,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/rules/narrative_starship_combat_(optional).json
+++ b/src/items/rules/narrative_starship_combat_(optional).json
@@ -15,7 +15,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": 1699465298142,
         "duplicateSource": null,
         "exportSource": null,
@@ -53,7 +53,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": 1699465416420,
         "duplicateSource": null,
         "exportSource": null,
@@ -91,7 +91,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": 1699465484529,
         "duplicateSource": null,
         "exportSource": null,
@@ -129,7 +129,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": 1699465698597,
         "duplicateSource": null,
         "exportSource": null,
@@ -168,7 +168,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": 1699466286389,
         "duplicateSource": null,
         "exportSource": null,
@@ -207,7 +207,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": 1699466376083,
         "duplicateSource": null,
         "exportSource": null,
@@ -246,7 +246,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": 1699466417951,
         "duplicateSource": null,
         "exportSource": null,
@@ -285,7 +285,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": 1699499062609,
         "duplicateSource": null,
         "exportSource": null,
@@ -324,7 +324,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": 1699499229109,
         "duplicateSource": null,
         "exportSource": null,
@@ -362,7 +362,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": 1699500806815,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/rules/other_purchases.json
+++ b/src/items/rules/other_purchases.json
@@ -14,7 +14,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -52,7 +52,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -90,7 +90,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -128,7 +128,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": "JournalEntry.tPE7jaPQPGyzYPOx.JournalEntryPage.m2QaMoUIFmUHppEC",
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -168,7 +168,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -206,7 +206,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -244,7 +244,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -282,7 +282,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/rules/resolve_points.json
+++ b/src/items/rules/resolve_points.json
@@ -14,7 +14,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": 1734730983443,
         "duplicateSource": null,
         "exportSource": null,
@@ -52,7 +52,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": 1734731336015,
         "duplicateSource": null,
         "exportSource": null,
@@ -90,7 +90,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": 1734731524396,
         "duplicateSource": null,
         "exportSource": null,
@@ -128,7 +128,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": 1734732130861,
         "duplicateSource": null,
         "exportSource": null,
@@ -166,7 +166,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": 1734732193952,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/rules/senses.json
+++ b/src/items/rules/senses.json
@@ -15,7 +15,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/rules/skills.json
+++ b/src/items/rules/skills.json
@@ -14,7 +14,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -52,7 +52,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -90,7 +90,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -128,7 +128,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -166,7 +166,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -204,7 +204,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -242,7 +242,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -280,7 +280,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -318,7 +318,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -356,7 +356,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -394,7 +394,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -432,7 +432,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -470,7 +470,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -508,7 +508,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -546,7 +546,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -584,7 +584,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -622,7 +622,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -660,7 +660,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -698,7 +698,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -736,7 +736,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -774,7 +774,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -812,7 +812,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -850,7 +850,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -888,7 +888,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -926,7 +926,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -964,7 +964,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1002,7 +1002,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1040,7 +1040,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/rules/special_abilities.json
+++ b/src/items/rules/special_abilities.json
@@ -15,7 +15,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -53,7 +53,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -91,7 +91,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -129,7 +129,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/rules/species_grafts.json
+++ b/src/items/rules/species_grafts.json
@@ -14,7 +14,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/rules/squadron_combat.json
+++ b/src/items/rules/squadron_combat.json
@@ -15,7 +15,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": 1699271830896,
         "duplicateSource": null,
         "exportSource": null,
@@ -53,7 +53,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": 1699271958568,
         "duplicateSource": null,
         "exportSource": null,
@@ -91,7 +91,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": 1699273034561,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/rules/starship_chases.json
+++ b/src/items/rules/starship_chases.json
@@ -15,7 +15,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": 1699246565016,
         "duplicateSource": null,
         "exportSource": null,
@@ -54,7 +54,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": 1699246599722,
         "duplicateSource": null,
         "exportSource": null,
@@ -93,7 +93,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": 1699246721747,
         "duplicateSource": null,
         "exportSource": null,
@@ -131,7 +131,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": 1699247374494,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/rules/starship_combat.json
+++ b/src/items/rules/starship_combat.json
@@ -15,7 +15,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": 1699198514870,
         "duplicateSource": null,
         "exportSource": null,
@@ -53,7 +53,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": 1699198569396,
         "duplicateSource": null,
         "exportSource": null,
@@ -91,7 +91,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": 1699199261657,
         "duplicateSource": null,
         "exportSource": null,
@@ -130,7 +130,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": 1699199318329,
         "duplicateSource": null,
         "exportSource": null,
@@ -168,7 +168,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": 1699199371218,
         "duplicateSource": null,
         "exportSource": null,
@@ -207,7 +207,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": 1699199477146,
         "duplicateSource": null,
         "exportSource": null,
@@ -246,7 +246,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": 1699199782282,
         "duplicateSource": null,
         "exportSource": null,
@@ -285,7 +285,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": 1699201427384,
         "duplicateSource": null,
         "exportSource": null,
@@ -323,7 +323,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": 1699201746743,
         "duplicateSource": null,
         "exportSource": null,
@@ -362,7 +362,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": 1699202336693,
         "duplicateSource": null,
         "exportSource": null,
@@ -401,7 +401,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": 1699207468799,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/rules/starship_rules.json
+++ b/src/items/rules/starship_rules.json
@@ -15,7 +15,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": 1699208259171,
         "duplicateSource": null,
         "exportSource": null,
@@ -53,7 +53,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": 1699208874288,
         "duplicateSource": null,
         "exportSource": null,
@@ -91,7 +91,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": 1699236216152,
         "duplicateSource": null,
         "exportSource": null,
@@ -130,7 +130,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": 1699330977435,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/rules/tactical_rules.json
+++ b/src/items/rules/tactical_rules.json
@@ -15,7 +15,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": 1689537964714,
         "duplicateSource": null,
         "exportSource": null,
@@ -53,7 +53,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": 1689538047327,
         "duplicateSource": null,
         "exportSource": null,
@@ -91,7 +91,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": 1689538137817,
         "duplicateSource": null,
         "exportSource": null,
@@ -129,7 +129,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": 1689538167742,
         "duplicateSource": null,
         "exportSource": null,
@@ -168,7 +168,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": 1689538211551,
         "duplicateSource": null,
         "exportSource": null,
@@ -206,7 +206,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": 1689538978955,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/rules/tech_relics.json
+++ b/src/items/rules/tech_relics.json
@@ -14,7 +14,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/rules/vehicle_chases.json
+++ b/src/items/rules/vehicle_chases.json
@@ -15,7 +15,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": 1689567392688,
         "duplicateSource": null,
         "exportSource": null,
@@ -54,7 +54,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": 1689567493510,
         "duplicateSource": null,
         "exportSource": null,
@@ -92,7 +92,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": 1689567686269,
         "duplicateSource": null,
         "exportSource": null,
@@ -130,7 +130,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": 1689568173419,
         "duplicateSource": null,
         "exportSource": null,
@@ -168,7 +168,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": 1689568532601,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/rules/vehicle_tactical_rules.json
+++ b/src/items/rules/vehicle_tactical_rules.json
@@ -15,7 +15,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -53,7 +53,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -91,7 +91,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -129,7 +129,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -167,7 +167,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -205,7 +205,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -243,7 +243,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -281,7 +281,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/rules/weapon_accessories.json
+++ b/src/items/rules/weapon_accessories.json
@@ -14,7 +14,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/rules/weapons.json
+++ b/src/items/rules/weapons.json
@@ -14,7 +14,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -52,7 +52,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -90,7 +90,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -128,7 +128,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -166,7 +166,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -204,7 +204,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -242,7 +242,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -280,7 +280,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -318,7 +318,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/setting/abadar.json
+++ b/src/items/setting/abadar.json
@@ -14,7 +14,7 @@
       "type": "image",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -50,7 +50,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/setting/aballon.json
+++ b/src/items/setting/aballon.json
@@ -14,7 +14,7 @@
       "type": "image",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -50,7 +50,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/setting/absalom_station.json
+++ b/src/items/setting/absalom_station.json
@@ -14,7 +14,7 @@
       "type": "image",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -50,7 +50,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/setting/akiton.json
+++ b/src/items/setting/akiton.json
@@ -14,7 +14,7 @@
       "type": "image",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -50,7 +50,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/setting/amran.json
+++ b/src/items/setting/amran.json
@@ -14,7 +14,7 @@
       "type": "image",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -50,7 +50,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/setting/angradd.json
+++ b/src/items/setting/angradd.json
@@ -14,7 +14,7 @@
       "type": "image",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -50,7 +50,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/setting/apostae.json
+++ b/src/items/setting/apostae.json
@@ -14,7 +14,7 @@
       "type": "image",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -50,7 +50,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/setting/arshea.json
+++ b/src/items/setting/arshea.json
@@ -14,7 +14,7 @@
       "type": "image",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -50,7 +50,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/setting/asmodeus.json
+++ b/src/items/setting/asmodeus.json
@@ -14,7 +14,7 @@
       "type": "image",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -50,7 +50,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/setting/aucturn.json
+++ b/src/items/setting/aucturn.json
@@ -14,7 +14,7 @@
       "type": "image",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -50,7 +50,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/setting/besmara.json
+++ b/src/items/setting/besmara.json
@@ -14,7 +14,7 @@
       "type": "image",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -50,7 +50,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/setting/black_butterfly.json
+++ b/src/items/setting/black_butterfly.json
@@ -14,7 +14,7 @@
       "type": "image",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -50,7 +50,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/setting/bretheda.json
+++ b/src/items/setting/bretheda.json
@@ -14,7 +14,7 @@
       "type": "image",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -50,7 +50,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/setting/calistria.json
+++ b/src/items/setting/calistria.json
@@ -14,7 +14,7 @@
       "type": "image",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -50,7 +50,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/setting/castrovel.json
+++ b/src/items/setting/castrovel.json
@@ -14,7 +14,7 @@
       "type": "image",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -50,7 +50,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/setting/centus_II.json
+++ b/src/items/setting/centus_II.json
@@ -14,7 +14,7 @@
       "type": "image",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -50,7 +50,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/setting/cordrazar_iv.json
+++ b/src/items/setting/cordrazar_iv.json
@@ -14,7 +14,7 @@
       "type": "image",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -50,7 +50,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/setting/daegox_4.json
+++ b/src/items/setting/daegox_4.json
@@ -14,7 +14,7 @@
       "type": "image",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -50,7 +50,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/setting/daimalko.json
+++ b/src/items/setting/daimalko.json
@@ -14,7 +14,7 @@
       "type": "image",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -50,7 +50,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/setting/damoritosh.json
+++ b/src/items/setting/damoritosh.json
@@ -14,7 +14,7 @@
       "type": "image",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -50,7 +50,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/setting/desna.json
+++ b/src/items/setting/desna.json
@@ -14,7 +14,7 @@
       "type": "image",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -50,7 +50,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/setting/diaspora.json
+++ b/src/items/setting/diaspora.json
@@ -14,7 +14,7 @@
       "type": "image",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -50,7 +50,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/setting/dina_iii.json
+++ b/src/items/setting/dina_iii.json
@@ -14,7 +14,7 @@
       "type": "image",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -50,7 +50,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/setting/eldest.json
+++ b/src/items/setting/eldest.json
@@ -14,7 +14,7 @@
       "type": "image",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -50,7 +50,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/setting/eloritu.json
+++ b/src/items/setting/eloritu.json
@@ -14,7 +14,7 @@
       "type": "image",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -50,7 +50,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/setting/embroi.json
+++ b/src/items/setting/embroi.json
@@ -14,7 +14,7 @@
       "type": "image",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -50,7 +50,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/setting/entha.json
+++ b/src/items/setting/entha.json
@@ -14,7 +14,7 @@
       "type": "image",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -50,7 +50,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/setting/eox.json
+++ b/src/items/setting/eox.json
@@ -14,7 +14,7 @@
       "type": "image",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -50,7 +50,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/setting/gadravel.json
+++ b/src/items/setting/gadravel.json
@@ -14,7 +14,7 @@
       "type": "image",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -50,7 +50,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/setting/grascha.json
+++ b/src/items/setting/grascha.json
@@ -14,7 +14,7 @@
       "type": "image",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -50,7 +50,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/setting/groetus.json
+++ b/src/items/setting/groetus.json
@@ -14,7 +14,7 @@
       "type": "image",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -50,7 +50,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/setting/hawanna.json
+++ b/src/items/setting/hawanna.json
@@ -14,7 +14,7 @@
       "type": "image",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -50,7 +50,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/setting/heicoron_iv.json
+++ b/src/items/setting/heicoron_iv.json
@@ -14,7 +14,7 @@
       "type": "image",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -50,7 +50,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/setting/hylax.json
+++ b/src/items/setting/hylax.json
@@ -14,7 +14,7 @@
       "type": "image",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -50,7 +50,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/setting/ibra.json
+++ b/src/items/setting/ibra.json
@@ -14,7 +14,7 @@
       "type": "image",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -50,7 +50,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/setting/idari.json
+++ b/src/items/setting/idari.json
@@ -14,7 +14,7 @@
       "type": "image",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -50,7 +50,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/setting/iomedae.json
+++ b/src/items/setting/iomedae.json
@@ -14,7 +14,7 @@
       "type": "image",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -50,7 +50,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/setting/kadrical.json
+++ b/src/items/setting/kadrical.json
@@ -14,7 +14,7 @@
       "type": "image",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -50,7 +50,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/setting/lamashtu.json
+++ b/src/items/setting/lamashtu.json
@@ -14,7 +14,7 @@
       "type": "image",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -50,7 +50,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/setting/lao_shu_po.json
+++ b/src/items/setting/lao_shu_po.json
@@ -14,7 +14,7 @@
       "type": "image",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -50,7 +50,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/setting/liavara.json
+++ b/src/items/setting/liavara.json
@@ -14,7 +14,7 @@
       "type": "image",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -50,7 +50,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/setting/lissala.json
+++ b/src/items/setting/lissala.json
@@ -14,7 +14,7 @@
       "type": "image",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -50,7 +50,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/setting/nerralen.json
+++ b/src/items/setting/nerralen.json
@@ -14,7 +14,7 @@
       "type": "image",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -50,7 +50,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/setting/nyarlathotep.json
+++ b/src/items/setting/nyarlathotep.json
@@ -14,7 +14,7 @@
       "type": "image",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -50,7 +50,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/setting/oras.json
+++ b/src/items/setting/oras.json
@@ -14,7 +14,7 @@
       "type": "image",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -50,7 +50,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/setting/orry.json
+++ b/src/items/setting/orry.json
@@ -14,7 +14,7 @@
       "type": "image",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -50,7 +50,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/setting/pharasma.json
+++ b/src/items/setting/pharasma.json
@@ -14,7 +14,7 @@
       "type": "image",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -50,7 +50,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/setting/preluria.json
+++ b/src/items/setting/preluria.json
@@ -14,7 +14,7 @@
       "type": "image",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -50,7 +50,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/setting/riven_shroud.json
+++ b/src/items/setting/riven_shroud.json
@@ -14,7 +14,7 @@
       "type": "image",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -50,7 +50,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/setting/sarenrae.json
+++ b/src/items/setting/sarenrae.json
@@ -14,7 +14,7 @@
       "type": "image",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -50,7 +50,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/setting/silselrik.json
+++ b/src/items/setting/silselrik.json
@@ -14,7 +14,7 @@
       "type": "image",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -50,7 +50,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/setting/stopgap.json
+++ b/src/items/setting/stopgap.json
@@ -14,7 +14,7 @@
       "type": "image",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -50,7 +50,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/setting/talavet.json
+++ b/src/items/setting/talavet.json
@@ -14,7 +14,7 @@
       "type": "image",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -50,7 +50,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/setting/the_devourer.json
+++ b/src/items/setting/the_devourer.json
@@ -14,7 +14,7 @@
       "type": "image",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -50,7 +50,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/setting/the_drift.json
+++ b/src/items/setting/the_drift.json
@@ -14,7 +14,7 @@
       "type": "image",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -50,7 +50,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/setting/the_sun.json
+++ b/src/items/setting/the_sun.json
@@ -14,7 +14,7 @@
       "type": "image",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -50,7 +50,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/setting/the_veskarium.json
+++ b/src/items/setting/the_veskarium.json
@@ -14,7 +14,7 @@
       "type": "image",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -50,7 +50,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/setting/triaxus.json
+++ b/src/items/setting/triaxus.json
@@ -14,7 +14,7 @@
       "type": "image",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -50,7 +50,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/setting/triune.json
+++ b/src/items/setting/triune.json
@@ -14,7 +14,7 @@
       "type": "image",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -50,7 +50,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/setting/urgathoa.json
+++ b/src/items/setting/urgathoa.json
@@ -14,7 +14,7 @@
       "type": "image",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -50,7 +50,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/setting/verces.json
+++ b/src/items/setting/verces.json
@@ -14,7 +14,7 @@
       "type": "image",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -50,7 +50,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/setting/vohxa.json
+++ b/src/items/setting/vohxa.json
@@ -14,7 +14,7 @@
       "type": "image",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -50,7 +50,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/setting/weydan.json
+++ b/src/items/setting/weydan.json
@@ -14,7 +14,7 @@
       "type": "image",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -50,7 +50,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/setting/yaraesa.json
+++ b/src/items/setting/yaraesa.json
@@ -14,7 +14,7 @@
       "type": "image",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -50,7 +50,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/setting/yrgytch.json
+++ b/src/items/setting/yrgytch.json
@@ -14,7 +14,7 @@
       "type": "image",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -50,7 +50,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/setting/zeres.json
+++ b/src/items/setting/zeres.json
@@ -14,7 +14,7 @@
       "type": "image",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -50,7 +50,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/setting/zon-kuthon.json
+++ b/src/items/setting/zon-kuthon.json
@@ -14,7 +14,7 @@
       "type": "image",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -50,7 +50,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/tables/android_subtypes.json
+++ b/src/items/tables/android_subtypes.json
@@ -18,7 +18,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -44,7 +44,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -70,7 +70,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/tables/complete_species_table.json
+++ b/src/items/tables/complete_species_table.json
@@ -18,7 +18,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -44,7 +44,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -70,7 +70,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -96,7 +96,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -122,7 +122,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -148,7 +148,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -174,7 +174,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -200,7 +200,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -226,7 +226,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -252,7 +252,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -278,7 +278,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -304,7 +304,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -330,7 +330,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -356,7 +356,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -382,7 +382,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -408,7 +408,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -434,7 +434,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -460,7 +460,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -486,7 +486,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -512,7 +512,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -538,7 +538,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -564,7 +564,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -590,7 +590,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -616,7 +616,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -642,7 +642,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -668,7 +668,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -694,7 +694,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -720,7 +720,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -746,7 +746,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -772,7 +772,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -798,7 +798,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -824,7 +824,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -850,7 +850,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -876,7 +876,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -902,7 +902,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -928,7 +928,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -954,7 +954,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -980,7 +980,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1006,7 +1006,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1032,7 +1032,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1058,7 +1058,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1084,7 +1084,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1110,7 +1110,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1136,7 +1136,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1162,7 +1162,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1188,7 +1188,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1214,7 +1214,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1240,7 +1240,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1266,7 +1266,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1292,7 +1292,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1318,7 +1318,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1344,7 +1344,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1370,7 +1370,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1396,7 +1396,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1422,7 +1422,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1448,7 +1448,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1474,7 +1474,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1500,7 +1500,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1526,7 +1526,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1552,7 +1552,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1578,7 +1578,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1604,7 +1604,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1630,7 +1630,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1656,7 +1656,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1682,7 +1682,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1708,7 +1708,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1734,7 +1734,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1760,7 +1760,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1786,7 +1786,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1812,7 +1812,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1838,7 +1838,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1864,7 +1864,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1890,7 +1890,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1916,7 +1916,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1942,7 +1942,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1968,7 +1968,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1994,7 +1994,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -2020,7 +2020,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -2046,7 +2046,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -2072,7 +2072,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -2098,7 +2098,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -2124,7 +2124,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -2150,7 +2150,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -2176,7 +2176,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -2202,7 +2202,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -2228,7 +2228,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -2254,7 +2254,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -2280,7 +2280,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -2306,7 +2306,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -2332,7 +2332,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -2358,7 +2358,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -2384,7 +2384,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -2410,7 +2410,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -2436,7 +2436,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -2462,7 +2462,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -2488,7 +2488,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -2514,7 +2514,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -2540,7 +2540,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -2566,7 +2566,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -2592,7 +2592,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -2618,7 +2618,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -2644,7 +2644,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -2670,7 +2670,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -2696,7 +2696,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -2722,7 +2722,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -2748,7 +2748,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -2774,7 +2774,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -2800,7 +2800,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -2826,7 +2826,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -2852,7 +2852,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -2878,7 +2878,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -2904,7 +2904,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -2930,7 +2930,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -2956,7 +2956,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -2982,7 +2982,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -3008,7 +3008,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -3034,7 +3034,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -3060,7 +3060,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -3086,7 +3086,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -3112,7 +3112,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -3138,7 +3138,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -3164,7 +3164,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -3190,7 +3190,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -3216,7 +3216,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -3242,7 +3242,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -3268,7 +3268,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -3294,7 +3294,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -3320,7 +3320,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -3346,7 +3346,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -3372,7 +3372,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/tables/confusion_table.json
+++ b/src/items/tables/confusion_table.json
@@ -18,7 +18,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -43,7 +43,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -68,7 +68,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -93,7 +93,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/tables/critical_fumble_energy.json
+++ b/src/items/tables/critical_fumble_energy.json
@@ -18,7 +18,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -43,7 +43,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -68,7 +68,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -93,7 +93,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -118,7 +118,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -143,7 +143,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -168,7 +168,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -193,7 +193,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -218,7 +218,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -243,7 +243,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -268,7 +268,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -293,7 +293,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -318,7 +318,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -343,7 +343,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -368,7 +368,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -393,7 +393,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -418,7 +418,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -443,7 +443,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -468,7 +468,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -493,7 +493,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -518,7 +518,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -543,7 +543,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -568,7 +568,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -593,7 +593,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -618,7 +618,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -643,7 +643,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -668,7 +668,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -693,7 +693,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -718,7 +718,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -743,7 +743,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -768,7 +768,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -793,7 +793,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -818,7 +818,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -843,7 +843,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -868,7 +868,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -893,7 +893,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -918,7 +918,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -943,7 +943,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -968,7 +968,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -993,7 +993,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1018,7 +1018,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1043,7 +1043,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1068,7 +1068,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1093,7 +1093,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1118,7 +1118,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1143,7 +1143,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1168,7 +1168,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1193,7 +1193,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1218,7 +1218,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1243,7 +1243,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1268,7 +1268,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1293,7 +1293,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1318,7 +1318,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1343,7 +1343,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1368,7 +1368,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/tables/critical_fumble_extreme.json
+++ b/src/items/tables/critical_fumble_extreme.json
@@ -18,7 +18,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -43,7 +43,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -68,7 +68,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -93,7 +93,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -118,7 +118,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -143,7 +143,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -168,7 +168,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -193,7 +193,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -218,7 +218,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -243,7 +243,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -268,7 +268,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -293,7 +293,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -318,7 +318,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -343,7 +343,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -368,7 +368,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -393,7 +393,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -418,7 +418,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -443,7 +443,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -468,7 +468,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -493,7 +493,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -518,7 +518,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -543,7 +543,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -568,7 +568,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -593,7 +593,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -618,7 +618,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -643,7 +643,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -668,7 +668,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -693,7 +693,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -718,7 +718,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -743,7 +743,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -768,7 +768,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -793,7 +793,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -818,7 +818,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -843,7 +843,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -868,7 +868,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -893,7 +893,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -918,7 +918,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -943,7 +943,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -968,7 +968,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -993,7 +993,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1018,7 +1018,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1043,7 +1043,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1068,7 +1068,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1093,7 +1093,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1118,7 +1118,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1143,7 +1143,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1168,7 +1168,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1193,7 +1193,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1218,7 +1218,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1243,7 +1243,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1268,7 +1268,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1293,7 +1293,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1318,7 +1318,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/tables/critical_fumble_kinetic.json
+++ b/src/items/tables/critical_fumble_kinetic.json
@@ -18,7 +18,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -43,7 +43,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -68,7 +68,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -93,7 +93,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -118,7 +118,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -143,7 +143,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -168,7 +168,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -193,7 +193,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -218,7 +218,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -243,7 +243,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -268,7 +268,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -293,7 +293,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -318,7 +318,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -343,7 +343,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -368,7 +368,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -393,7 +393,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -418,7 +418,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -443,7 +443,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -468,7 +468,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -493,7 +493,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -518,7 +518,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -543,7 +543,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -568,7 +568,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -593,7 +593,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -618,7 +618,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -643,7 +643,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -668,7 +668,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -693,7 +693,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -718,7 +718,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -743,7 +743,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -768,7 +768,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -793,7 +793,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -818,7 +818,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -843,7 +843,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -868,7 +868,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -893,7 +893,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -918,7 +918,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -943,7 +943,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -968,7 +968,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -993,7 +993,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1018,7 +1018,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1043,7 +1043,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1068,7 +1068,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1093,7 +1093,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1118,7 +1118,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1143,7 +1143,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1168,7 +1168,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1193,7 +1193,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1218,7 +1218,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1243,7 +1243,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1268,7 +1268,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1293,7 +1293,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1318,7 +1318,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1343,7 +1343,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1368,7 +1368,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/tables/critical_fumble_spell.json
+++ b/src/items/tables/critical_fumble_spell.json
@@ -18,7 +18,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -43,7 +43,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -68,7 +68,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -93,7 +93,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -118,7 +118,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -143,7 +143,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -168,7 +168,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -193,7 +193,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -218,7 +218,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -243,7 +243,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -268,7 +268,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -293,7 +293,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -318,7 +318,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -343,7 +343,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -368,7 +368,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -393,7 +393,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -418,7 +418,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -443,7 +443,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -468,7 +468,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -493,7 +493,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -518,7 +518,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -543,7 +543,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -568,7 +568,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -593,7 +593,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -618,7 +618,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -643,7 +643,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -668,7 +668,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -693,7 +693,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -718,7 +718,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -743,7 +743,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -768,7 +768,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -793,7 +793,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -818,7 +818,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -843,7 +843,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -868,7 +868,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -893,7 +893,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -918,7 +918,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -943,7 +943,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -968,7 +968,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -993,7 +993,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1018,7 +1018,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1043,7 +1043,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1068,7 +1068,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1093,7 +1093,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1118,7 +1118,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1143,7 +1143,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1168,7 +1168,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1193,7 +1193,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1218,7 +1218,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1243,7 +1243,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1268,7 +1268,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1293,7 +1293,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1318,7 +1318,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1343,7 +1343,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1368,7 +1368,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/tables/critical_hit_energy.json
+++ b/src/items/tables/critical_hit_energy.json
@@ -18,7 +18,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -43,7 +43,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -68,7 +68,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -93,7 +93,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -118,7 +118,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -143,7 +143,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -168,7 +168,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -193,7 +193,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -218,7 +218,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -243,7 +243,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -268,7 +268,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -293,7 +293,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -318,7 +318,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -343,7 +343,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -368,7 +368,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -393,7 +393,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -418,7 +418,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -443,7 +443,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -468,7 +468,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -493,7 +493,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -518,7 +518,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -543,7 +543,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -568,7 +568,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -593,7 +593,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -618,7 +618,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -643,7 +643,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -668,7 +668,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -693,7 +693,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -718,7 +718,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -743,7 +743,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -768,7 +768,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -793,7 +793,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -818,7 +818,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -843,7 +843,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -868,7 +868,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -893,7 +893,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -918,7 +918,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -943,7 +943,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -968,7 +968,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -993,7 +993,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1018,7 +1018,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1043,7 +1043,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1068,7 +1068,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1093,7 +1093,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1118,7 +1118,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1143,7 +1143,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1168,7 +1168,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1193,7 +1193,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1218,7 +1218,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1243,7 +1243,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1268,7 +1268,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1293,7 +1293,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1318,7 +1318,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1343,7 +1343,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1368,7 +1368,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/tables/critical_hit_extreme.json
+++ b/src/items/tables/critical_hit_extreme.json
@@ -18,7 +18,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -43,7 +43,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -68,7 +68,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -93,7 +93,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -118,7 +118,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -143,7 +143,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -168,7 +168,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -193,7 +193,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -218,7 +218,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -243,7 +243,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -268,7 +268,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -293,7 +293,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -318,7 +318,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -343,7 +343,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -368,7 +368,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -393,7 +393,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -418,7 +418,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -443,7 +443,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -468,7 +468,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -493,7 +493,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -518,7 +518,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -543,7 +543,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -568,7 +568,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -593,7 +593,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -618,7 +618,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -643,7 +643,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -668,7 +668,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -693,7 +693,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -718,7 +718,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -743,7 +743,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -768,7 +768,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -793,7 +793,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -818,7 +818,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -843,7 +843,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -868,7 +868,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -893,7 +893,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -918,7 +918,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -943,7 +943,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -968,7 +968,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -993,7 +993,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1018,7 +1018,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1043,7 +1043,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1068,7 +1068,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1093,7 +1093,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1118,7 +1118,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1143,7 +1143,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1168,7 +1168,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1193,7 +1193,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1218,7 +1218,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1243,7 +1243,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1268,7 +1268,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1293,7 +1293,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1318,7 +1318,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/tables/critical_hit_kinetic.json
+++ b/src/items/tables/critical_hit_kinetic.json
@@ -18,7 +18,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -43,7 +43,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -68,7 +68,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -93,7 +93,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -118,7 +118,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -143,7 +143,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -168,7 +168,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -193,7 +193,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -218,7 +218,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -243,7 +243,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -268,7 +268,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -293,7 +293,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -318,7 +318,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -343,7 +343,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -368,7 +368,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -393,7 +393,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -418,7 +418,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -443,7 +443,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -468,7 +468,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -493,7 +493,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -518,7 +518,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -543,7 +543,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -568,7 +568,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -593,7 +593,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -618,7 +618,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -643,7 +643,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -668,7 +668,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -693,7 +693,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -718,7 +718,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -743,7 +743,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -768,7 +768,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -793,7 +793,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -818,7 +818,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -843,7 +843,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -868,7 +868,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -893,7 +893,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -918,7 +918,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -943,7 +943,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -968,7 +968,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -993,7 +993,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1018,7 +1018,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1043,7 +1043,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1068,7 +1068,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1093,7 +1093,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1118,7 +1118,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1143,7 +1143,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1168,7 +1168,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1193,7 +1193,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1218,7 +1218,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1243,7 +1243,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1268,7 +1268,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1293,7 +1293,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1318,7 +1318,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1343,7 +1343,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1368,7 +1368,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/tables/critical_hit_spell.json
+++ b/src/items/tables/critical_hit_spell.json
@@ -18,7 +18,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -43,7 +43,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -68,7 +68,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -93,7 +93,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -118,7 +118,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -143,7 +143,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -168,7 +168,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -193,7 +193,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -218,7 +218,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -243,7 +243,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -268,7 +268,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -293,7 +293,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -318,7 +318,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -343,7 +343,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -368,7 +368,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -393,7 +393,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -418,7 +418,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -443,7 +443,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -468,7 +468,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -493,7 +493,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -518,7 +518,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -543,7 +543,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -568,7 +568,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -593,7 +593,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -618,7 +618,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -643,7 +643,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -668,7 +668,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -693,7 +693,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -718,7 +718,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -743,7 +743,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -768,7 +768,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -793,7 +793,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -818,7 +818,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -843,7 +843,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -868,7 +868,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -893,7 +893,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -918,7 +918,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -943,7 +943,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -968,7 +968,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -993,7 +993,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1018,7 +1018,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1043,7 +1043,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1068,7 +1068,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1093,7 +1093,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1118,7 +1118,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1143,7 +1143,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1168,7 +1168,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1193,7 +1193,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1218,7 +1218,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1243,7 +1243,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1268,7 +1268,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1293,7 +1293,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1318,7 +1318,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1343,7 +1343,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -1368,7 +1368,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/tables/damai_subtypes.json
+++ b/src/items/tables/damai_subtypes.json
@@ -18,7 +18,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -44,7 +44,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/tables/dessamar_subtypes.json
+++ b/src/items/tables/dessamar_subtypes.json
@@ -18,7 +18,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -44,7 +44,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/tables/drift_crisis_treasure_100000_credits.json
+++ b/src/items/tables/drift_crisis_treasure_100000_credits.json
@@ -18,7 +18,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -43,7 +43,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -68,7 +68,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -93,7 +93,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -118,7 +118,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -143,7 +143,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -168,7 +168,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -193,7 +193,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -218,7 +218,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -243,7 +243,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/tables/drift_crisis_treasure_1000_credits.json
+++ b/src/items/tables/drift_crisis_treasure_1000_credits.json
@@ -18,7 +18,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -43,7 +43,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -68,7 +68,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -93,7 +93,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -118,7 +118,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -143,7 +143,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -168,7 +168,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -193,7 +193,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -218,7 +218,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -243,7 +243,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/tables/drift_crisis_treasure_25000_credits.json
+++ b/src/items/tables/drift_crisis_treasure_25000_credits.json
@@ -18,7 +18,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -43,7 +43,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -68,7 +68,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -93,7 +93,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -118,7 +118,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -143,7 +143,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -168,7 +168,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -193,7 +193,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -218,7 +218,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -243,7 +243,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/tables/drift_crisis_treasure_5000_credits.json
+++ b/src/items/tables/drift_crisis_treasure_5000_credits.json
@@ -18,7 +18,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -43,7 +43,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -68,7 +68,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -93,7 +93,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -118,7 +118,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -143,7 +143,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -168,7 +168,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -193,7 +193,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -218,7 +218,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -243,7 +243,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/tables/drift_crisis_treasure_variable_credits.json
+++ b/src/items/tables/drift_crisis_treasure_variable_credits.json
@@ -18,7 +18,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -43,7 +43,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -68,7 +68,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -93,7 +93,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -118,7 +118,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -143,7 +143,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -168,7 +168,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -194,7 +194,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -220,7 +220,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -246,7 +246,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/tables/dwarf_subtypes.json
+++ b/src/items/tables/dwarf_subtypes.json
@@ -18,7 +18,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -44,7 +44,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/tables/elf_subtypes.json
+++ b/src/items/tables/elf_subtypes.json
@@ -18,7 +18,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -44,7 +44,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/tables/embri_subtypes.json
+++ b/src/items/tables/embri_subtypes.json
@@ -18,7 +18,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -44,7 +44,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -70,7 +70,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/tables/ghibrani_subtypes.json
+++ b/src/items/tables/ghibrani_subtypes.json
@@ -18,7 +18,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -44,7 +44,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/tables/ghoran_subtypes.json
+++ b/src/items/tables/ghoran_subtypes.json
@@ -18,7 +18,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -44,7 +44,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -70,7 +70,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/tables/giant_subtypes.json
+++ b/src/items/tables/giant_subtypes.json
@@ -18,7 +18,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -44,7 +44,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -70,7 +70,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -96,7 +96,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -122,7 +122,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/tables/gnome_subtypes.json
+++ b/src/items/tables/gnome_subtypes.json
@@ -18,7 +18,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -44,7 +44,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -70,7 +70,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -96,7 +96,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -122,7 +122,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -148,7 +148,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/tables/hadrogaan_subtypes.json
+++ b/src/items/tables/hadrogaan_subtypes.json
@@ -18,7 +18,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -44,7 +44,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/tables/half-elf_subtypes.json
+++ b/src/items/tables/half-elf_subtypes.json
@@ -18,7 +18,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -44,7 +44,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/tables/half-orc_subtypes.json
+++ b/src/items/tables/half-orc_subtypes.json
@@ -18,7 +18,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -44,7 +44,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/tables/halfling_subtypes.json
+++ b/src/items/tables/halfling_subtypes.json
@@ -18,7 +18,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -44,7 +44,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/tables/hobgoblin_subtypes.json
+++ b/src/items/tables/hobgoblin_subtypes.json
@@ -18,7 +18,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -44,7 +44,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -70,7 +70,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/tables/human_subtypes.json
+++ b/src/items/tables/human_subtypes.json
@@ -18,7 +18,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -44,7 +44,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -70,7 +70,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/tables/ijtikri_subtypes.json
+++ b/src/items/tables/ijtikri_subtypes.json
@@ -18,7 +18,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -44,7 +44,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/tables/kasatha_subtypes.json
+++ b/src/items/tables/kasatha_subtypes.json
@@ -18,7 +18,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -44,7 +44,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -70,7 +70,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -96,7 +96,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/tables/lashunta_subtypes.json
+++ b/src/items/tables/lashunta_subtypes.json
@@ -18,7 +18,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -44,7 +44,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -70,7 +70,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -96,7 +96,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -122,7 +122,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -148,7 +148,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/tables/osharu_subtypes.json
+++ b/src/items/tables/osharu_subtypes.json
@@ -18,7 +18,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -44,7 +44,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -70,7 +70,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -96,7 +96,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/tables/pahtra_subtypes.json
+++ b/src/items/tables/pahtra_subtypes.json
@@ -18,7 +18,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -44,7 +44,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -70,7 +70,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -96,7 +96,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/tables/roll_table_wall_of_warped_time.json
+++ b/src/items/tables/roll_table_wall_of_warped_time.json
@@ -19,7 +19,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -44,7 +44,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -69,7 +69,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -94,7 +94,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -119,7 +119,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/tables/shirren_subtypes.json
+++ b/src/items/tables/shirren_subtypes.json
@@ -18,7 +18,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -44,7 +44,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -70,7 +70,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -96,7 +96,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/tables/skittermander_subtypes.json
+++ b/src/items/tables/skittermander_subtypes.json
@@ -18,7 +18,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -44,7 +44,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -70,7 +70,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/tables/sro_subtypes.json
+++ b/src/items/tables/sro_subtypes.json
@@ -18,7 +18,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -44,7 +44,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/tables/starship_critical_damage_effects.json
+++ b/src/items/tables/starship_critical_damage_effects.json
@@ -18,7 +18,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -43,7 +43,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -68,7 +68,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -93,7 +93,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -118,7 +118,7 @@
       "type": "text",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/tables/tromlin_subtypes.json
+++ b/src/items/tables/tromlin_subtypes.json
@@ -18,7 +18,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -44,7 +44,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/tables/vesk_subtypes.json
+++ b/src/items/tables/vesk_subtypes.json
@@ -18,7 +18,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -44,7 +44,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -70,7 +70,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -96,7 +96,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -122,7 +122,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -148,7 +148,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/tables/woioko_subtypes.json
+++ b/src/items/tables/woioko_subtypes.json
@@ -18,7 +18,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -44,7 +44,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,

--- a/src/items/tables/ysoki_subtypes.json
+++ b/src/items/tables/ysoki_subtypes.json
@@ -18,7 +18,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -44,7 +44,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -70,7 +70,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,
@@ -96,7 +96,7 @@
       "type": "document",
       "_stats": {
         "compendiumSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "13.345",
         "createdTime": null,
         "duplicateSource": null,
         "exportSource": null,


### PR DESCRIPTION
Updates "coreVersion" field on tables and journals to latest version. This should hopefully be the last commit to get all the src item data current.

This should prevent anyone making future data PRs from seeing hundreds of changed files each time they `unpack` their Foundry dbs.