### PR TITLE
Add full speed display to speed tooltip

### DIFF
--- a/src/less/sheets.less
+++ b/src/less/sheets.less
@@ -38,3 +38,11 @@ body {
         padding: 5px;
     }
 }
+
+aside {
+    &#tooltip {
+        &.wide-tooltip {
+            max-width: 500px;
+        }
+    }
+}

--- a/static/lang/de.json
+++ b/static/lang/de.json
@@ -70,6 +70,7 @@
                         "Clumsy": "Unbeholfen",
                         "Perfect": "Perfekt"
                     },
+                    "FlightManeuverability": "Flight Maneuverability",
                     "MainMovementType": "Hauptbewegung",
                     "MovementSpeedNamedTitle": "Bewegungsrate: {name}",
                     "MovementSpeedTitle": "Bewegungsrate",

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -70,6 +70,7 @@
                         "Clumsy": "Clumsy",
                         "Perfect": "Perfect"
                     },
+                    "FlightManeuverability": "Flight Maneuverability",
                     "MainMovementType": "Main Movement",
                     "MovementSpeedNamedTitle": "Movement Speed: {name}",
                     "MovementSpeedTitle": "Movement Speed",

--- a/static/lang/fr.json
+++ b/static/lang/fr.json
@@ -70,6 +70,7 @@
                         "Clumsy": "Déplorable",
                         "Perfect": "Parfaite"
                     },
+                    "FlightManeuverability": "Flight Maneuverability",
                     "MainMovementType": "Type de mouvement principal",
                     "MovementSpeedNamedTitle": "Vitesse de mouvement: {name}",
                     "MovementSpeedTitle": "Vitesse de mouvement",

--- a/static/lang/it.json
+++ b/static/lang/it.json
@@ -70,6 +70,7 @@
                         "Clumsy": "Clumsy",
                         "Perfect": "Perfect"
                     },
+                    "FlightManeuverability": "Flight Maneuverability",
                     "MainMovementType": "Main Movement",
                     "MovementSpeedNamedTitle": "Movement Speed: {name}",
                     "MovementSpeedTitle": "Movement Speed",

--- a/static/lang/ja.json
+++ b/static/lang/ja.json
@@ -70,6 +70,7 @@
                         "Clumsy": "Clumsy",
                         "Perfect": "Perfect"
                     },
+                    "FlightManeuverability": "Flight Maneuverability",
                     "MainMovementType": "Main Movement",
                     "MovementSpeedNamedTitle": "Movement Speed: {name}",
                     "MovementSpeedTitle": "Movement Speed",

--- a/static/lang/pt-BR.json
+++ b/static/lang/pt-BR.json
@@ -70,6 +70,7 @@
                         "Clumsy": "Clumsy",
                         "Perfect": "Perfect"
                     },
+                    "FlightManeuverability": "Flight Maneuverability",
                     "MainMovementType": "Main Movement",
                     "MovementSpeedNamedTitle": "Movement Speed: {name}",
                     "MovementSpeedTitle": "Movement Speed",

--- a/static/templates/actors/drone-sheet.hbs
+++ b/static/templates/actors/drone-sheet.hbs
@@ -123,7 +123,7 @@
             {{!-- Skills --}}
             <ul class="left-side">
                 <ul class="attributes flexrow">
-                    {{> "systems/sfrpg/templates/actors/parts/actor-movement-element.hbs" disableEdit=true}}
+                    {{> "systems/sfrpg/templates/actors/parts/actor-movement-element.hbs" disableEdit=true expand=true}}
                 </ul>
                 <ul class="skills-list">
                     <li class="skills-header flexrow">

