### PR TITLE
Fix legibility of journal in-line checks

### DIFF
--- a/src/less/apps.less
+++ b/src/less/apps.less
@@ -65,7 +65,8 @@ a.inline-roll {
 }
 
 a.enriched-link {
-    background: #ddd;
+    background: light-dark(@colorDark, @colorFaint);
+    color: light-dark(@colorFaint, @colorDark);
     padding: 1px 4px;
     border: 1px solid var(--color-border-dark-tertiary);
     border-radius: 2px;


### PR DESCRIPTION
Fixes #1605 , toggles colors for inline check links based on whether dark or light theme is selected so they're legible in both cases.