### PR TITLE
Resolve `cook` not parsing folders correctly

### DIFF
--- a/build/cook.js
+++ b/build/cook.js
@@ -139,7 +139,7 @@ export async function cook() {
 
         }
 
-        const parsedFolders = (async () => {
+        const parsedFolders = await (async () => {
             const foldersFile = path.resolve(itemSourceDir, "_folders.json");
             if (fs.existsSync(foldersFile)) {
                 const jsonString = await fs.readFile(foldersFile, "utf-8");
@@ -167,7 +167,7 @@ export async function cook() {
         if (!limitToPack || directory === limitToPack) {
             const packName = path.basename(outputDir);
             const db = new LevelDatabase(outputDir, { packName });
-            promises.push(db.createPack(duplicate(parsedFiles), duplicate(parsedFolders), packName));
+            promises.push(db.createPack(parsedFiles, parsedFolders, packName));
         }
     }
 


### PR DESCRIPTION
For some reason `await Promise.all(readPromises);` doesn't resolve `parsedFolders`, one of its constituent elements, before it is duplicated and passed to `createPack`. This causes an empty array to always be passed for the folders, so they never get created in the packed databases.

This PR forces the folders to be evaluated synchronously, and removes the duplication step since it seems unnecessary.

Resolves #1577 