--- a/static/templates/actors/parts/actor-movement-element.hbs
+++ b/static/templates/actors/parts/actor-movement-element.hbs
@@ -5,8 +5,11 @@
     {{#if system.attributes.speed.swimming.value}}{{localize "SFRPG.ActorSheet.Attributes.Speed.Types.Swimming"}} - {{system.attributes.speed.swimming.value}} {{localize "SFRPG.Units.Speed"}} | @attributes.speed.swimming.value<br>{{/if}}
     {{#if system.attributes.speed.burrowing.value}}{{localize "SFRPG.ActorSheet.Attributes.Speed.Types.Burrowing"}} - {{system.attributes.speed.burrowing.value}} {{localize "SFRPG.Units.Speed"}} | @attributes.speed.burrowing.value<br>{{/if}}
     {{#if system.attributes.speed.climbing.value}}{{localize "SFRPG.ActorSheet.Attributes.Speed.Types.Climbing"}} - {{system.attributes.speed.climbing.value}} {{localize "SFRPG.Units.Speed"}} | @attributes.speed.climbing.value<br>{{/if}}
-    {{#if system.attributes.speed.special}}{{localize "SFRPG.ActorSheet.Attributes.Speed.Types.Special"}} - {{system.attributes.speed.special}} | @attributes.speed.special{{/if}}
-    {{#each system.attributes.speed.tooltip as |tip|}}{{tip}}<br>{{/each}}">
+    {{#if system.attributes.speed.special}}{{localize "SFRPG.ActorSheet.Attributes.Speed.Types.Special"}} - {{system.attributes.speed.special}} | @attributes.speed.special<br>{{/if}}
+    {{#if system.attributes.speed.tooltip}}
+    <br><strong>{{localize "SFRPG.Modifiers"}}</strong><br>
+    {{#each system.attributes.speed.tooltip as |tip|}}{{tip}}<br>{{/each}}
+    {{/if}}">
     <h4 class="attribute-name box-title">
         {{ localize "SFRPG.Speed" }}
         {{#unless disableEdit}}

--- a/static/templates/actors/parts/actor-movement-element.hbs
+++ b/static/templates/actors/parts/actor-movement-element.hbs
@@ -1,4 +1,13 @@
-<li class="attribute speed" {{#if expand}}style="height: {{expandedSpeedBoxHeight}}px;"{{/if}} data-tooltip="<strong>{{ localize "SFRPG.Speed" }}</strong><br>@attributes.speed.land.value<br>@attributes.speed.flying.value<br>@attributes.speed.flying.maneuverability<br>@attributes.speed.swimming.value<br>@attributes.speed.burrowing.value<br>@attributes.speed.climbing.value<br>@attributes.speed.special{{#if system.attributes.speed.special}}<br><br>{{localize "SFRPG.ActorSheet.Attributes.Speed.Types.Special"}}: {{system.attributes.speed.special}}{{/if}}<br><br>{{#each system.attributes.speed.tooltip as |tip|}}{{tip}}<br>{{/each}}">
+<li class="attribute speed" {{#if expand}}style="height: {{expandedSpeedBoxHeight}}px;"{{/if}} data-tooltip-class="wide-tooltip" data-tooltip="<strong>{{ localize "SFRPG.Speed" }}</strong><br>
+    {{localize "SFRPG.ActorSheet.Attributes.Speed.Types.Land"}} - {{system.attributes.speed.land.value}} {{localize "SFRPG.Units.Speed"}} | @attributes.speed.land.value<br>
+    {{localize "SFRPG.ActorSheet.Attributes.Speed.Types.Flying"}} - {{system.attributes.speed.flying.value}} {{localize "SFRPG.Units.Speed"}} | @attributes.speed.flying.value<br>
+    {{localize "SFRPG.ActorSheet.Attributes.Speed.FlightManeuverability"}} - {{sfrpg "flightManeuverability" system.attributes.speed.flying.maneuverability}} | @attributes.speed.flying.maneuverability<br>
+    {{localize "SFRPG.ActorSheet.Attributes.Speed.Types.Swimming"}} - {{system.attributes.speed.swimming.value}} {{localize "SFRPG.Units.Speed"}} | @attributes.speed.swimming.value<br>
+    {{localize "SFRPG.ActorSheet.Attributes.Speed.Types.Burrowing"}} - {{system.attributes.speed.burrowing.value}} {{localize "SFRPG.Units.Speed"}} | @attributes.speed.burrowing.value<br>
+    {{localize "SFRPG.ActorSheet.Attributes.Speed.Types.Climbing"}} - {{system.attributes.speed.climbing.value}} {{localize "SFRPG.Units.Speed"}} | @attributes.speed.climbing.value<br>
+    {{localize "SFRPG.ActorSheet.Attributes.Speed.Types.Special"}} - {{system.attributes.speed.special.value}} | @attributes.speed.special{{#if system.attributes.speed.special}}<br><br>
+    {{localize "SFRPG.ActorSheet.Attributes.Speed.Types.Special"}}: {{system.attributes.speed.special}}{{/if}}<br><br>
+    {{#each system.attributes.speed.tooltip as |tip|}}{{tip}}<br>{{/each}}">
     <h4 class="attribute-name box-title">
         {{ localize "SFRPG.Speed" }}
         {{#unless disableEdit}}

--- a/static/templates/actors/parts/actor-movement-element.hbs
+++ b/static/templates/actors/parts/actor-movement-element.hbs
@@ -1,12 +1,11 @@
 <li class="attribute speed" {{#if expand}}style="height: {{expandedSpeedBoxHeight}}px;"{{/if}} data-tooltip-class="wide-tooltip" data-tooltip="<strong>{{ localize "SFRPG.Speed" }}</strong><br>
-    {{localize "SFRPG.ActorSheet.Attributes.Speed.Types.Land"}} - {{system.attributes.speed.land.value}} {{localize "SFRPG.Units.Speed"}} | @attributes.speed.land.value<br>
-    {{localize "SFRPG.ActorSheet.Attributes.Speed.Types.Flying"}} - {{system.attributes.speed.flying.value}} {{localize "SFRPG.Units.Speed"}} | @attributes.speed.flying.value<br>
-    {{localize "SFRPG.ActorSheet.Attributes.Speed.FlightManeuverability"}} - {{sfrpg "flightManeuverability" system.attributes.speed.flying.maneuverability}} | @attributes.speed.flying.maneuverability<br>
-    {{localize "SFRPG.ActorSheet.Attributes.Speed.Types.Swimming"}} - {{system.attributes.speed.swimming.value}} {{localize "SFRPG.Units.Speed"}} | @attributes.speed.swimming.value<br>
-    {{localize "SFRPG.ActorSheet.Attributes.Speed.Types.Burrowing"}} - {{system.attributes.speed.burrowing.value}} {{localize "SFRPG.Units.Speed"}} | @attributes.speed.burrowing.value<br>
-    {{localize "SFRPG.ActorSheet.Attributes.Speed.Types.Climbing"}} - {{system.attributes.speed.climbing.value}} {{localize "SFRPG.Units.Speed"}} | @attributes.speed.climbing.value<br>
-    {{localize "SFRPG.ActorSheet.Attributes.Speed.Types.Special"}} - {{system.attributes.speed.special.value}} | @attributes.speed.special{{#if system.attributes.speed.special}}<br><br>
-    {{localize "SFRPG.ActorSheet.Attributes.Speed.Types.Special"}}: {{system.attributes.speed.special}}{{/if}}<br><br>
+    {{#if system.attributes.speed.land.value}}{{localize "SFRPG.ActorSheet.Attributes.Speed.Types.Land"}} - {{system.attributes.speed.land.value}} {{localize "SFRPG.Units.Speed"}} | @attributes.speed.land.value<br>{{/if}}
+    {{#if system.attributes.speed.flying.value}}{{localize "SFRPG.ActorSheet.Attributes.Speed.Types.Flying"}} - {{system.attributes.speed.flying.value}} {{localize "SFRPG.Units.Speed"}} | @attributes.speed.flying.value<br>{{/if}}
+    {{#if system.attributes.speed.flying.value}}{{localize "SFRPG.ActorSheet.Attributes.Speed.FlightManeuverability"}} - {{sfrpg "flightManeuverability" system.attributes.speed.flying.maneuverability}} | @attributes.speed.flying.maneuverability<br>{{/if}}
+    {{#if system.attributes.speed.swimming.value}}{{localize "SFRPG.ActorSheet.Attributes.Speed.Types.Swimming"}} - {{system.attributes.speed.swimming.value}} {{localize "SFRPG.Units.Speed"}} | @attributes.speed.swimming.value<br>{{/if}}
+    {{#if system.attributes.speed.burrowing.value}}{{localize "SFRPG.ActorSheet.Attributes.Speed.Types.Burrowing"}} - {{system.attributes.speed.burrowing.value}} {{localize "SFRPG.Units.Speed"}} | @attributes.speed.burrowing.value<br>{{/if}}
+    {{#if system.attributes.speed.climbing.value}}{{localize "SFRPG.ActorSheet.Attributes.Speed.Types.Climbing"}} - {{system.attributes.speed.climbing.value}} {{localize "SFRPG.Units.Speed"}} | @attributes.speed.climbing.value<br>{{/if}}
+    {{#if system.attributes.speed.special}}{{localize "SFRPG.ActorSheet.Attributes.Speed.Types.Special"}} - {{system.attributes.speed.special}} | @attributes.speed.special{{/if}}
     {{#each system.attributes.speed.tooltip as |tip|}}{{tip}}<br>{{/each}}">
     <h4 class="attribute-name box-title">
         {{ localize "SFRPG.Speed" }}

--- a/static/templates/apps/movement-config.hbs
+++ b/static/templates/apps/movement-config.hbs
@@ -1,24 +1,24 @@
 <form autocomplete="off">
     <p class="notes">{{ localize "SFRPG.ActorSheet.Attributes.Speed.MovementSpeedTitle" }}</p>
-    <div class="form-group">
+    <div class="form-group" data-tooltip-class="wide-tooltip" data-tooltip="{{localize "SFRPG.ActorSheet.Attributes.Speed.Types.Land"}} | @attributes.speed.land.value">
         <label>{{ localize "SFRPG.ActorSheet.Attributes.Speed.Types.Land" }}</label>
         <div class="form-fields">
             <input name="system.attributes.speed.land.base" type="number" step="0.1" value="{{system.attributes.speed.land.base}}"/>
         </div>
     </div>
-    <div class="form-group">
+    <div class="form-group" data-tooltip-class="wide-tooltip" data-tooltip="{{localize "SFRPG.ActorSheet.Attributes.Speed.Types.Burrowing"}} | @attributes.speed.burrowing.value">
         <label>{{ localize "SFRPG.ActorSheet.Attributes.Speed.Types.Burrowing" }}</label>
         <div class="form-fields">
             <input name="system.attributes.speed.burrowing.base" type="number" step="0.1" value="{{system.attributes.speed.burrowing.base}}"/>
         </div>
     </div>
-    <div class="form-group">
+    <div class="form-group" data-tooltip-class="wide-tooltip" data-tooltip="{{localize "SFRPG.ActorSheet.Attributes.Speed.Types.Climbing"}} | @attributes.speed.climbing.value">
         <label>{{ localize "SFRPG.ActorSheet.Attributes.Speed.Types.Climbing" }}</label>
         <div class="form-fields">
             <input name="system.attributes.speed.climbing.base" type="number" step="0.1" value="{{system.attributes.speed.climbing.base}}"/>
         </div>
     </div>
-    <div class="form-group">
+    <div class="form-group" data-tooltip-class="wide-tooltip" data-tooltip="{{localize "SFRPG.ActorSheet.Attributes.Speed.Types.Flying"}} | @attributes.speed.flying.value<br>{{localize "SFRPG.ActorSheet.Attributes.Speed.FlightManeuverability"}} | @attributes.speed.flying.maneuverability">
         <label>{{ localize "SFRPG.ActorSheet.Attributes.Speed.Types.Flying" }}</label>
         <div class="form-fields">
             <input name="system.attributes.speed.flying.base" type="number" step="0.1" value="{{system.attributes.speed.flying.base}}"/>
@@ -27,19 +27,19 @@
             </select>
         </div>
     </div>
-    <div class="form-group">
+    <div class="form-group" data-tooltip-class="wide-tooltip" data-tooltip="{{localize "SFRPG.ActorSheet.Attributes.Speed.Types.Swimming"}} | @attributes.speed.swimming.value">
         <label>{{ localize "SFRPG.ActorSheet.Attributes.Speed.Types.Swimming" }}</label>
         <div class="form-fields">
             <input name="system.attributes.speed.swimming.base" type="number" step="0.1" value="{{system.attributes.speed.swimming.base}}"/>
         </div>
     </div>
-    <div class="form-group">
+    <div class="form-group" data-tooltip-class="wide-tooltip" data-tooltip="{{localize "SFRPG.ActorSheet.Attributes.Speed.Types.Special"}} | @attributes.speed.special">
         <label>{{ localize "SFRPG.ActorSheet.Attributes.Speed.Types.Special" }}</label>
         <div class="form-fields">
             <input type="text" class="speed" name="system.attributes.speed.special" value="{{system.attributes.speed.special}}" placeholder="{{ localize 'SFRPG.SpeedSpecial' }}" />
         </div>
     </div>
-    <div class="form-group">
+    <div class="form-group"  data-tooltip-class="wide-tooltip" data-tooltip="{{ localize "SFRPG.ActorSheet.Attributes.Speed.MainMovementType" }} | @attributes.speed.mainMovement">
         <label>{{ localize "SFRPG.ActorSheet.Attributes.Speed.MainMovementType" }}</label>
         <div class="form-fields">
             <select name="system.attributes.speed.mainMovement">


### PR DESCRIPTION
Resolves #798.

This will show the full set of speeds for an actor in the speed hover tooltip. In addition, shows the full set of speeds in drone's speed displays.