### PR TITLE
ItemCollection fixes and changes

### DIFF
--- a/src/module/actor/actor-inventory-utils.js
+++ b/src/module/actor/actor-inventory-utils.js
@@ -1,7 +1,6 @@
 import { SFRPG } from "../config.js";
 import { RPC } from "../rpc.js";
 
-import { generateUUID } from "../utils/utilities.js";
 import { value_equals } from "../utils/value_equals.js";
 
 export function initializeRemoteInventory() {

--- a/src/module/actor/actor-inventory-utils.js
+++ b/src/module/actor/actor-inventory-utils.js
@@ -624,7 +624,7 @@ async function onItemDraggedToCollection(message) {
             return;
         }
 
-        newItems.push(data.draggedItemData);
+        newItems.push(data.draggedItemData.toObject());
 
         const itemIdsToDelete = [data.draggedItemData._id];
 
@@ -636,7 +636,7 @@ async function onItemDraggedToCollection(message) {
                 const children = source.filterItems(x => container.system?.container?.contents?.find(y => y.id === x.id));
                 if (children) {
                     for (const child of children) {
-                        newItems.push(child);
+                        newItems.push(child.toObject());
                         itemIdsToDelete.push(child.id);
 
                         if (child.system.container?.contents && child.system.container.contents.length > 0) {
@@ -653,6 +653,23 @@ async function onItemDraggedToCollection(message) {
         if (sidebarItem) {
             const itemData = sidebarItem.toObject();
             newItems.push(itemData);
+        }
+    }
+
+    const itemToItemMapping = {};
+    for (const item of newItems) {
+        const newId = foundry.utils.randomID();
+        itemToItemMapping[item._id] = newId;
+        item._id = newId;
+    }
+
+    for (const item of newItems) {
+        if (item.system?.container?.contents && item.system.container.contents.length > 0) {
+            for (const content of item.system.container.contents) {
+                if (itemToItemMapping[content.id]) {
+                    content.id = itemToItemMapping[content.id];
+                }
+            }
         }
     }
 

--- a/src/module/apps/item-collection-sheet.js
+++ b/src/module/apps/item-collection-sheet.js
@@ -121,7 +121,12 @@ export class ItemCollectionSheet extends DocumentSheet {
         // Ensure containers are always open in loot collection tokens
         for (const itemData of data.items) {
             if (itemData.contents && itemData.contents.length > 0) {
-                itemData.item.isOpen = true;
+                itemData.item.config = { "isOpen": true};
+                for (const child of itemData.contents) {
+                    if (child.contents && child.contents.length > 0) {
+                        child.item.config = { "isOpen": true};
+                    }
+                }
             }
         }
 

--- a/src/module/canvas/canvas.js
+++ b/src/module/canvas/canvas.js
@@ -136,16 +136,16 @@ async function handleCanvasDropAsync(canvas, data, targetActor) {
     if (targetActor === null) {
         const transferringItems = [sourceItem];
         if (sourceActor !== null && sourceItemData.container?.contents && sourceItemData.container.contents.length > 0) {
-            const containersToTest = [sourceItemData];
+            const containersToTest = [sourceItemData.container];
             while (containersToTest.length > 0) {
                 const container = containersToTest.shift();
-                const children = sourceActor.filterItems(x => container.container.contents.find(y => y.id === x.id));
+                const children = sourceActor.filterItems(x => container.contents?.find(y => y.id === x.id));
                 if (children) {
                     for (const child of children) {
                         transferringItems.push(child);
 
                         if (child.system.container?.contents && child.system.container.contents.length > 0) {
-                            containersToTest.push(child);
+                            containersToTest.push(child.system.container);
                         }
                     }
                 }

--- a/src/module/token/token-ruler.js
+++ b/src/module/token/token-ruler.js
@@ -18,7 +18,10 @@ export default class SFRPGTokenRuler extends foundry.canvas.placeables.tokens.To
             /** @type {TokenMovementActionConfig} */
             burrow: {
                 canSelect: (token) => {
-                    if (CONFIG.SFRPG.actorsCharacterScale.includes(token.actor.type)) {
+                    const hasActor = token?.actor ? true : false;
+                    if (!hasActor) {
+                        return false;
+                    } else if (CONFIG.SFRPG.actorsCharacterScale.includes(token.actor.type)) {
                         return !(token instanceof TokenDocument) || token.actor.system.attributes.speed.burrowing?.value;
                     } else if (token.actor.type === "starship") {
                         return !(token instanceof TokenDocument);
@@ -30,7 +33,10 @@ export default class SFRPGTokenRuler extends foundry.canvas.placeables.tokens.To
             /** @type {TokenMovementActionConfig} */
             climb: {
                 canSelect: (token) => {
-                    if (token.actor.type !== "starship") {
+                    const hasActor = token?.actor ? true : false;
+                    if (!hasActor) {
+                        return false;
+                    } else if (token.actor.type !== "starship") {
                         return !(token instanceof TokenDocument) || !token.hasStatusEffect("prone");
                     }
                     return false;
@@ -43,7 +49,10 @@ export default class SFRPGTokenRuler extends foundry.canvas.placeables.tokens.To
             /** @type {TokenMovementActionConfig} */
             crawl: {
                 canSelect: (token) => {
-                    if (token.actor.type !== "starship") {
+                    const hasActor = token?.actor ? true : false;
+                    if (!hasActor) {
+                        return false;
+                    } else if (token.actor.type !== "starship") {
                         return (token instanceof TokenDocument) && token.hasStatusEffect("prone");
                     }
                     return false;
@@ -55,7 +64,10 @@ export default class SFRPGTokenRuler extends foundry.canvas.placeables.tokens.To
             /** @type {TokenMovementActionConfig} */
             fly: {
                 canSelect: (token) => {
-                    if (CONFIG.SFRPG.actorsCharacterScale.includes(token.actor.type)) {
+                    const hasActor = token?.actor ? true : false;
+                    if (!hasActor) {
+                        return false;
+                    } else if (CONFIG.SFRPG.actorsCharacterScale.includes(token.actor.type)) {
                         return !(token instanceof TokenDocument) || (!token.hasStatusEffect("prone") && token.actor.system.attributes.speed.flying?.value);
                     } else if (token.actor.type === "starship") {
                         return !(token instanceof TokenDocument) || token.actor.system.attributes.speed.value;
@@ -67,7 +79,10 @@ export default class SFRPGTokenRuler extends foundry.canvas.placeables.tokens.To
             /** @type {TokenMovementActionConfig} */
             jump: {
                 canSelect: (token) => {
-                    if (token.actor.type !== "starship") {
+                    const hasActor = token?.actor ? true : false;
+                    if (!hasActor) {
+                        return false;
+                    } else if (token.actor.type !== "starship") {
                         return !(token instanceof TokenDocument) || !token.hasStatusEffect("prone");
                     }
                     return false;
@@ -79,7 +94,10 @@ export default class SFRPGTokenRuler extends foundry.canvas.placeables.tokens.To
             /** @type {TokenMovementActionConfig} */
             swim: {
                 canSelect: (token) => {
-                    if (token.actor.type !== "starship") {
+                    const hasActor = token?.actor ? true : false;
+                    if (!hasActor) {
+                        return false;
+                    } else if (token.actor.type !== "starship") {
                         return !(token instanceof TokenDocument) || !token.hasStatusEffect("prone");
                     }
                     return false;
@@ -92,7 +110,10 @@ export default class SFRPGTokenRuler extends foundry.canvas.placeables.tokens.To
             /** @type {TokenMovementActionConfig} */
             walk: {
                 canSelect: (token) => {
-                    if (token.actor.type !== "starship") {
+                    const hasActor = token?.actor ? true : false;
+                    if (!hasActor) {
+                        return false;
+                    } else if (token.actor.type !== "starship") {
                         return !(token instanceof TokenDocument) || !token.hasStatusEffect("prone");
                     }
                     return false;
@@ -144,7 +165,7 @@ export default class SFRPGTokenRuler extends foundry.canvas.placeables.tokens.To
         );
         const activeMovementType = movementOptionsInverted[waypoint.action];
         let value = 0;
-        const hasActor = this.token.actor ? true : false;
+        const hasActor = this.token?.actor ? true : false;
         const actorSpeed = hasActor ? this.token.actor.system.attributes.speed : false;
         switch (waypoint.action) {
             case "crawl":
@@ -154,7 +175,7 @@ export default class SFRPGTokenRuler extends foundry.canvas.placeables.tokens.To
                 value = hasActor ? actorSpeed.land?.value : Infinity;
                 break;
             default:
-                if (this.token.actor.type === "starship") {
+                if (hasActor && this.token.actor.type === "starship") {
                     value = hasActor ? actorSpeed.value : Infinity;
                 } else {
                     value = hasActor ? actorSpeed[activeMovementType]?.value ?? Infinity : Infinity;


### PR DESCRIPTION
This is an attempt to get the dropping items on canvas to be a little more usable. 

Dropping items on the canvas will create an item collection with the new container svg as the image to give a better understanding of what is going on. 

The collection item will not be locked so it can be moved and or deleted directly.

There is an already existing bug that I am having issue locating that when you drop collections in collections sometimes they are not reproduced correctly nested on the target actor. It seems to create new items but with id's for the old items in the parents collection property. *Resolved by generating new id's for each item and updating contents references*


-Fix HUD crash on right click and unlock the token.
-Change image to new container image 
-Open collections two containers deep.
-Canvas dropping fixes