### PR TITLE
New setting Lock Artwork Rotation Default

### DIFF
--- a/src/module/actor/actor.js
+++ b/src/module/actor/actor.js
@@ -229,8 +229,12 @@ export class ActorSFRPG extends Mix(foundry.documents.Actor).with(ActorCondition
         if (this.type === "starship") {
             updates.prototypeToken = {movementAction: "fly"};
         } else if (CONFIG.SFRPG.actorsCharacterScale.includes(this.type)) {
-            const mainMovementAction = CONFIG.SFRPG.movementOptions[this.system.attributes.speed.mainMovement] ?? null;
+            const mainMovementAction = CONFIG.SFRPG.movementOptions[this.system.attributes?.speed?.mainMovement] ?? null;
             updates.prototypeToken = {movementAction: mainMovementAction};
+        }
+        if (game.settings.get("sfrpg", "lockArtworkRotationDefault") && CONFIG.SFRPG.actorsCharacterScale.includes(this.type)) {
+            updates.prototypeToken = foundry.utils.mergeObject(updates.prototypeToken ?? {}, { lockRotation : true });
+            console.error(updates);
         }
 
         this.updateSource(updates);

--- a/src/module/config.js
+++ b/src/module/config.js
@@ -28,7 +28,8 @@ SFRPG.actorsCharacterScale = [
     "character",
     "drone",
     "npc",
-    "npc2"
+    "npc2",
+    "hazard"
 ];
 
 /**

--- a/src/module/system/settings.js
+++ b/src/module/system/settings.js
@@ -326,4 +326,28 @@ export const registerSystemSettings = function() {
         type: String,
         default: "LIMITED"
     });
+
+    game.settings.register("sfrpg", "lockArtworkRotationDefault", {
+        name: "SFRPG.Settings.LockArtworkRotationDefault.Name",
+        hint: "SFRPG.Settings.LockArtworkRotationDefault.Hint",
+        scope: "world",
+        config: true,
+        default: false,
+        type: Boolean,
+        onChange: async (value) => {
+            const confirmed = await Dialog.confirm({
+                title: "Artwork Rotation Default",
+                content: "<p>Do you want to apply this setting change to all actors?</p>",
+                yes: () => true,
+                no: () => false,
+                defaultYes: false
+            });
+            if (!confirmed) return;
+            game.actors.forEach(actor => {
+                if (CONFIG.SFRPG.actorsCharacterScale.includes(actor?.type)) {
+                    actor.update({'prototypeToken.lockRotation': value});
+                }
+            });
+        }
+    });
 };

--- a/static/lang/de.json
+++ b/static/lang/de.json
@@ -2433,6 +2433,10 @@
                 "Hint": "Gibt es Meldungen über Raumschiffe mit kritischen Werten oder Schwellenwerten und das Schiff ist ein feindlicher Token, werden diese nur an den Spielleiter gepostet.",
                 "Name": "Verstecke kritische Meldungen von feindlichen Raumschiffen"
             },
+            "LockArtworkRotationDefault": {
+                "Hint": "When enabled, enables Lock Artwork Rotation on character scale actors by default (Characters/NPC/Drones/Hazards). This can be overridden by the actor's prototype token settings.",
+                "Name": "Lock Artwork Rotation by Default"
+            },
             "SFRPGTheme": {
                 "Hint": "Wenn ausgewählt werden einige kleinere Anpassungen an den Foundryfarben vorgenommen, um besser zur Starfinder Farbpalette zu passen.",
                 "Name": "Angepasstes SFRPG Thema"

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -2426,6 +2426,10 @@
                 "Hint": "When posting notifications about starship criticals or thresholds, only post to GM if the ship is a Hostile Token.",
                 "Name": "Hide Hostile Starship Critical Message"
             },
+            "LockArtworkRotationDefault": {
+                "Hint": "When enabled, enables Lock Artwork Rotation on character scale actors by default (Characters/NPC/Drones/Hazards). This can be overridden by the actor's prototype token settings.",
+                "Name": "Lock Artwork Rotation by Default"
+            },
             "SFRPGTheme": {
                 "Hint": "When enabled, a few minor tweaks to Foundry's colours will be made to match Starfinder's colour scheme.",
                 "Name": "Custom SFRPG theme"

--- a/static/lang/es.json
+++ b/static/lang/es.json
@@ -1,150 +1,150 @@
 {
     "SFRPG": {
-         "ACPTooltip": "Penalizador por Armadura: {mod} ({source})",
-    "ACTooltipArmorACMod": "Modificador de Armadura: {armor} ({name})",
-    "ACTooltipBase": "Clase de Armadura Base: {base}",
-    "ACTooltipBonus": "Bono de {type}: {mod} ({source})",
-    "ACTooltipMaxDex": "Modificador de Destreza: {maxDex} (máx armadura: {armorMax}, máx escudo: {shieldMax})",
-    "ACTooltipNotProficientMod": "Penalización por no ser competente con armadura: {profMod}",
-    "ACTooltipNotProficientShield": "Penalización por no ser competente con escudo: {profMod}",
-    "ACTooltipShieldACMod": "Modificador de Escudo: {shield} ({name})",
-    "ACvsCombatManeuversLabel": "KAC + 8",
-    "ACvsCombatManeuversTitle": "CA vs Maniobras de Combate",
-    "AbilityActivationTypesDay": "Día",
-    "AbilityActivationTypesFull": "Acción Completa",
-    "AbilityActivationTypesHour": "Hora",
-    "AbilityActivationTypesMinute": "Minuto",
-    "AbilityActivationTypesMove": "Acción M.",
-    "AbilityActivationTypesNone": "Ninguna",
-    "AbilityActivationTypesNoneButton": "Activar",
-    "AbilityActivationTypesOther": "Otras Acciones",
-    "AbilityActivationTypesReaction": "Reacción",
-    "AbilityActivationTypesRound": "Asalto",
-    "AbilityActivationTypesSpecial": "Especial",
-    "AbilityActivationTypesStandard": "Acción E.",
-    "AbilityActivationTypesSwift": "Acción Rápida",
-    "AbilityCha": "Carisma",
-    "AbilityCon": "Constitución",
-    "AbilityDamagePlaceholder": "DMG",
-    "AbilityDamageTitle": "Daño a Habilidad",
-    "AbilityDamageTooltip": "Daño a Habilidad: {mod}",
-    "AbilityDex": "Destreza",
-    "AbilityDrainPlaceholder": "DRN",
-    "AbilityDrainTitle": "Drenaje de Habilidad",
-    "AbilityDrainTooltip": "Drenaje de Habilidad: {mod}",
-    "AbilityInt": "Inteligencia",
-    "AbilityModifierBase": "Modificador Base de Habilidad: {mod}",
-    "AbilityModifiersTooltip": "Bono de {type}: {mod} ({source})",
-    "AbilityPenaltyPlaceholder": "PNL",
-    "AbilityPenaltyTitle": "Penalización a Habilidad",
-    "AbilityPenaltyTooltip": "Penalización a Habilidad: {mod}",
-    "AbilityScoreBase": "Puntuación Base de Habilidad",
-    "AbilityScoreBaseTooltip": "Puntuación Base de Habilidad: {mod}",
-    "AbilityScoreBonusModifiedTooltip": "Bono de {type}: {mod} (calculado de {base}) ({source})",
-    "AbilityScoreBonusTooltip": "Bono de {type}: {mod} ({source})",
-    "AbilityScoreGenericTooltip": "Puntuación de {score}: {value} ({source})",
-    "AbilityScoreIncreaseTooltip": "Aumento de Puntuación de Habilidad: {mod}",
-    "AbilityScoreRaceTooltip": "Especie: {mod}",
-    "AbilityScoreThemeTooltip": "Tema: {mod}",
-    "AbilityStr": "Fuerza",
-    "AbilityWis": "Sabiduría",
-    "About": "Acerca de",
-    "ActionAbil": "Prueba de Habilidad",
-    "ActionHeal": "Curación",
-    "ActionMSAK": "Ataque de Conjuro Cuerpo a Cuerpo",
-    "ActionMWAK": "Ataque de Arma Cuerpo a Cuerpo",
-    "ActionOther": "Otro",
-    "ActionRSAK": "Ataque de Conjuro a Distancia",
-    "ActionRWAK": "Ataque de Arma a Distancia",
-    "ActionSave": "Tirada de Salvación",
-    "ActionSkill": "Prueba de Habilidad",
-    "ActionUtil": "Utilidad",
-    "ActorSheet": {
-        "Attributes": {
-            "Skills": {
-                "SkillRanks": "Rangos de Habilidad"
-            },
-            "Speed": {
-                "Flight": {
-                    "Average": "Promedio",
-                    "Clumsy": "Torpe",
-                    "Perfect": "Perfecto"
+        "ACPTooltip": "Penalizador por Armadura: {mod} ({source})",
+        "ACTooltipArmorACMod": "Modificador de Armadura: {armor} ({name})",
+        "ACTooltipBase": "Clase de Armadura Base: {base}",
+        "ACTooltipBonus": "Bono de {type}: {mod} ({source})",
+        "ACTooltipMaxDex": "Modificador de Destreza: {maxDex} (máx armadura: {armorMax}, máx escudo: {shieldMax})",
+        "ACTooltipNotProficientMod": "Penalización por no ser competente con armadura: {profMod}",
+        "ACTooltipNotProficientShield": "Penalización por no ser competente con escudo: {profMod}",
+        "ACTooltipShieldACMod": "Modificador de Escudo: {shield} ({name})",
+        "ACvsCombatManeuversLabel": "KAC + 8",
+        "ACvsCombatManeuversTitle": "CA vs Maniobras de Combate",
+        "AbilityActivationTypesDay": "Día",
+        "AbilityActivationTypesFull": "Acción Completa",
+        "AbilityActivationTypesHour": "Hora",
+        "AbilityActivationTypesMinute": "Minuto",
+        "AbilityActivationTypesMove": "Acción M.",
+        "AbilityActivationTypesNone": "Ninguna",
+        "AbilityActivationTypesNoneButton": "Activar",
+        "AbilityActivationTypesOther": "Otras Acciones",
+        "AbilityActivationTypesReaction": "Reacción",
+        "AbilityActivationTypesRound": "Asalto",
+        "AbilityActivationTypesSpecial": "Especial",
+        "AbilityActivationTypesStandard": "Acción E.",
+        "AbilityActivationTypesSwift": "Acción Rápida",
+        "AbilityCha": "Carisma",
+        "AbilityCon": "Constitución",
+        "AbilityDamagePlaceholder": "DMG",
+        "AbilityDamageTitle": "Daño a Habilidad",
+        "AbilityDamageTooltip": "Daño a Habilidad: {mod}",
+        "AbilityDex": "Destreza",
+        "AbilityDrainPlaceholder": "DRN",
+        "AbilityDrainTitle": "Drenaje de Habilidad",
+        "AbilityDrainTooltip": "Drenaje de Habilidad: {mod}",
+        "AbilityInt": "Inteligencia",
+        "AbilityModifierBase": "Modificador Base de Habilidad: {mod}",
+        "AbilityModifiersTooltip": "Bono de {type}: {mod} ({source})",
+        "AbilityPenaltyPlaceholder": "PNL",
+        "AbilityPenaltyTitle": "Penalización a Habilidad",
+        "AbilityPenaltyTooltip": "Penalización a Habilidad: {mod}",
+        "AbilityScoreBase": "Puntuación Base de Habilidad",
+        "AbilityScoreBaseTooltip": "Puntuación Base de Habilidad: {mod}",
+        "AbilityScoreBonusModifiedTooltip": "Bono de {type}: {mod} (calculado de {base}) ({source})",
+        "AbilityScoreBonusTooltip": "Bono de {type}: {mod} ({source})",
+        "AbilityScoreGenericTooltip": "Puntuación de {score}: {value} ({source})",
+        "AbilityScoreIncreaseTooltip": "Aumento de Puntuación de Habilidad: {mod}",
+        "AbilityScoreRaceTooltip": "Especie: {mod}",
+        "AbilityScoreThemeTooltip": "Tema: {mod}",
+        "AbilityStr": "Fuerza",
+        "AbilityWis": "Sabiduría",
+        "About": "Acerca de",
+        "ActionAbil": "Prueba de Habilidad",
+        "ActionHeal": "Curación",
+        "ActionMSAK": "Ataque de Conjuro Cuerpo a Cuerpo",
+        "ActionMWAK": "Ataque de Arma Cuerpo a Cuerpo",
+        "ActionOther": "Otro",
+        "ActionRSAK": "Ataque de Conjuro a Distancia",
+        "ActionRWAK": "Ataque de Arma a Distancia",
+        "ActionSave": "Tirada de Salvación",
+        "ActionSkill": "Prueba de Habilidad",
+        "ActionUtil": "Utilidad",
+        "ActorSheet": {
+            "Attributes": {
+                "Skills": {
+                    "SkillRanks": "Rangos de Habilidad"
                 },
-                "MainMovementType": "Movimiento Principal",
-                "MovementSpeedNamedTitle": "Velocidad de Movimiento: {name}",
-                "MovementSpeedTitle": "Velocidad de Movimiento",
-                "Types": {
-                    "All": "Todas las velocidades",
-                    "Burrowing": "Cavar",
-                    "Climbing": "Escalar",
-                    "Flying": "Volar",
-                    "Land": "Terrestre",
-                    "Special": "Especial",
-                    "Swimming": "Nadar"
+                "Speed": {
+                    "Flight": {
+                        "Average": "Promedio",
+                        "Clumsy": "Torpe",
+                        "Perfect": "Perfecto"
+                    },
+                    "MainMovementType": "Movimiento Principal",
+                    "MovementSpeedNamedTitle": "Velocidad de Movimiento: {name}",
+                    "MovementSpeedTitle": "Velocidad de Movimiento",
+                    "Types": {
+                        "All": "Todas las velocidades",
+                        "Burrowing": "Cavar",
+                        "Climbing": "Escalar",
+                        "Flying": "Volar",
+                        "Land": "Terrestre",
+                        "Special": "Especial",
+                        "Swimming": "Nadar"
+                    }
                 }
-            }
-        },
-        "Biography": {
-            "Age": "Edad",
-            "AgePlaceholder": "ej. 19",
-            "DateOfBirth": "Fecha de Nacimiento",
-            "DateOfBirthPlaceholder": "ej. 6 de Gozran, 300 AG",
-            "Deity": "Deidad",
-            "DeityPlaceholder": "ej. Pharasma",
-            "GenderPronouns": "Género/Pronombres",
-            "GenderPronounsPlaceholder": "ej. Elle/Elles",
-            "Height": "Altura",
-            "HeightPlaceholder": "ej. 1,65 m",
-            "HomeWorld": "Mundo Natal",
-            "HomeWorldPlaceholder": "ej. Akiton",
-            "ImageTooltip": "Esta es una imagen de cuerpo completo que puedes asignar a este personaje. Las dimensiones deben ser de 200x250 píxeles o proporción 4:5.",
-            "OtherVisuals": "Apariencia",
-            "TabBio": "Biografía",
-            "TabEcology": "Ecología",
-            "TabGM": "Notas de DJ",
-            "TooltipGM": "Hay notas del DJ asignadas a este personaje.",
-            "Weight": "Peso",
-            "WeightPlaceholder": "ej. 60 kg"
-        },
-        "Features": {
-            "Categories": {
-                "ActiveFeats": "Rasgos Activos",
-                "ActorResources": "Recursos del Personaje",
-                "ArchetypeFeatures": "Rasgos de Arquetipo",
-                "Archetypes": "Arquetipos",
-                "ClassFeatures": "Rasgos de Clase",
-                "Classes": "Clases",
-                "Feats": "Dotes",
-                "OtherFeatures": "Otros Rasgos",
-                "PassiveFeats": "Dotes Pasivas",
-                "Race": "Especie",
-                "SpeciesFeatures": "Rasgos de Especie",
-                "Theme": "Tema",
-                "ThemeFeatures": "Rasgos de Tema",
-                "UniversalCreatureRules": "Reglas Universales de Criatura"
             },
-            "Create": "Crear nuevo rasgo",
-            "Filters": {
-                "Action": "Acción",
-                "Bonus": "Bono",
-                "Reaction": "Reacción"
-            }
+            "Biography": {
+                "Age": "Edad",
+                "AgePlaceholder": "ej. 19",
+                "DateOfBirth": "Fecha de Nacimiento",
+                "DateOfBirthPlaceholder": "ej. 6 de Gozran, 300 AG",
+                "Deity": "Deidad",
+                "DeityPlaceholder": "ej. Pharasma",
+                "GenderPronouns": "Género/Pronombres",
+                "GenderPronounsPlaceholder": "ej. Elle/Elles",
+                "Height": "Altura",
+                "HeightPlaceholder": "ej. 1,65 m",
+                "HomeWorld": "Mundo Natal",
+                "HomeWorldPlaceholder": "ej. Akiton",
+                "ImageTooltip": "Esta es una imagen de cuerpo completo que puedes asignar a este personaje. Las dimensiones deben ser de 200x250 píxeles o proporción 4:5.",
+                "OtherVisuals": "Apariencia",
+                "TabBio": "Biografía",
+                "TabEcology": "Ecología",
+                "TabGM": "Notas de DJ",
+                "TooltipGM": "Hay notas del DJ asignadas a este personaje.",
+                "Weight": "Peso",
+                "WeightPlaceholder": "ej. 60 kg"
             },
-"Header": {
-    "CL": "NL",
-    "Hitpoints": {
-        "ClassTooltip": "Clase Base: {mod} ({source})", 
-        "RacialTooltip": "Especie Base: {mod} ({source})" 
-    },
-    "Resolve": {
-        "KeyAbilityTooltip": "Puntuación Base de Habilidad Clave: {mod} ({kas}, {source})",
-        "LevelTooltip": "Nivel Base: {mod}" 
-    },
-    "Stamina": {
-        "ClassTooltip": "Clase Base: {mod} ({source})", 
-        "ConstitutionTooltip": "Constitución Base: {mod}" 
-    }
-},
+            "Features": {
+                "Categories": {
+                    "ActiveFeats": "Rasgos Activos",
+                    "ActorResources": "Recursos del Personaje",
+                    "ArchetypeFeatures": "Rasgos de Arquetipo",
+                    "Archetypes": "Arquetipos",
+                    "ClassFeatures": "Rasgos de Clase",
+                    "Classes": "Clases",
+                    "Feats": "Dotes",
+                    "OtherFeatures": "Otros Rasgos",
+                    "PassiveFeats": "Dotes Pasivas",
+                    "Race": "Especie",
+                    "SpeciesFeatures": "Rasgos de Especie",
+                    "Theme": "Tema",
+                    "ThemeFeatures": "Rasgos de Tema",
+                    "UniversalCreatureRules": "Reglas Universales de Criatura"
+                },
+                "Create": "Crear nuevo rasgo",
+                "Filters": {
+                    "Action": "Acción",
+                    "Bonus": "Bono",
+                    "Reaction": "Reacción"
+                }
+            },
+            "Header": {
+                "CL": "NL",
+                "Hitpoints": {
+                    "ClassTooltip": "Clase Base: {mod} ({source})",
+                    "RacialTooltip": "Especie Base: {mod} ({source})"
+                },
+                "Resolve": {
+                    "KeyAbilityTooltip": "Puntuación Base de Habilidad Clave: {mod} ({kas}, {source})",
+                    "LevelTooltip": "Nivel Base: {mod}"
+                },
+                "Stamina": {
+                    "ClassTooltip": "Clase Base: {mod} ({source})",
+                    "ConstitutionTooltip": "Constitución Base: {mod}"
+                }
+            },
             "Inventory": {
                 "Container": {
                     "AcceptedItemTypes": "Accepted item types",
@@ -241,3223 +241,3210 @@
                     "ReloadFromContainer": "The weapon {name} was reloaded with {ammoName} pulled from the container {containerName}. Double-check your action economy."
                 }
             },
-"Modifiers": {
-    "EffectTypes": {
-        "ActorResource": "Recurso del actor",
-        "AllAttackDamage": "Daño de todos los ataques",
-        "AllAttackRolls": "Todas las tiradas de ataque",
-        "AllSpeeds": "Todas las velocidades",
-        "BAB": "BAF",
-        "BaseAttackBonus": "Bono de ataque base",
-        "DamageReduction": "Reducción de daño",
-        "Encumbrance": "Carga",
-        "EnergyResistance": "Resistencia a la energía",
-        "HP": "PV",
-        "Hitpoints": "Puntos de vida",
-        "MeleeAttackDamage": "Daño de arma cuerpo a cuerpo",
-        "MeleeAttackRolls": "Tiradas de ataque cuerpo a cuerpo",
-        "MultiplyAllSpeeds": "Multiplicador de todas las velocidades",
-        "RP": "PR",
-        "RangedAttackDamage": "Daño de arma a distancia",
-        "RangedAttackRolls": "Tiradas de ataque a distancia",
-        "Resolve": "Voluntad",
-        "SP": "PE",
-        "SkillRanks": "Rangos de habilidad",
-        "Skillpoints": "Puntos de habilidad",
-        "SpecificSpeed": "Velocidad específica",
-        "SpecificWeaponAttackDamage": "Daño de arma específico",
-        "SpecificWeaponAttackRolls": "Tiradas de ataque de arma específicas",
-        "SpellAttackDamage": "Daño de hechizo",
-        "SpellAttackRolls": "Tiradas de ataque de hechizo",
-        "SpellSaveDC": "CD de salvación de hechizo",
-        "Stamina": "Resistencia",
-        "WeaponCategoryAttackRolls": "Tiradas de ataque por categoría de arma",
-        "WeaponCategoryDamage": "Daño por categoría de arma",
-        "WeaponPropertyAttackRolls": "Tiradas de ataque por propiedad de arma",
-        "WeaponPropertyDamage": "Daño por propiedad de arma"
-    },
-    "ModifierTypes": {
-        "Class": "Clase",
-        "Racial": "Especie"
-    },
-    "Tooltips": {
-        "BonusSkillpoints": "Bono de {type}: {mod} ({source})",
-        "ClassSkillpoints": "Puntos de habilidad de {class}: {total}",
-        "DeleteModifier": "Eliminar modificador",
-        "DeleteModifierTooltip": "Eliminar este modificador.",
-        "EditModifier": "Editar modificador",
-        "EditModifierTooltip": "Abrir el editor de modificadores para este modificador.",
-        "SkillRank": "Rangos de {type}: {mod} ({source})",
-        "Speed": "{speed}: {type} {mod} ({source})",
-        "ToggleEffect": "Activar/desactivar efecto",
-        "ToggleEffectTooltip": "Activar o desactivar este efecto. Los efectos deshabilitados no afectan al personaje.",
-        "ToggleModifier": "Activar/desactivar modificador",
-        "ToggleModifierTooltip": "Activar o desactivar este modificador. Los modificadores deshabilitados no afectan al personaje."
-    },
-    "UI": {
-        "LongFormula": "Fórmula larga"
-    }
-},
+            "Modifiers": {
+                "EffectTypes": {
+                    "ActorResource": "Recurso del actor",
+                    "AllAttackDamage": "Daño de todos los ataques",
+                    "AllAttackRolls": "Todas las tiradas de ataque",
+                    "AllSpeeds": "Todas las velocidades",
+                    "BAB": "BAF",
+                    "BaseAttackBonus": "Bono de ataque base",
+                    "DamageReduction": "Reducción de daño",
+                    "Encumbrance": "Carga",
+                    "EnergyResistance": "Resistencia a la energía",
+                    "HP": "PV",
+                    "Hitpoints": "Puntos de vida",
+                    "MeleeAttackDamage": "Daño de arma cuerpo a cuerpo",
+                    "MeleeAttackRolls": "Tiradas de ataque cuerpo a cuerpo",
+                    "MultiplyAllSpeeds": "Multiplicador de todas las velocidades",
+                    "RP": "PR",
+                    "RangedAttackDamage": "Daño de arma a distancia",
+                    "RangedAttackRolls": "Tiradas de ataque a distancia",
+                    "Resolve": "Voluntad",
+                    "SP": "PE",
+                    "SkillRanks": "Rangos de habilidad",
+                    "Skillpoints": "Puntos de habilidad",
+                    "SpecificSpeed": "Velocidad específica",
+                    "SpecificWeaponAttackDamage": "Daño de arma específico",
+                    "SpecificWeaponAttackRolls": "Tiradas de ataque de arma específicas",
+                    "SpellAttackDamage": "Daño de hechizo",
+                    "SpellAttackRolls": "Tiradas de ataque de hechizo",
+                    "SpellSaveDC": "CD de salvación de hechizo",
+                    "Stamina": "Resistencia",
+                    "WeaponCategoryAttackRolls": "Tiradas de ataque por categoría de arma",
+                    "WeaponCategoryDamage": "Daño por categoría de arma",
+                    "WeaponPropertyAttackRolls": "Tiradas de ataque por propiedad de arma",
+                    "WeaponPropertyDamage": "Daño por propiedad de arma"
+                },
+                "ModifierTypes": {
+                    "Class": "Clase",
+                    "Racial": "Especie"
+                },
+                "Tooltips": {
+                    "BonusSkillpoints": "Bono de {type}: {mod} ({source})",
+                    "ClassSkillpoints": "Puntos de habilidad de {class}: {total}",
+                    "DeleteModifier": "Eliminar modificador",
+                    "DeleteModifierTooltip": "Eliminar este modificador.",
+                    "EditModifier": "Editar modificador",
+                    "EditModifierTooltip": "Abrir el editor de modificadores para este modificador.",
+                    "SkillRank": "Rangos de {type}: {mod} ({source})",
+                    "Speed": "{speed}: {type} {mod} ({source})",
+                    "ToggleEffect": "Activar/desactivar efecto",
+                    "ToggleEffectTooltip": "Activar o desactivar este efecto. Los efectos deshabilitados no afectan al personaje.",
+                    "ToggleModifier": "Activar/desactivar modificador",
+                    "ToggleModifierTooltip": "Activar o desactivar este modificador. Los modificadores deshabilitados no afectan al personaje."
+                },
+                "UI": {
+                    "LongFormula": "Fórmula larga"
+                }
+            },
 
-           "Skills": {
-    "HideUntrained": "Ocultar habilidades no entrenadas",
-    "RightClickHint": "Haz clic derecho en una habilidad para más propiedades.",
-    "ShowUntrained": "Mostrar habilidades no entrenadas"
-},
-"Traits": {
-    "MagicalItems": "Objetos mágicos equipados"
-},
-"UI": {
-    "ErrorNoCharges": "{name} no tiene cargas restantes."
-}
-},
-"AddLabel": "Agregar",
-"AddProfessionButtonText": "Agregar profesión",
-"AlignmentCE": "Caótico Malvado",
-"AlignmentCG": "Caótico Bueno",
-"AlignmentCN": "Caótico Neutral",
-"AlignmentLE": "Legal Malvado",
-"AlignmentLG": "Legal Bueno",
-"AlignmentLN": "Legal Neutral",
-"AlignmentNE": "Neutral Malvado",
-"AlignmentNG": "Neutral Bueno",
-"AlignmentPlaceHolderText": "Alineamiento",
-"AlignmentTN": "Neutral Verdadero",
-"AllowedClasses": {
-    "Myst": "Místico",
-    "Precog": "Precognitivo",
-    "Tech": "Tecnomante",
-    "Wysh": "Hechicero de cambio"
-},
-"Any": "Cualquiera",
-"ArchetypesAlternateClassFeatures": "Características alternativas de clase",
-"ArmorCheckPenalty": "Penalización por armadura",
-"ArmorProficiencyHeavy": "Armadura pesada",
-"ArmorProficiencyLight": "Armadura ligera",
-"ArmorProficiencyPower": "Armadura de potencia",
-"ArmorProficiencyShields": "Escudos",
-"ArmorTypes": {
-    "Heavy": "Armadura pesada",
-    "Light": "Armadura ligera",
-    "Power": "Armadura de potencia"
-},
-"Attack": "Ataque",
-"Attributes": "Atributos",
-"AugAllArms": "Todos los brazos",
-"AugAllFeet": "Todos los pies",
-"AugAllHands": "Todas las manos",
-"AugAllLegs": "Todas las piernas",
-"AugAllLegsAndFeet": "Todas las piernas y pies",
-"AugArm": "Brazo",
-"AugArmAndHand": "Brazo y mano",
-"AugBrain": "Cerebro",
-"AugBrainAndEyes": "Cerebro y ojos",
-"AugBrainHeartLungs": "Cerebro, corazón, pulmones",
-"AugBrainThroat": "Cerebro y garganta",
-"AugEars": "Orejas",
-"AugEarsAndThroat": "Orejas y garganta",
-"AugEndocrine": "Sistema endocrino",
-"AugEye": "Ojo",
-"AugEyes": "Ojos",
-"AugFoot": "Pie",
-"AugHand": "Mano",
-"AugHeart": "Corazón",
-"AugLeg": "Pierna",
-"AugLegAndFoot": "Pierna y pie",
-"AugLungs": "Pulmones",
-"AugLungsAndThroat": "Pulmones y garganta",
-"AugSkin": "Piel",
-"AugSkinAndThroat": "Piel y garganta",
-"AugSpinalColumn": "Columna vertebral",
-"AugThroat": "Garganta",
-"BABProgressionFull": "Completo",
-"BABProgressionModerate": "Moderado",
-"BABTooltip": "Bono de {class}: {bonus}",
-"BaseAttackBonusLabel": "BAF",
-"BaseAttackBonusTitle": "Bono de ataque base",
-"Biography": "Biografía",
-"Biotech": "Biotecnología",
+            "Skills": {
+                "HideUntrained": "Ocultar habilidades no entrenadas",
+                "RightClickHint": "Haz clic derecho en una habilidad para más propiedades.",
+                "ShowUntrained": "Mostrar habilidades no entrenadas"
+            },
+            "Traits": {
+                "MagicalItems": "Objetos mágicos equipados"
+            },
+            "UI": {
+                "ErrorNoCharges": "{name} no tiene cargas restantes."
+            }
+        },
+        "AddLabel": "Agregar",
+        "AddProfessionButtonText": "Agregar profesión",
+        "AlignmentCE": "Caótico Malvado",
+        "AlignmentCG": "Caótico Bueno",
+        "AlignmentCN": "Caótico Neutral",
+        "AlignmentLE": "Legal Malvado",
+        "AlignmentLG": "Legal Bueno",
+        "AlignmentLN": "Legal Neutral",
+        "AlignmentNE": "Neutral Malvado",
+        "AlignmentNG": "Neutral Bueno",
+        "AlignmentPlaceHolderText": "Alineamiento",
+        "AlignmentTN": "Neutral Verdadero",
+        "AllowedClasses": {
+            "Myst": "Místico",
+            "Precog": "Precognitivo",
+            "Tech": "Tecnomante",
+            "Wysh": "Hechicero de cambio"
+        },
+        "Any": "Cualquiera",
+        "ArchetypesAlternateClassFeatures": "Características alternativas de clase",
+        "ArmorCheckPenalty": "Penalización por armadura",
+        "ArmorProficiencyHeavy": "Armadura pesada",
+        "ArmorProficiencyLight": "Armadura ligera",
+        "ArmorProficiencyPower": "Armadura de potencia",
+        "ArmorProficiencyShields": "Escudos",
+        "ArmorTypes": {
+            "Heavy": "Armadura pesada",
+            "Light": "Armadura ligera",
+            "Power": "Armadura de potencia"
+        },
+        "Attack": "Ataque",
+        "Attributes": "Atributos",
+        "AugAllArms": "Todos los brazos",
+        "AugAllFeet": "Todos los pies",
+        "AugAllHands": "Todas las manos",
+        "AugAllLegs": "Todas las piernas",
+        "AugAllLegsAndFeet": "Todas las piernas y pies",
+        "AugArm": "Brazo",
+        "AugArmAndHand": "Brazo y mano",
+        "AugBrain": "Cerebro",
+        "AugBrainAndEyes": "Cerebro y ojos",
+        "AugBrainHeartLungs": "Cerebro, corazón, pulmones",
+        "AugBrainThroat": "Cerebro y garganta",
+        "AugEars": "Orejas",
+        "AugEarsAndThroat": "Orejas y garganta",
+        "AugEndocrine": "Sistema endocrino",
+        "AugEye": "Ojo",
+        "AugEyes": "Ojos",
+        "AugFoot": "Pie",
+        "AugHand": "Mano",
+        "AugHeart": "Corazón",
+        "AugLeg": "Pierna",
+        "AugLegAndFoot": "Pierna y pie",
+        "AugLungs": "Pulmones",
+        "AugLungsAndThroat": "Pulmones y garganta",
+        "AugSkin": "Piel",
+        "AugSkinAndThroat": "Piel y garganta",
+        "AugSpinalColumn": "Columna vertebral",
+        "AugThroat": "Garganta",
+        "BABProgressionFull": "Completo",
+        "BABProgressionModerate": "Moderado",
+        "BABTooltip": "Bono de {class}: {bonus}",
+        "BaseAttackBonusLabel": "BAF",
+        "BaseAttackBonusTitle": "Bono de ataque base",
+        "Biography": "Biografía",
+        "Biotech": "Biotecnología",
 
         "Browsers": {
-    "AlienArchiveBrowser": {
-        "BrowserFilterAlignment": "Filtrar por Alineamiento",
-        "BrowserFilterCR": "Filtrar por CR",
-        "BrowserFilterHP": "Filtrar por HP",
-        "BrowserFilterOrganizationSize": "Filtrar por Tamaño de Organización",
-        "BrowserFilterSize": "Filtrar por Tamaño",
-        "BrowserFilterType": "Filtrar por Tipo",
-        "BrowserSortMethodCR": "CR",
-        "BrowserSortMethodHP": "HP",
-        "Button": "Aliens",
-        "Title": "Explorar Archivo Alienígena"
-    },
-    "EquipmentBrowser": {
-        "BrowserSortMethodLevel": "Nivel",
-        "Button": "Equipo",
-        "EquipmentType": "Tipo de Equipo",
-        "ItemType": "Tipo de Ítem",
-        "Title": "Explorar Equipo",
-        "WeaponCategories": "Categorías de Armas",
-        "WeaponType": "Tipo de Arma"
-    },
-    "ItemBrowser": {
-        "BrowserClearFilters": "Limpiar Filtros",
-        "BrowserSearchPlaceholder": "Texto de búsqueda",
-        "BrowserSearchTitle": "Clic derecho para guía",
-        "BrowserSortByLabel": "Ordenar por",
-        "BrowserSortMethodName": "Nombre",
-        "SearchHint": "Puedes escribir el nombre del ítem que buscas.",
-        "Title": "Explorar Ítems"
-    },
-    "SpellBrowser": {
-        "BrowserFilterClass": "Filtrar por Clases",
-        "BrowserFilterLevel": "Filtrar por Nivel",
-        "BrowserFilterSchool": "Filtrar por Escuela",
-        "BrowserSortMethodLevel": "Nivel",
-        "Button": "Hechizos",
-        "Title": "Explorar Hechizos"
-    },
-    "StarshipBrowser": {
-        "BrowserSortMethodBP": "BP",
-        "BrowserSortMethodPCU": "PCU",
-        "Button": "Naves Estelares",
-        "ComponentType": "Tipo de Componente",
-        "Title": "Explorar Naves Estelares",
-        "WeaponClass": "Clase de Arma",
-        "WeaponType": "Tipo de Arma"
-    }
-},
-"CMDBaseTooltip": "Base: 8",
-"CMDKACModTooltip": "KAC: {kac}",
-"CMDModiferTooltip": "Bono {type}: {mod} ({source})",
-"CancelButtonLabel": "Cancelar",
-"Canvas": {
-    "Interface": {
-        "NoTargetTokenForItemDrop": "¡No hay token objetivo, no se puede soltar el ítem!"
-    },
-    "TokenHud": {
-        "RemoveAll": "Eliminar todo"
-    }
-},
-"Capacity": {
-    "UsagePer": {
-        "Action": "Acción",
-        "Day": "Día",
-        "Hour": "Hora",
-        "Hour8": "8 Horas",
-        "Minute": "Minuto",
-        "Minute10": "10 Minutos",
-        "Round": "Turno de combate",
-        "Shot": "Disparo"
-    }
-},
-"CapacityUsage": "Capacidad y Uso",
-"CharacterFlagsSectionClassFeatures": "Características de clase",
-"CharacterFlagsSectionFeats": "Hazañas",
-"CharacterFlagsSectionRacialTraits": "Rasgos de especie",
-"CharacterLevelsTooltip": "Niveles de {class}: {levels}",
-"CharacterNamePlaceHolderText": "Nombre del personaje",
-"CharacterSheet": {
-    "Inventory": {
-        "ContainedWealth": "Riqueza contenida: {wealth}"
-    },
-    "Warnings": {
-        "DeathByMassiveDamage": "¡{name} ha muerto por daño masivo! ☠"
-    }
-},
-"ChatCard": {
-    "ContextMenu": {
-        "Accept": "Aceptar",
-        "ApplyDamage": "Aplicar daño",
-        "ApplyHealing": "Aplicar como curación",
-        "ApplyHealingTo": "Aplicar curación a",
-        "BypassStamina": "Omitir resistencia",
-        "DamageAndAHalf": "Aplicar daño x1.5",
-        "DoubleDamage": "Aplicar daño doble",
-        "HP": "HP (por defecto)",
-        "HPAndSP": "HP y SP",
-        "HalfDamage": "Aplicar medio daño",
-        "ModifyDamage": "Modificar daño",
-        "ModifyDamageText": "Ingresa un número para modificar la cantidad de daño. Se aplica después de cualquier multiplicación.",
-        "NoDamageModifier": "No se aplicó modificador de daño.",
-        "NoToken": "No se puede aplicar: ¡No hay token seleccionado!",
-        "SP": "SP"
-    },
-    "ItemAction": {
-        "Check": "Chequeo",
-        "NoActor": "Debes tener un actor seleccionado o asignado a tu usuario."
-    },
-    "ItemActivation": {
-        "Activates": "Activa",
-        "Cost": "Costo: {cost}",
-        "Deactivates": "Desactiva",
-        "Duration": "Duración: {duration}",
-        "NoCharges": "Sin cargas",
-        "Reloads": "Recarga",
-        "Use": "Usar"
-    },
-    "PlaceAbilityTemplate": "Colocar {label}"
-},
+            "AlienArchiveBrowser": {
+                "BrowserFilterAlignment": "Filtrar por Alineamiento",
+                "BrowserFilterCR": "Filtrar por CR",
+                "BrowserFilterHP": "Filtrar por HP",
+                "BrowserFilterOrganizationSize": "Filtrar por Tamaño de Organización",
+                "BrowserFilterSize": "Filtrar por Tamaño",
+                "BrowserFilterType": "Filtrar por Tipo",
+                "BrowserSortMethodCR": "CR",
+                "BrowserSortMethodHP": "HP",
+                "Button": "Aliens",
+                "Title": "Explorar Archivo Alienígena"
+            },
+            "EquipmentBrowser": {
+                "BrowserSortMethodLevel": "Nivel",
+                "Button": "Equipo",
+                "EquipmentType": "Tipo de Equipo",
+                "ItemType": "Tipo de Ítem",
+                "Title": "Explorar Equipo",
+                "WeaponCategories": "Categorías de Armas",
+                "WeaponType": "Tipo de Arma"
+            },
+            "ItemBrowser": {
+                "BrowserClearFilters": "Limpiar Filtros",
+                "BrowserSearchPlaceholder": "Texto de búsqueda",
+                "BrowserSearchTitle": "Clic derecho para guía",
+                "BrowserSortByLabel": "Ordenar por",
+                "BrowserSortMethodName": "Nombre",
+                "SearchHint": "Puedes escribir el nombre del ítem que buscas.",
+                "Title": "Explorar Ítems"
+            },
+            "SpellBrowser": {
+                "BrowserFilterClass": "Filtrar por Clases",
+                "BrowserFilterLevel": "Filtrar por Nivel",
+                "BrowserFilterSchool": "Filtrar por Escuela",
+                "BrowserSortMethodLevel": "Nivel",
+                "Button": "Hechizos",
+                "Title": "Explorar Hechizos"
+            },
+            "StarshipBrowser": {
+                "BrowserSortMethodBP": "BP",
+                "BrowserSortMethodPCU": "PCU",
+                "Button": "Naves Estelares",
+                "ComponentType": "Tipo de Componente",
+                "Title": "Explorar Naves Estelares",
+                "WeaponClass": "Clase de Arma",
+                "WeaponType": "Tipo de Arma"
+            }
+        },
+        "CMDBaseTooltip": "Base: 8",
+        "CMDKACModTooltip": "KAC: {kac}",
+        "CMDModiferTooltip": "Bono {type}: {mod} ({source})",
+        "CancelButtonLabel": "Cancelar",
+        "Canvas": {
+            "Interface": {
+                "NoTargetTokenForItemDrop": "¡No hay token objetivo, no se puede soltar el ítem!"
+            },
+            "TokenHud": {
+                "RemoveAll": "Eliminar todo"
+            }
+        },
+        "Capacity": {
+            "UsagePer": {
+                "Action": "Acción",
+                "Day": "Día",
+                "Hour": "Hora",
+                "Hour8": "8 Horas",
+                "Minute": "Minuto",
+                "Minute10": "10 Minutos",
+                "Round": "Turno de combate",
+                "Shot": "Disparo"
+            }
+        },
+        "CapacityUsage": "Capacidad y Uso",
+        "CharacterFlagsSectionClassFeatures": "Características de clase",
+        "CharacterFlagsSectionFeats": "Hazañas",
+        "CharacterFlagsSectionRacialTraits": "Rasgos de especie",
+        "CharacterLevelsTooltip": "Niveles de {class}: {levels}",
+        "CharacterNamePlaceHolderText": "Nombre del personaje",
+        "CharacterSheet": {
+            "Inventory": {
+                "ContainedWealth": "Riqueza contenida: {wealth}"
+            },
+            "Warnings": {
+                "DeathByMassiveDamage": "¡{name} ha muerto por daño masivo! ☠"
+            }
+        },
+        "ChatCard": {
+            "ContextMenu": {
+                "Accept": "Aceptar",
+                "ApplyDamage": "Aplicar daño",
+                "ApplyHealing": "Aplicar como curación",
+                "ApplyHealingTo": "Aplicar curación a",
+                "BypassStamina": "Omitir resistencia",
+                "DamageAndAHalf": "Aplicar daño x1.5",
+                "DoubleDamage": "Aplicar daño doble",
+                "HP": "HP (por defecto)",
+                "HPAndSP": "HP y SP",
+                "HalfDamage": "Aplicar medio daño",
+                "ModifyDamage": "Modificar daño",
+                "ModifyDamageText": "Ingresa un número para modificar la cantidad de daño. Se aplica después de cualquier multiplicación.",
+                "NoDamageModifier": "No se aplicó modificador de daño.",
+                "NoToken": "No se puede aplicar: ¡No hay token seleccionado!",
+                "SP": "SP"
+            },
+            "ItemAction": {
+                "Check": "Chequeo",
+                "NoActor": "Debes tener un actor seleccionado o asignado a tu usuario."
+            },
+            "ItemActivation": {
+                "Activates": "Activa",
+                "Cost": "Costo: {cost}",
+                "Deactivates": "Desactiva",
+                "Duration": "Duración: {duration}",
+                "NoCharges": "Sin cargas",
+                "Reloads": "Recarga",
+                "Use": "Usar"
+            },
+            "PlaceAbilityTemplate": "Colocar {label}"
+        },
 
         "Check": "Chequeo",
-"ClassArmorProf": "Competencias en Armadura",
-"ClassBABProgression": "Progresión de BAB",
-"ClassFortSaveProgression": "Progresión de Salvación contra Fortaleza",
-"ClassHPPerLevel": "Puntos de Golpe por Nivel",
-"ClassKeyAbilityScore": "Puntuación de Habilidad Clave",
-"ClassLevelLabel": "Niveles de Clase",
-"ClassReflexSaveProgression": "Progresión de Salvación contra Reflejos",
-"ClassSPPerlevel": "Puntos de Resistencia por Nivel",
-"ClassSkillRanksPerlevel": "Rangos de Habilidad por Nivel",
-"ClassSkills": "Habilidades de Clase",
-"ClassSpellcastingAbility": "Habilidad para Lanzar Hechizos",
-"ClassWeaponProf": "Competencias en Armas",
-"ClassWillSaveProgression": "Progresión de Salvación contra Voluntad",
-"Classes": {
-    "IsCasterClass": "¿Es esta una clase lanzadora de hechizos?"
-},
-"Close": "Cerrar",
-"Combat": {
-    "ChatCards": {
-        "Footer": "{combatType} - fase {combatPhase}",
-        "Phase": {
-            "Header": "Fase {phase}",
-            "MessageTitle": "Descripción"
+        "ClassArmorProf": "Competencias en Armadura",
+        "ClassBABProgression": "Progresión de BAB",
+        "ClassFortSaveProgression": "Progresión de Salvación contra Fortaleza",
+        "ClassHPPerLevel": "Puntos de Golpe por Nivel",
+        "ClassKeyAbilityScore": "Puntuación de Habilidad Clave",
+        "ClassLevelLabel": "Niveles de Clase",
+        "ClassReflexSaveProgression": "Progresión de Salvación contra Reflejos",
+        "ClassSPPerlevel": "Puntos de Resistencia por Nivel",
+        "ClassSkillRanksPerlevel": "Rangos de Habilidad por Nivel",
+        "ClassSkills": "Habilidades de Clase",
+        "ClassSpellcastingAbility": "Habilidad para Lanzar Hechizos",
+        "ClassWeaponProf": "Competencias en Armas",
+        "ClassWillSaveProgression": "Progresión de Salvación contra Voluntad",
+        "Classes": {
+            "IsCasterClass": "¿Es esta una clase lanzadora de hechizos?"
         },
-        "Round": {
-            "BodyHeader": "Nueva Ronda",
-            "Header": "Ronda {round}"
-        },
-        "Speaker": {
-            "GM": "El GM"
-        },
-        "Turn": {
-            "Header": "Turno de {combatant}"
-        }
-    },
-    "Difficulty": {
-        "Levels": {
-            "Average": "Promedio",
-            "Challenging": "Desafiante",
-            "Easy": "Fácil",
-            "Epic": "Épico",
-            "GreaterThanEpic": "Mayor que Épico",
-            "Hard": "Difícil",
-            "LessThanEasy": "Menor que Fácil",
-            "NoEnemies": "Sin enemigos",
-            "NoEnemyShips": "Sin naves enemigas",
-            "NoPCShips": "Sin naves de PC",
-            "NoPCs": "Sin PCs"
-        },
-        "Tooltip": {
-            "APL": "APL",
-            "APLFull": "Nivel promedio del grupo",
-            "CR": "CR",
-            "CanBeAdded": "Se puede agregar una criatura de este CR sin aumentar la dificultad del encuentro",
-            "ClickForDetails": "Haz clic para detalles del encuentro",
-            "Details": "Detalles",
-            "DifficultyEncounter": "Dificultad del encuentro",
-            "EncounterCR": "Nivel de desafío del encuentro",
-            "EncounterTotalXP": "Valor total de XP del encuentro",
-            "EncounterWealth": "Ganancia sugerida de riqueza (equivalente en créditos)",
-            "Enemies": "Enemigos",
-            "EnemyShipEffectiveTier": "Nivel efectivo, nave(s) enemigas",
-            "EnemyXP": "XP total enemigo",
-            "HostileNPCs": "PNJs hostiles",
-            "PCs": "Número de PCs",
-            "PlayerShipEffectiveTier": "Nivel efectivo, nave(s) del jugador",
-            "PlayerXP": "XP por jugador",
-            "Players": "Jugadores",
-            "XPBounds": "Límites de XP del encuentro"
-        },
-        "Units": {
-            "Credits": "cr",
-            "XP": "XP"
-        }
-    },
-    "EncounterTracker": {
-        "SelectNextType": "Cambiar al siguiente tipo de combate",
-        "SelectPrevType": "Cambiar al tipo de combate anterior"
-    },
-    "Errors": {
-        "HistoryLimitedResetInitiative": "La fase actual ha reiniciado la iniciativa, no podemos retroceder más en la historia.<br/><br/>Haz clic para cerrar.",
-        "HistoryLimitedStartOfEncounter": "Has llegado al inicio del encuentro, no podemos retroceder más en la historia.<br/><br/>Haz clic para cerrar.",
-        "MissingInitiative": "La fase actual ha reiniciado la iniciativa. Por favor vuelve a tirar iniciativa para todos los combatientes antes de continuar.<br/><br/>Haz clic para cerrar."
-    },
-    "Normal": {
-        "Name": "Combate normal",
-        "Phases": {
-            "1": {
-                "Description": "Todos pueden ahora realizar su turno de combate.",
-                "Name": "Combate"
+        "Close": "Cerrar",
+        "Combat": {
+            "ChatCards": {
+                "Footer": "{combatType} - fase {combatPhase}",
+                "Phase": {
+                    "Header": "Fase {phase}",
+                    "MessageTitle": "Descripción"
+                },
+                "Round": {
+                    "BodyHeader": "Nueva Ronda",
+                    "Header": "Ronda {round}"
+                },
+                "Speaker": {
+                    "GM": "El GM"
+                },
+                "Turn": {
+                    "Header": "Turno de {combatant}"
+                }
+            },
+            "Difficulty": {
+                "Levels": {
+                    "Average": "Promedio",
+                    "Challenging": "Desafiante",
+                    "Easy": "Fácil",
+                    "Epic": "Épico",
+                    "GreaterThanEpic": "Mayor que Épico",
+                    "Hard": "Difícil",
+                    "LessThanEasy": "Menor que Fácil",
+                    "NoEnemies": "Sin enemigos",
+                    "NoEnemyShips": "Sin naves enemigas",
+                    "NoPCShips": "Sin naves de PC",
+                    "NoPCs": "Sin PCs"
+                },
+                "Tooltip": {
+                    "APL": "APL",
+                    "APLFull": "Nivel promedio del grupo",
+                    "CR": "CR",
+                    "CanBeAdded": "Se puede agregar una criatura de este CR sin aumentar la dificultad del encuentro",
+                    "ClickForDetails": "Haz clic para detalles del encuentro",
+                    "Details": "Detalles",
+                    "DifficultyEncounter": "Dificultad del encuentro",
+                    "EncounterCR": "Nivel de desafío del encuentro",
+                    "EncounterTotalXP": "Valor total de XP del encuentro",
+                    "EncounterWealth": "Ganancia sugerida de riqueza (equivalente en créditos)",
+                    "Enemies": "Enemigos",
+                    "EnemyShipEffectiveTier": "Nivel efectivo, nave(s) enemigas",
+                    "EnemyXP": "XP total enemigo",
+                    "HostileNPCs": "PNJs hostiles",
+                    "PCs": "Número de PCs",
+                    "PlayerShipEffectiveTier": "Nivel efectivo, nave(s) del jugador",
+                    "PlayerXP": "XP por jugador",
+                    "Players": "Jugadores",
+                    "XPBounds": "Límites de XP del encuentro"
+                },
+                "Units": {
+                    "Credits": "cr",
+                    "XP": "XP"
+                }
+            },
+            "EncounterTracker": {
+                "SelectNextType": "Cambiar al siguiente tipo de combate",
+                "SelectPrevType": "Cambiar al tipo de combate anterior"
+            },
+            "Errors": {
+                "HistoryLimitedResetInitiative": "La fase actual ha reiniciado la iniciativa, no podemos retroceder más en la historia.<br/><br/>Haz clic para cerrar.",
+                "HistoryLimitedStartOfEncounter": "Has llegado al inicio del encuentro, no podemos retroceder más en la historia.<br/><br/>Haz clic para cerrar.",
+                "MissingInitiative": "La fase actual ha reiniciado la iniciativa. Por favor vuelve a tirar iniciativa para todos los combatientes antes de continuar.<br/><br/>Haz clic para cerrar."
+            },
+            "Normal": {
+                "Name": "Combate normal",
+                "Phases": {
+                    "1": {
+                        "Description": "Todos pueden ahora realizar su turno de combate.",
+                        "Name": "Combate"
+                    }
+                }
+            },
+            "Starship": {
+                "Name": "Combate de nave estelar",
+                "Phases": {
+                    "1": {
+                        "Description": "Cualquiera que desee cambiar roles en la nave, puede hacerlo ahora.",
+                        "Name": "Cambio de roles"
+                    },
+                    "2": {
+                        "Description": "Capitanes, ingenieros, oficiales mágicos, primeros oficiales y marineros pueden actuar durante esta fase.",
+                        "Name": "Ingeniería"
+                    },
+                    "3": {
+                        "Description": "Los pilotos pueden tirar sus chequeos de pilotaje para determinar la iniciativa de esta ronda.",
+                        "Name": "Chequeo de pilotaje"
+                    },
+                    "4": {
+                        "Description": "Capitanes, pilotos, oficiales científicos, primeros oficiales y marineros pueden actuar durante esta fase.",
+                        "Name": "Timón"
+                    },
+                    "5": {
+                        "Description": "Capitanes y artilleros pueden actuar durante esta fase.",
+                        "Name": "Artillería"
+                    },
+                    "6": {
+                        "Description": "Todos ahora procesan daños recibidos, umbrales críticos, etc.",
+                        "Name": "Daño"
+                    }
+                }
+            },
+            "VehicleChase": {
+                "Name": "Persecución de vehículos",
+                "Phases": {
+                    "1": {
+                        "Description": "Los conductores pueden decidir sus maniobras ahora.",
+                        "Name": "Acciones del piloto"
+                    },
+                    "2": {
+                        "Description": "El GM ahora procesará los resultados del progreso de la persecución.",
+                        "Name": "Progreso de la persecución"
+                    },
+                    "3": {
+                        "Description": "Todos pueden ahora realizar su turno de combate.",
+                        "Name": "Combate"
+                    }
+                }
             }
-        }
-    },
-    "Starship": {
-        "Name": "Combate de nave estelar",
-        "Phases": {
-            "1": {
-                "Description": "Cualquiera que desee cambiar roles en la nave, puede hacerlo ahora.",
-                "Name": "Cambio de roles"
+        },
+        "CombatRoles": {
+            "Combatant": "Combatiente",
+            "Descriptions": {
+                "Combatant": "Estas criaturas están mejor adaptadas al combate físico; pueden ser más efectivas a distancia, cuerpo a cuerpo o ambas.",
+                "Expert": "Estas criaturas tienden a ser más efectivas con varias habilidades.",
+                "Spellcaster": "Estas criaturas dependen principalmente de hechizos o habilidades similares a hechizos."
             },
-            "2": {
-                "Description": "Capitanes, ingenieros, oficiales mágicos, primeros oficiales y marineros pueden actuar durante esta fase.",
-                "Name": "Ingeniería"
-            },
-            "3": {
-                "Description": "Los pilotos pueden tirar sus chequeos de pilotaje para determinar la iniciativa de esta ronda.",
-                "Name": "Chequeo de pilotaje"
-            },
-            "4": {
-                "Description": "Capitanes, pilotos, oficiales científicos, primeros oficiales y marineros pueden actuar durante esta fase.",
-                "Name": "Timón"
-            },
-            "5": {
-                "Description": "Capitanes y artilleros pueden actuar durante esta fase.",
-                "Name": "Artillería"
-            },
-            "6": {
-                "Description": "Todos ahora procesan daños recibidos, umbrales críticos, etc.",
-                "Name": "Daño"
-            }
-        }
-    },
-    "VehicleChase": {
-        "Name": "Persecución de vehículos",
-        "Phases": {
-            "1": {
-                "Description": "Los conductores pueden decidir sus maniobras ahora.",
-                "Name": "Acciones del piloto"
-            },
-            "2": {
-                "Description": "El GM ahora procesará los resultados del progreso de la persecución.",
-                "Name": "Progreso de la persecución"
-            },
-            "3": {
-                "Description": "Todos pueden ahora realizar su turno de combate.",
-                "Name": "Combate"
-            }
-        }
-    }
-},
-"CombatRoles": {
-    "Combatant": "Combatiente",
-    "Descriptions": {
-        "Combatant": "Estas criaturas están mejor adaptadas al combate físico; pueden ser más efectivas a distancia, cuerpo a cuerpo o ambas.",
-        "Expert": "Estas criaturas tienden a ser más efectivas con varias habilidades.",
-        "Spellcaster": "Estas criaturas dependen principalmente de hechizos o habilidades similares a hechizos."
-    },
-    "Expert": "Experto",
-    "Label": "Rol en combate",
-    "Spellcaster": "Lanzador de hechizos"
-},
+            "Expert": "Experto",
+            "Label": "Rol en combate",
+            "Spellcaster": "Lanzador de hechizos"
+        },
 
         "ComingSoon": "¡Próximamente!",
-"ConImm": "Inmunidades a condiciones",
-"ConditionTooltips": {
-    "Asleep": "Tienes una penalización de -10 a las tiradas de Percepción para notar cosas.",
-    "Bleeding": "Recibes el daño listado al comienzo de tu turno.",
-    "Blinded": "Estás desprevenido, sufres una penalización de -4 a la mayoría de las pruebas de habilidades basadas en Fuerza y Destreza y a las pruebas de Percepción opuestas, fallas automáticamente las pruebas de Percepción basadas en la vista, los oponentes tienen ocultación total contra ti, y debes tener éxito en una prueba de Acrobatics DC 10 para moverte más rápido que la mitad de tu velocidad o de lo contrario caerás prone.",
-    "Broken": "<strong>Arma:</strong> las tiradas de ataque y daño sufren una penalización de -2 y no pueden causar efectos adicionales en un golpe crítico;<br> <strong>Armadura:</strong> los bonificadores a CA se reducen a la mitad y la penalización por chequeo de armadura se duplica;<br> <strong>Vehículo:</strong> penalización de -2 a CA, DC de colisión y modificador de Pilotaje, y reduce a la mitad su velocidad máxima y MPH;<br> <strong>Herramienta o tecnología que proporciona bonificadores:</strong> los bonificadores se reducen a la mitad.",
-    "Burning": "Recibes el daño por fuego listado cada ronda, y debes ser apagado para terminar la condición.",
-    "Confused": "Tratas a todas las criaturas como enemigos y debes tirar en la tabla para determinar tus acciones.",
-    "Cowering": "Estás desprevenido y no puedes realizar acciones.",
-    "Dazed": "No puedes realizar acciones.",
-    "Dazzled": "Recibes una penalización de -1 a las tiradas de ataque y pruebas de Percepción basadas en la vista.",
-    "Dead": "Tu alma abandona tu cuerpo, no puedes actuar de ninguna manera, y no puedes beneficiarte de curaciones normales o mágicas.",
-    "Deafened": "Recibes una penalización de -4 a las tiradas de iniciativa y pruebas de Percepción opuestas, y fallas automáticamente las pruebas de Percepción basadas en sonido.",
-    "Dying": "Estás inconsciente, no puedes realizar acciones, y debes estabilizarte o perder Puntos de Resolución y potencialmente morir.",
-    "Encumbered": "Las velocidades se reducen en 10 pies, el bono máximo de Destreza a la CA se reduce a +2, y sufres una penalización de -5 a las pruebas basadas en Fuerza y Destreza.",
-    "Entangled": "Te mueves a media velocidad; no puedes correr ni cargar; y sufres una penalización de -2 a la CA, tiradas de ataque, salvaciones de Reflejos, tiradas de iniciativa y pruebas basadas en Destreza y habilidades.",
-    "Exhausted": "Te mueves a media velocidad; no puedes correr ni cargar; sufres una penalización de -3 a la CA, tiradas de ataque, tiradas de daño cuerpo a cuerpo, salvaciones de Reflejos, tiradas de iniciativa y pruebas basadas en Fuerza, Destreza y habilidades; y reduces tu límite de carga en 3 bulk.",
-    "Fascinated": "Debes prestar atención al efecto fascinante y sufres una penalización de -4 a las pruebas de habilidad realizadas como reacciones.",
-    "Fatigued": "No puedes correr ni cargar; sufres una penalización de -1 a la CA, tiradas de ataque, tiradas de daño cuerpo a cuerpo, salvaciones de Reflejos, tiradas de iniciativa y pruebas basadas en Fuerza, Destreza y habilidades; y reduces tu límite de carga en 1 bulk.",
-    "FlatFooted": "Sufres una penalización de -2 a la CA, y no puedes realizar reacciones ni ataques de oportunidad.",
-    "Frightened": "Debes huir o luchar, y sufres una penalización de -2 a pruebas de habilidad, tiradas de ataque, salvaciones y pruebas de habilidad.",
-    "Grappled": "No puedes moverte ni realizar acciones con ambas manos; sufres una penalización de -2 a la CA, la mayoría de las tiradas de ataque, salvaciones de Reflejos, tiradas de iniciativa y pruebas basadas en Destreza y habilidades; y no puedes hacer ataques de oportunidad.",
-    "Helpless": "Tu modificador de Destreza es -5, y los ataques cuerpo a cuerpo contra ti ganan un bono de +4.",
-    "Nauseated": "No puedes atacar, lanzar conjuros ni concentrarte en ellos, y la única acción que puedes realizar es una acción de movimiento por turno.",
-    "OffKilter": "No puedes realizar acciones de movimiento excepto para enderezarte, sufres una penalización de -2 a ataques, y estás desprevenido.",
-    "OffTarget": "Sufres una penalización de -2 a las tiradas de ataque.",
-    "Overburdened": "Las velocidades se reducen a 5 pies; el bono máximo de Destreza a la CA se reduce a +0; y sufres una penalización de -5 a las pruebas basadas en Fuerza y Destreza.",
-    "Panicked": "<ul><li>Dejas caer todos los objetos que sostienes</li><li>Huyes a máxima velocidad</li><li>No puedes realizar otras acciones</li><li>Sufres una penalización de -2 a pruebas de habilidad, salvaciones y pruebas de habilidad</li><li>Y te acobardas si estás acorralado</li></ul>",
-    "Paralyzed": "Tu modificador de Destreza es -5, y no puedes moverte pero puedes realizar acciones mentales.",
-    "Pinned": "No puedes moverte, estás desprevenido, y sufres penalizaciones a los mismos atributos que en estado agarrado pero la penalización es -4.",
-    "Prone": "Sufres una penalización de -4 a ataques cuerpo a cuerpo, un bono de +4 a la CA contra ataques a distancia, y una penalización de -4 a la CA contra ataques cuerpo a cuerpo.",
-    "Shaken": "Sufres una penalización de -2 a pruebas de habilidad, tiradas de ataque, salvaciones y pruebas de habilidad.",
-    "Sickened": "Sufres una penalización de -2 a pruebas de habilidad, tiradas de ataque, tiradas de daño con armas, salvaciones y pruebas de habilidad.",
-    "Stable": "Ya no estás muriendo, pero sigues inconsciente.",
-    "Staggered": "Solo puedes realizar una acción de movimiento o estándar por ronda y no puedes hacer reacciones, pero puedes realizar acciones rápidas con normalidad.",
-    "Stunned": "Dejas caer todo lo que sostienes, no puedes realizar acciones y estás desprevenido.",
-    "Unconscious": "Estás inconsciente e indefenso."
-},
-"ConditionsAsleep": "Dormido",
-"ConditionsBleeding": "Sangrando",
-"ConditionsBlinded": "Cegado",
-"ConditionsBroken": "Roto (solo objeto)",
-"ConditionsBurning": "Ardiendo",
-"ConditionsConfused": "Confundido",
-"ConditionsCowering": "Acobardado",
-"ConditionsDazed": "Aturdido",
-"ConditionsDazzled": "Deslumbrado",
-"ConditionsDead": "Muerto",
-"ConditionsDeafened": "Sordo",
-"ConditionsDying": "Muriendo",
-"ConditionsEncumbered": "Cargado",
-"ConditionsEntangled": "Enredado",
-"ConditionsExhausted": "Agotado",
-"ConditionsFascinated": "Fascinado",
-"ConditionsFatigued": "Fatigado",
-"ConditionsFlatFooted": "Desprevenido",
-"ConditionsFrightened": "Asustado",
-"ConditionsGrappled": "Agarrado",
-"ConditionsHelpless": "Indefenso",
-"ConditionsInvisible": "Invisible",
-"ConditionsNauseated": "Náuseas",
-"ConditionsOffKilter": "Fuera de eje",
-"ConditionsOffTarget": "Fuera de objetivo",
-"ConditionsOverburdened": "Sobrecargado",
-"ConditionsPanicked": "Pánico",
-"ConditionsParalyzed": "Paralizado",
-"ConditionsPinned": "Inmovilizado",
-"ConditionsProne": "Tumbado",
-"ConditionsShaken": "Conmocionado",
-"ConditionsSickened": "Enfermo",
-"ConditionsStable": "Estable",
-"ConditionsStaggered": "Tambaleante",
-"ConditionsStunned": "Aturdido",
-"ConditionsUnconscious": "Inconsciente",
-"ConsumableTypes": {
-    "Ampoule": "Ampollas de conjuro",
-    "Drugs": "Drogas",
-    "FoodDrink": "Comida y bebida",
-    "Medicine": "Medicinas",
-    "Other": "Otros",
-    "Poison": "Venenos",
-    "Serum": "Suero",
-    "SpellGem": "Gemas de conjuro"
-},
-"CounterClassesAddButton": "Agregar 1",
-"CounterClassesCurrentCount": "Puntos totales:",
-"CounterClassesCurrentPositionLabel": "Posición actual:",
-"CounterClassesKiSoldier": "Puntos de Soldado Ki",
-"CounterClassesManagementTitle": "Gestionar tu",
-"CounterClassesManagementWindowsTitles": "Ventanas de gestión de contadores de clases",
-"CounterClassesRemoveButton": "Quitar 1",
-"CounterClassesSolarian": "Sintonización Solariana",
-"CounterClassesSolarianGraviton": "Gravitón",
-"CounterClassesSolarianPhoton": "Fotón",
-"CounterClassesSolarianUnaligned": "No alineado",
-"CounterClassesVanguard": "Puntos entrópicos de Vanguardia",
-"Credits": "Créditos",
-"Currencies": {
-    "BPs": "BPs",
-    "Credits": "Créditos",
-    "UPBs": "UPBs"
-},
-"Cybernetic": "Cibernético",
-"Damage": {
-    "DamageOperator": "Operador de daño",
-    "EnergyDamage": "Daño de energía",
-    "Immunities": "Inmunidades al daño",
-    "KineticDamage": "Daño cinético",
-    "MinimumDamage": "Daño mínimo",
-    "PartIndex": "Parte {partIndex} de {partCount}",
-    "Reduction": "Reducción de daño",
-    "Resistances": "Resistencias a energía",
-    "Title": "Daño",
-    "Types": {
-        "Acid": "Ácido",
-        "Bludgeoning": "Contundente",
-        "Cold": "Frío",
-        "Custom": "Personalizado",
-        "DamageGroup": "Grupo de daño {group}",
-        "DamageGroupTooltip": "Si las secciones de daño comparten un grupo, solo puedes habilitar una de ese grupo al hacer una tirada de daño. Puedes habilitar o deshabilitar libremente secciones de daño que no tienen grupo. Los grupos de daño deben ser numéricos.",
-        "Electricity": "Electricidad",
-        "Fire": "Fuego",
-        "Force": "Fuerza",
-        "GrouplessDamage": "Daño sin grupo",
-        "Hint": "Esta es una lista de las diferentes secciones de daño disponibles para esta tirada de daño.",
-        "Nonlethal": "No letal",
-        "Operators": {
-            "And": "y",
-            "Or": "o"
+        "ConImm": "Inmunidades a condiciones",
+        "ConditionTooltips": {
+            "Asleep": "Tienes una penalización de -10 a las tiradas de Percepción para notar cosas.",
+            "Bleeding": "Recibes el daño listado al comienzo de tu turno.",
+            "Blinded": "Estás desprevenido, sufres una penalización de -4 a la mayoría de las pruebas de habilidades basadas en Fuerza y Destreza y a las pruebas de Percepción opuestas, fallas automáticamente las pruebas de Percepción basadas en la vista, los oponentes tienen ocultación total contra ti, y debes tener éxito en una prueba de Acrobatics DC 10 para moverte más rápido que la mitad de tu velocidad o de lo contrario caerás prone.",
+            "Broken": "<strong>Arma:</strong> las tiradas de ataque y daño sufren una penalización de -2 y no pueden causar efectos adicionales en un golpe crítico;<br> <strong>Armadura:</strong> los bonificadores a CA se reducen a la mitad y la penalización por chequeo de armadura se duplica;<br> <strong>Vehículo:</strong> penalización de -2 a CA, DC de colisión y modificador de Pilotaje, y reduce a la mitad su velocidad máxima y MPH;<br> <strong>Herramienta o tecnología que proporciona bonificadores:</strong> los bonificadores se reducen a la mitad.",
+            "Burning": "Recibes el daño por fuego listado cada ronda, y debes ser apagado para terminar la condición.",
+            "Confused": "Tratas a todas las criaturas como enemigos y debes tirar en la tabla para determinar tus acciones.",
+            "Cowering": "Estás desprevenido y no puedes realizar acciones.",
+            "Dazed": "No puedes realizar acciones.",
+            "Dazzled": "Recibes una penalización de -1 a las tiradas de ataque y pruebas de Percepción basadas en la vista.",
+            "Dead": "Tu alma abandona tu cuerpo, no puedes actuar de ninguna manera, y no puedes beneficiarte de curaciones normales o mágicas.",
+            "Deafened": "Recibes una penalización de -4 a las tiradas de iniciativa y pruebas de Percepción opuestas, y fallas automáticamente las pruebas de Percepción basadas en sonido.",
+            "Dying": "Estás inconsciente, no puedes realizar acciones, y debes estabilizarte o perder Puntos de Resolución y potencialmente morir.",
+            "Encumbered": "Las velocidades se reducen en 10 pies, el bono máximo de Destreza a la CA se reduce a +2, y sufres una penalización de -5 a las pruebas basadas en Fuerza y Destreza.",
+            "Entangled": "Te mueves a media velocidad; no puedes correr ni cargar; y sufres una penalización de -2 a la CA, tiradas de ataque, salvaciones de Reflejos, tiradas de iniciativa y pruebas basadas en Destreza y habilidades.",
+            "Exhausted": "Te mueves a media velocidad; no puedes correr ni cargar; sufres una penalización de -3 a la CA, tiradas de ataque, tiradas de daño cuerpo a cuerpo, salvaciones de Reflejos, tiradas de iniciativa y pruebas basadas en Fuerza, Destreza y habilidades; y reduces tu límite de carga en 3 bulk.",
+            "Fascinated": "Debes prestar atención al efecto fascinante y sufres una penalización de -4 a las pruebas de habilidad realizadas como reacciones.",
+            "Fatigued": "No puedes correr ni cargar; sufres una penalización de -1 a la CA, tiradas de ataque, tiradas de daño cuerpo a cuerpo, salvaciones de Reflejos, tiradas de iniciativa y pruebas basadas en Fuerza, Destreza y habilidades; y reduces tu límite de carga en 1 bulk.",
+            "FlatFooted": "Sufres una penalización de -2 a la CA, y no puedes realizar reacciones ni ataques de oportunidad.",
+            "Frightened": "Debes huir o luchar, y sufres una penalización de -2 a pruebas de habilidad, tiradas de ataque, salvaciones y pruebas de habilidad.",
+            "Grappled": "No puedes moverte ni realizar acciones con ambas manos; sufres una penalización de -2 a la CA, la mayoría de las tiradas de ataque, salvaciones de Reflejos, tiradas de iniciativa y pruebas basadas en Destreza y habilidades; y no puedes hacer ataques de oportunidad.",
+            "Helpless": "Tu modificador de Destreza es -5, y los ataques cuerpo a cuerpo contra ti ganan un bono de +4.",
+            "Nauseated": "No puedes atacar, lanzar conjuros ni concentrarte en ellos, y la única acción que puedes realizar es una acción de movimiento por turno.",
+            "OffKilter": "No puedes realizar acciones de movimiento excepto para enderezarte, sufres una penalización de -2 a ataques, y estás desprevenido.",
+            "OffTarget": "Sufres una penalización de -2 a las tiradas de ataque.",
+            "Overburdened": "Las velocidades se reducen a 5 pies; el bono máximo de Destreza a la CA se reduce a +0; y sufres una penalización de -5 a las pruebas basadas en Fuerza y Destreza.",
+            "Panicked": "<ul><li>Dejas caer todos los objetos que sostienes</li><li>Huyes a máxima velocidad</li><li>No puedes realizar otras acciones</li><li>Sufres una penalización de -2 a pruebas de habilidad, salvaciones y pruebas de habilidad</li><li>Y te acobardas si estás acorralado</li></ul>",
+            "Paralyzed": "Tu modificador de Destreza es -5, y no puedes moverte pero puedes realizar acciones mentales.",
+            "Pinned": "No puedes moverte, estás desprevenido, y sufres penalizaciones a los mismos atributos que en estado agarrado pero la penalización es -4.",
+            "Prone": "Sufres una penalización de -4 a ataques cuerpo a cuerpo, un bono de +4 a la CA contra ataques a distancia, y una penalización de -4 a la CA contra ataques cuerpo a cuerpo.",
+            "Shaken": "Sufres una penalización de -2 a pruebas de habilidad, tiradas de ataque, salvaciones y pruebas de habilidad.",
+            "Sickened": "Sufres una penalización de -2 a pruebas de habilidad, tiradas de ataque, tiradas de daño con armas, salvaciones y pruebas de habilidad.",
+            "Stable": "Ya no estás muriendo, pero sigues inconsciente.",
+            "Staggered": "Solo puedes realizar una acción de movimiento o estándar por ronda y no puedes hacer reacciones, pero puedes realizar acciones rápidas con normalidad.",
+            "Stunned": "Dejas caer todo lo que sostienes, no puedes realizar acciones y estás desprevenido.",
+            "Unconscious": "Estás inconsciente e indefenso."
         },
-        "Piercing": "Perforante",
-        "PrimaryDamageGroup": "Grupo principal de daño",
-        "PrimaryDamageGroupTooltip": "Las secciones de daño que son miembros del grupo principal de daño estarán todas marcadas como principales. Aún solo podrás elegir una sección de daño por grupo al hacer una tirada de daño, y por lo tanto los modificadores se aplicarán correctamente solo una vez.",
-        "PrimaryDamageSection": "Sección principal de daño",
-        "PrimaryDamageSectionTooltip": "Los modificadores que afectan al daño de este objeto solo se aplicarán a la sección principal de daño. Las secciones no principales simplemente tirarán su fórmula. Un objeto debe tener exactamente una sección o grupo principal de daño (ver arriba).",
-        "Radiation": "Radiación",
-        "Slashing": "Cortante",
-        "Sonic": "Sónico",
-        "Title": "Secciones de daño"
-    },
-    "Vulnerabilities": "Vulnerabilidades al daño"
-},
+        "ConditionsAsleep": "Dormido",
+        "ConditionsBleeding": "Sangrando",
+        "ConditionsBlinded": "Cegado",
+        "ConditionsBroken": "Roto (solo objeto)",
+        "ConditionsBurning": "Ardiendo",
+        "ConditionsConfused": "Confundido",
+        "ConditionsCowering": "Acobardado",
+        "ConditionsDazed": "Aturdido",
+        "ConditionsDazzled": "Deslumbrado",
+        "ConditionsDead": "Muerto",
+        "ConditionsDeafened": "Sordo",
+        "ConditionsDying": "Muriendo",
+        "ConditionsEncumbered": "Cargado",
+        "ConditionsEntangled": "Enredado",
+        "ConditionsExhausted": "Agotado",
+        "ConditionsFascinated": "Fascinado",
+        "ConditionsFatigued": "Fatigado",
+        "ConditionsFlatFooted": "Desprevenido",
+        "ConditionsFrightened": "Asustado",
+        "ConditionsGrappled": "Agarrado",
+        "ConditionsHelpless": "Indefenso",
+        "ConditionsInvisible": "Invisible",
+        "ConditionsNauseated": "Náuseas",
+        "ConditionsOffKilter": "Fuera de eje",
+        "ConditionsOffTarget": "Fuera de objetivo",
+        "ConditionsOverburdened": "Sobrecargado",
+        "ConditionsPanicked": "Pánico",
+        "ConditionsParalyzed": "Paralizado",
+        "ConditionsPinned": "Inmovilizado",
+        "ConditionsProne": "Tumbado",
+        "ConditionsShaken": "Conmocionado",
+        "ConditionsSickened": "Enfermo",
+        "ConditionsStable": "Estable",
+        "ConditionsStaggered": "Tambaleante",
+        "ConditionsStunned": "Aturdido",
+        "ConditionsUnconscious": "Inconsciente",
+        "ConsumableTypes": {
+            "Ampoule": "Ampollas de conjuro",
+            "Drugs": "Drogas",
+            "FoodDrink": "Comida y bebida",
+            "Medicine": "Medicinas",
+            "Other": "Otros",
+            "Poison": "Venenos",
+            "Serum": "Suero",
+            "SpellGem": "Gemas de conjuro"
+        },
+        "CounterClassesAddButton": "Agregar 1",
+        "CounterClassesCurrentCount": "Puntos totales:",
+        "CounterClassesCurrentPositionLabel": "Posición actual:",
+        "CounterClassesKiSoldier": "Puntos de Soldado Ki",
+        "CounterClassesManagementTitle": "Gestionar tu",
+        "CounterClassesManagementWindowsTitles": "Ventanas de gestión de contadores de clases",
+        "CounterClassesRemoveButton": "Quitar 1",
+        "CounterClassesSolarian": "Sintonización Solariana",
+        "CounterClassesSolarianGraviton": "Gravitón",
+        "CounterClassesSolarianPhoton": "Fotón",
+        "CounterClassesSolarianUnaligned": "No alineado",
+        "CounterClassesVanguard": "Puntos entrópicos de Vanguardia",
+        "Credits": "Créditos",
+        "Currencies": {
+            "BPs": "BPs",
+            "Credits": "Créditos",
+            "UPBs": "UPBs"
+        },
+        "Cybernetic": "Cibernético",
+        "Damage": {
+            "DamageOperator": "Operador de daño",
+            "EnergyDamage": "Daño de energía",
+            "Immunities": "Inmunidades al daño",
+            "KineticDamage": "Daño cinético",
+            "MinimumDamage": "Daño mínimo",
+            "PartIndex": "Parte {partIndex} de {partCount}",
+            "Reduction": "Reducción de daño",
+            "Resistances": "Resistencias a energía",
+            "Title": "Daño",
+            "Types": {
+                "Acid": "Ácido",
+                "Bludgeoning": "Contundente",
+                "Cold": "Frío",
+                "Custom": "Personalizado",
+                "DamageGroup": "Grupo de daño {group}",
+                "DamageGroupTooltip": "Si las secciones de daño comparten un grupo, solo puedes habilitar una de ese grupo al hacer una tirada de daño. Puedes habilitar o deshabilitar libremente secciones de daño que no tienen grupo. Los grupos de daño deben ser numéricos.",
+                "Electricity": "Electricidad",
+                "Fire": "Fuego",
+                "Force": "Fuerza",
+                "GrouplessDamage": "Daño sin grupo",
+                "Hint": "Esta es una lista de las diferentes secciones de daño disponibles para esta tirada de daño.",
+                "Nonlethal": "No letal",
+                "Operators": {
+                    "And": "y",
+                    "Or": "o"
+                },
+                "Piercing": "Perforante",
+                "PrimaryDamageGroup": "Grupo principal de daño",
+                "PrimaryDamageGroupTooltip": "Las secciones de daño que son miembros del grupo principal de daño estarán todas marcadas como principales. Aún solo podrás elegir una sección de daño por grupo al hacer una tirada de daño, y por lo tanto los modificadores se aplicarán correctamente solo una vez.",
+                "PrimaryDamageSection": "Sección principal de daño",
+                "PrimaryDamageSectionTooltip": "Los modificadores que afectan al daño de este objeto solo se aplicarán a la sección principal de daño. Las secciones no principales simplemente tirarán su fórmula. Un objeto debe tener exactamente una sección o grupo principal de daño (ver arriba).",
+                "Radiation": "Radiación",
+                "Slashing": "Cortante",
+                "Sonic": "Sónico",
+                "Title": "Secciones de daño"
+            },
+            "Vulnerabilities": "Vulnerabilidades al daño"
+        },
 
         "Description": "Descripción",
-"DescriptionShort": "Descripción corta",
-"Descriptors": {
-    "Acid": "Ácido",
-    "Air": "Aire",
-    "Auditory": "Auditivo",
-    "Calling": "Llamado",
-    "CallingDescription": "Un efecto de llamado transporta a una criatura desde otro plano al plano en el que te encuentras. El efecto otorga a la criatura la habilidad única de regresar a su plano de origen, aunque el efecto podría limitar las circunstancias bajo las cuales esto es posible. Las criaturas que son llamadas mueren si son asesinadas en el nuevo plano. Una criatura llamada no puede ser disipado, incluso si fue llamada por medios mágicos.",
-    "Chaotic": "Caótico",
-    "Charm": "Encanto",
-    "CharmDescription": "Un efecto de encanto cambia cómo el sujeto te ve. Esto te da la habilidad de hacerte amigo y sugerir cursos de acción a otra criatura, pero su servidumbre no es absoluta ni sin sentido. Esencialmente, un personaje encantado retiene libre albedrío pero toma decisiones según una visión distorsionada del mundo.<br><br>Una criatura encantada mantiene su alineamiento y lealtades originales, generalmente con la excepción de que ahora considera a la persona que la encantó como un amigo querido y da gran importancia a las sugerencias y órdenes de ese personaje. Una criatura encantada no ofrece información ni tácticas que su amo no solicite. Una criatura encantada nunca obedece una orden que sea obviamente suicida o gravemente perjudicial para ella.<br><br>Una criatura pelea contra amigos que tenía antes de ser encantada solo si amenazan a su nuevo amigo. Aun así, utiliza los medios menos letales a su disposición, pues desea resolver el conflicto sin causar daño real.<br><br>Una criatura encantada puede intentar una prueba opuesta de Carisma contra su amo para resistir instrucciones u órdenes que la obligarían a hacer algo que normalmente no haría ni siquiera por un amigo cercano. Si tiene éxito en esta prueba, decide no seguir esa orden particular pero permanece encantada. Si el amo de la criatura le ordena realizar una acción a la que la criatura se opondría vehementemente, puede intentar una nueva tirada de salvación para liberarse por completo de la influencia de su amo.<br><br>Si una criatura encantada es atacada abiertamente por el personaje que la encantó o por los aliados aparentes de ese personaje, queda automáticamente libre del hechizo o efecto.",
-    "Cold": "Frío",
-    "Compulsion": "Compulsión",
-    "CompulsionDescription": "Un efecto de compulsión anula el libre albedrío del sujeto de alguna manera, forzando al sujeto a actuar de cierta forma o cambiando el modo en que funciona su mente.",
-    "Creation": "Creación",
-    "CreationDescription": "Un efecto de creación manipula la materia para crear un objeto o criatura en el lugar que el creador designe. Si el efecto tiene una duración distinta de instantánea, la magia u otra energía mantiene la creación unida, pero cuando la duración termina, la criatura u objeto creado desaparece sin dejar rastro. Si el efecto tiene duración instantánea, el objeto o criatura creada no depende de energía externa para su existencia, por lo que dura indefinidamente una vez creado.",
-    "Curse": "Maldición",
-    "Darkness": "Oscuridad",
-    "Death": "Muerte",
-    "Descriptors": "Descriptores",
-    "Disease": "Enfermedad",
-    "Earth": "Tierra",
-    "Electricity": "Electricidad",
-    "Emotion": "Emoción",
-    "Evil": "Mal",
-    "Fear": "Miedo",
-    "Fire": "Fuego",
-    "Force": "Fuerza",
-    "ForceDescription": "Un efecto de fuerza inflige daño completo a criaturas incorpóreas y bloquea su movimiento. También bloquea el sentido mediante la habilidad.",
-    "Good": "Bien",
-    "Healing": "Curación",
-    "Illusion": "Ilusión",
-    "LanguageDependent": "Dependiente del lenguaje",
-    "LanguageDependentDescription": "Un efecto dependiente del lenguaje usa un idioma inteligible (ya sea audible, visual o telepático) como medio de comunicación. Si no puedes comunicarte con el objetivo o el objetivo no puede entender lo que comunicas, el efecto no afecta a ese objetivo.",
-    "Lawful": "Legal",
-    "Light": "Luz",
-    "MindAffecting": "Afecta la mente",
-    "MindAffectingDescription": "Un efecto que afecta la mente solo funciona contra criaturas con una puntuación de Inteligencia de 1 o más.",
-    "Pain": "Dolor",
-    "PainDescription": "Un efecto de dolor causa sensaciones desagradables pero no daño físico permanente. Las criaturas inmunes a efectos que requieren una tirada de salvación de Fortaleza son inmunes a efectos de dolor.",
-    "Poison": "Veneno",
-    "Polymorph": "Polimorfismo",
-    "Radiation": "Radiación",
-    "Scrying": "Adivinación",
-    "ScryingDescription": "Un efecto de adivinación crea un sensor mágico invisible que te envía información mientras dura el efecto. A menos que se indique lo contrario, el sensor tiene las mismas habilidades sensoriales que tú tienes naturalmente, pero no las habilidades sensoriales que obtienes de otros hechizos o tecnología. El sensor es una fuente independiente de entrada sensorial para ti, por lo que funciona normalmente incluso si has quedado ciego, sordo o sufres alguna discapacidad sensorial.<br><br>Una criatura puede notar un sensor de adivinación con una prueba exitosa de Percepción (DC = 20 + nivel del hechizo o efecto). El sensor puede ser disipado como si fuera un hechizo activo. Láminas de plomo, campos de fuerza y algunos materiales exóticos y protecciones mágicas bloquean efectos de adivinación; si es el caso, puedes percibir que el efecto ha sido bloqueado.",
-    "SenseDependent": "Dependiente del sentido",
-    "SenseDependentDescription": "Un efecto dependiente del sentido tiene elementos audibles o visuales, requiriendo vista o audición para tener efecto. Para que este tipo de efecto afecte a un objetivo, debes poder verlo o escucharlo, y el objetivo debe poder verte o escucharte.",
-    "Shadow": "Sombra",
-    "ShadowDescription": "Un efecto de sombra crea algo parcialmente real a partir de una amalgama de energía extradimensional. El daño causado por un efecto de sombra es real.",
-    "Sonic": "Sónico",
-    "Summoning": "Invocación",
-    "SummoningDescription": "Un efecto de invocación trae instantáneamente a una criatura u objeto a un lugar que designes. Cuando el efecto termina o es disipado, una criatura invocada es enviada instantáneamente de regreso a su lugar de origen (típicamente otro plano, pero no siempre), pero un objeto invocado no es devuelto a menos que la descripción del efecto indique lo contrario. Una criatura invocada también desaparece si es asesinada o si sus Puntos de Golpe llegan a 0, pero en realidad no está muerta. Tarda 24 horas en reformarse en el lugar desde donde fue invocada, durante las cuales no puede ser invocada nuevamente.<br><br>Cuando un efecto de invocación termina y la criatura invocada desaparece, todos los hechizos que haya lanzado expiran. Una criatura invocada no puede usar habilidades innatas de invocación que pueda tener.",
-    "Teleportation": "Teletransportación",
-    "TeleportationDescription": "Un efecto de teletransportación implica un viaje instantáneo a través del Plano Astral (ver página 471). Todo lo que bloquea el viaje astral también bloquea la teletransportación a menos que el efecto específico indique lo contrario, y los efectos de teletransportación funcionan dentro del Deriva.",
-    "Water": "Agua"
-},
-"Details": "Detalles",
-"Dialogs": {
-    "InputDialog": {
-        "MultipleFieldsInvalid": "Entrada inválida para los siguientes campos:<br/>{fieldNames}",
-        "SingleFieldInvalid": "Entrada inválida para {fieldName}."
-    }
-},
-"Disabled": "Deshabilitado",
-"DistAny": "Cualquiera",
-"DroneSheet": {
-    "Chassis": {
-        "Details": {
-            "AbilityScores": {
-                "Charisma": "Carisma base",
-                "Dexterity": "Destreza base",
-                "Header": "Puntuaciones de habilidad",
-                "Increases": "Incrementos de puntuación de habilidad",
-                "Intelligence": "Inteligencia base",
-                "Strength": "Fuerza base",
-                "Wisdom": "Sabiduría base"
-            },
-            "BaseStatistics": {
-                "Header": "Estadísticas base",
-                "MechanicLevel": "Nivel de mecánico",
-                "Size": "Tamaño",
-                "SpeedBase": "Velocidad, base (numérico, en pies)",
-                "SpeedSpecial": "Velocidad, especial"
-            },
-            "Defense": {
-                "EAC": "EAC base",
-                "Header": "Defensa",
-                "KAC": "KAC base"
-            },
-            "Saves": {
-                "Fortitude": "Progresión de salvación de Fortaleza",
-                "Header": "Salvaciones",
-                "Reflex": "Progresión de salvación de Reflejos",
-                "Will": "Progresión de salvación de Voluntad"
-            }
-        },
-        "Missing": "Chasis faltante",
-        "Name": {
-            "Placeholder": "Nombre del chasis"
-        },
-        "NotInstalled": "No hay chasis instalado.",
-        "Source": "Fuente",
-        "SourceTooltip": "¿De dónde proviene este chasis? ¿Qué libro? ¿Qué página?"
-    },
-    "Details": {
-        "Speed": {
-            "SpecialPlaceholder": "Sin movimiento especial"
-        }
-    },
-    "Features": {
-        "Chassis": "Chasis",
-        "Feats": {
-            "Active": "Hazañas activas",
-            "Header": "Hazañas (Cantidad: {current} de {max})",
-            "Passive": "Hazañas pasivas"
-        },
-        "Mods": "Modificaciones (Cantidad: {current} de {max})",
-        "ModsFree": "Gratis"
-    },
-    "Header": {
-        "Actions": {
-            "Header": "Acciones",
-            "Repair": "Reparar"
-        },
-        "Defense": "Defensa",
-        "Owner": "Propietario"
-    },
-    "Inventory": {
-        "ArmorUpgrades": "Mejoras de armadura (Equipadas {current} de {max} ranuras de armadura)",
-        "CarriedItems": "Objetos transportados",
-        "Weapons": {
-            "Both": "Armas (Montajes de armas equipados: Cuerpo a cuerpo {meleeCurrent} de {meleeMax}, A distancia {rangedCurrent} de {rangedMax})",
-            "MeleeOnly": "Armas (Montajes de armas equipados: Cuerpo a cuerpo {meleeCurrent} de {meleeMax})",
-            "None": "Armas",
-            "RangedOnly": "Armas (Montajes de armas equipados: A distancia {rangedCurrent} de {rangedMax})"
-        }
-    },
-
-           "Mod": {
-    "Details": {
-        "Arms": {
-            "Amount": "Número de brazos",
-            "ArmType": {
-                "General": "Uso general",
-                "Label": "Tipo de brazo",
-                "Melee": "Montura de arma cuerpo a cuerpo",
-                "Ranged": "Montura de arma a distancia"
-            },
-            "Header": "Brazos"
-        },
-        "BaseStatistics": {
-            "FreeInstall": "Módulo gratuito",
-            "FreeInstallLabel": "Excluir módulo del conteo de módulos",
-            "Header": "Estadísticas base",
-            "MaxInstalls": "Máximo de instalaciones"
-        },
-        "OtherEffects": {
-            "AdditionalSenses": "Sentidos adicionales",
-            "ArmorSlot": "Es ranura de armadura",
-            "BonusSkill": "Habilidad adicional",
-            "Header": "Otros efectos",
-            "SpeedSpecial": "Movimiento especial",
-            "SpellResistance": "Resistencia a conjuros",
-            "WeaponProficiency": "Competencia con armas"
-        }
-    },
-    "Name": {
-        "Placeholder": "Nombre del mod"
-    },
-    "Source": "Fuente",
-    "SourceTooltip": "¿De dónde proviene este mod del dron? ¿Qué libro? ¿Qué página?"
-},
-"Skills": {
-    "NoSkillsAvailable": "Este dron no tiene habilidades disponibles."
-},
-"Traits": {
-    "ArmorSlots": "Ranuras de armadura",
-    "GeneralPurposeArms": "Brazos de uso general",
-    "MeleeWeaponMounts": "Monturas de armas cuerpo a cuerpo",
-    "RangedWeaponMounts": "Monturas de armas a distancia"
-            }
-        },
-"DurationTypesInstantaneous": "Instantáneo",
-"Effect": {
-    "DetailsEnabledLabel": "Habilitado",
-    "DetailsHeader": "Detalles del efecto",
-    "DetailsShowOnToken": "Mostrar en ficha",
-    "DurationTypesDays": "Días",
-    "DurationTypesHours": "Horas",
-    "DurationTypesLabel": "Duración",
-    "DurationTypesMinutes": "Minutos",
-    "DurationTypesNone": "Ninguno",
-    "DurationTypesPermanent": "Permanente",
-    "DurationTypesRounds": "Asaltos",
-    "EndTypesLabel": "Termina en",
-    "EndTypesOnTurnEnd": "Fin del turno",
-    "EndTypesOnTurnStart": "Inicio del turno",
-    "EndsOnTooltip": "<br><strong>Turno del actor principal</strong><p>El efecto expirará al inicio/fin del turno del actor al que pertenece.</p><strong>Turno del actor de origen</strong><p>El efecto expirará al inicio/fin del turno del actor del que fue arrastrado.</p><strong>Iniciativa más cercana</strong><p>El efecto expirará al inicio/fin del turno con la iniciativa más cercana al turno en que se activó.</p><strong>Turnos del combatiente</strong><p>El efecto expirará al inicio/fin del turno del combatiente especificado.</p>",
-    "Expired": "Expirado",
-    "ExpiryModeInit": "Conteo de iniciativa",
-    "ExpiryModeLabel": "Modo de expiración",
-    "ExpiryModeTooltip": "<br><strong>Turno del combatiente</strong><p>El efecto expirará al inicio/fin de un turno especificado.</p><strong>Conteo de iniciativa</strong><p>El efecto expirará cuando el combate actual alcance el conteo de iniciativa especificado.</p>",
-    "ExpiryModeTurn": "Turno del combatiente"
-},
-"Enabled": "Habilitado",
-"EnergyArmorClass": "CA de energía",
-"EnergyArmorClassShort": "CAE",
-"Enrichers": {
-    "Icon": {
-        "Types": {
-            "Graviton": "Gravitón",
+        "DescriptionShort": "Descripción corta",
+        "Descriptors": {
+            "Acid": "Ácido",
+            "Air": "Aire",
+            "Auditory": "Auditivo",
+            "Calling": "Llamado",
+            "CallingDescription": "Un efecto de llamado transporta a una criatura desde otro plano al plano en el que te encuentras. El efecto otorga a la criatura la habilidad única de regresar a su plano de origen, aunque el efecto podría limitar las circunstancias bajo las cuales esto es posible. Las criaturas que son llamadas mueren si son asesinadas en el nuevo plano. Una criatura llamada no puede ser disipado, incluso si fue llamada por medios mágicos.",
+            "Chaotic": "Caótico",
+            "Charm": "Encanto",
+            "CharmDescription": "Un efecto de encanto cambia cómo el sujeto te ve. Esto te da la habilidad de hacerte amigo y sugerir cursos de acción a otra criatura, pero su servidumbre no es absoluta ni sin sentido. Esencialmente, un personaje encantado retiene libre albedrío pero toma decisiones según una visión distorsionada del mundo.<br><br>Una criatura encantada mantiene su alineamiento y lealtades originales, generalmente con la excepción de que ahora considera a la persona que la encantó como un amigo querido y da gran importancia a las sugerencias y órdenes de ese personaje. Una criatura encantada no ofrece información ni tácticas que su amo no solicite. Una criatura encantada nunca obedece una orden que sea obviamente suicida o gravemente perjudicial para ella.<br><br>Una criatura pelea contra amigos que tenía antes de ser encantada solo si amenazan a su nuevo amigo. Aun así, utiliza los medios menos letales a su disposición, pues desea resolver el conflicto sin causar daño real.<br><br>Una criatura encantada puede intentar una prueba opuesta de Carisma contra su amo para resistir instrucciones u órdenes que la obligarían a hacer algo que normalmente no haría ni siquiera por un amigo cercano. Si tiene éxito en esta prueba, decide no seguir esa orden particular pero permanece encantada. Si el amo de la criatura le ordena realizar una acción a la que la criatura se opondría vehementemente, puede intentar una nueva tirada de salvación para liberarse por completo de la influencia de su amo.<br><br>Si una criatura encantada es atacada abiertamente por el personaje que la encantó o por los aliados aparentes de ese personaje, queda automáticamente libre del hechizo o efecto.",
+            "Cold": "Frío",
+            "Compulsion": "Compulsión",
+            "CompulsionDescription": "Un efecto de compulsión anula el libre albedrío del sujeto de alguna manera, forzando al sujeto a actuar de cierta forma o cambiando el modo en que funciona su mente.",
+            "Creation": "Creación",
+            "CreationDescription": "Un efecto de creación manipula la materia para crear un objeto o criatura en el lugar que el creador designe. Si el efecto tiene una duración distinta de instantánea, la magia u otra energía mantiene la creación unida, pero cuando la duración termina, la criatura u objeto creado desaparece sin dejar rastro. Si el efecto tiene duración instantánea, el objeto o criatura creada no depende de energía externa para su existencia, por lo que dura indefinidamente una vez creado.",
+            "Curse": "Maldición",
+            "Darkness": "Oscuridad",
+            "Death": "Muerte",
+            "Descriptors": "Descriptores",
+            "Disease": "Enfermedad",
+            "Earth": "Tierra",
+            "Electricity": "Electricidad",
+            "Emotion": "Emoción",
+            "Evil": "Mal",
+            "Fear": "Miedo",
+            "Fire": "Fuego",
+            "Force": "Fuerza",
+            "ForceDescription": "Un efecto de fuerza inflige daño completo a criaturas incorpóreas y bloquea su movimiento. También bloquea el sentido mediante la habilidad.",
+            "Good": "Bien",
+            "Healing": "Curación",
+            "Illusion": "Ilusión",
             "LanguageDependent": "Dependiente del lenguaje",
+            "LanguageDependentDescription": "Un efecto dependiente del lenguaje usa un idioma inteligible (ya sea audible, visual o telepático) como medio de comunicación. Si no puedes comunicarte con el objetivo o el objetivo no puede entender lo que comunicas, el efecto no afecta a ese objetivo.",
+            "Lawful": "Legal",
+            "Light": "Luz",
             "MindAffecting": "Afecta la mente",
-            "Photon": "Fotón",
-            "SenseDependent": "Dependiente del sentido"
-        }
-    },
-    "SendToChat": "Enviar al chat",
-    "TypeError": "¡Fallo al analizar {enricherType}! Tipo inválido."
-},
-"Environment": "Entorno",
-"FeatTypes": {
-    "Combat": "Hazañas de combate",
-    "General": "Hazañas generales"
-},
-"FeatureCategory": {
-    "ArchetypeFeature": "Característica de arquetipo",
-    "ClassFeature": "Característica de clase",
-    "Feat": "Hazaña",
-    "OtherFeature": "Otra característica",
-    "SpeciesFeature": "Característica de especie",
-    "ThemeFeature": "Característica temática",
-    "UniversalCreatureRule": "Regla universal de criatura"
-},
-"Features": "Características",
-"FeaturesAdd": "Agregar",
-"FeaturesCharges": "Cargas",
-"FeaturesFilter": "Filtrar",
-"FeaturesUsage": "Uso",
-"FlagDeprecationNotice": "<strong>NOTA:</strong> Estos valores están siendo reemplazados por el nuevo sistema de modificadores y serán eliminados en una actualización futura. Se recomienda desmarcar cualquiera de estos valores y agregarlos como modificador en la pestaña de Modificadores.",
-"FlagsEmptySolarian": "No hay rasgos especiales por el momento. Si buscas Sintonía Solariana, usa el nuevo sistema de recursos de actor dentro de la característica de clase Modo Estelar.",
-"FlagsInstructions": "Configura características y rasgos de personaje que ajustan los comportamientos del sistema Starfinder.",
-"FlagsSave": "Actualizar rasgos especiales",
-"FlagsTitle": "Configurar rasgos especiales",
-"FloatingHP": {
-    "HP": "PG",
-    "Sh.A.": "Sh.A.",
-    "Sh.F.": "Sh.F.",
-    "Sh.P.": "Sh.P.",
-    "Sh.S.": "Sh.S.",
-    "stamina": "PE",
-    "temp": "Temp"
-},
-"FloatingHPVerbose": {
-    "HP": "PG",
-    "Sh.A.": "Escudos traseros",
-    "Sh.F.": "Escudos frontales",
-    "Sh.P.": "Escudos de babor",
-    "Sh.S.": "Escudos de estribor",
-    "stamina": "PE",
-    "temp": "Temp"
-},
-"FortitudeSave": "Fortaleza",
-"Ft": "Pies",
-"GreatFortitudeHint": "Hazaña de personaje que añade 2 a tiradas de salvación de Fortaleza",
-"GreatFortitudeLabel": "Gran fortaleza",
-"HazardSheet": {
-    "Details": {
-        "Attributes": {
-            "Bypass": "Bypass",
-            "BypassTooltip": "(Opcional) Algunas trampas tienen un mecanismo de bypass que permite al creador de la trampa u otros usuarios desactivarla temporalmente.",
-            "Duration": "Duración",
-            "DurationTooltip": "(Opcional) Si una trampa tiene una duración mayor que instantánea, se indica aquí. Tal trampa continúa produciendo su efecto durante varios asaltos en su conteo de iniciativa.",
-            "Header": "Atributos",
-            "Initiative": "Iniciativa",
-            "InitiativeTooltip": "(Opcional) Algunas trampas lanzan iniciativa para determinar cuándo se activan en una ronda de combate.",
-            "Reset": "Reiniciar",
-            "ResetPlaceholder": "Ninguno, Manual, 1 minuto, etc.",
-            "ResetTooltip": "Esto indica cuánto tiempo tarda una trampa en reiniciarse automáticamente.",
-            "Trigger": "Disparador",
-            "TriggerPlaceholder": "Ubicación, proximidad, toque, etc.",
-            "TriggerTooltip": "El disparador de una trampa determina cómo se activa. Salvo que se indique lo contrario, las criaturas más pequeñas que diminutas no activan trampas normalmente."
+            "MindAffectingDescription": "Un efecto que afecta la mente solo funciona contra criaturas con una puntuación de Inteligencia de 1 o más.",
+            "Pain": "Dolor",
+            "PainDescription": "Un efecto de dolor causa sensaciones desagradables pero no daño físico permanente. Las criaturas inmunes a efectos que requieren una tirada de salvación de Fortaleza son inmunes a efectos de dolor.",
+            "Poison": "Veneno",
+            "Polymorph": "Polimorfismo",
+            "Radiation": "Radiación",
+            "Scrying": "Adivinación",
+            "ScryingDescription": "Un efecto de adivinación crea un sensor mágico invisible que te envía información mientras dura el efecto. A menos que se indique lo contrario, el sensor tiene las mismas habilidades sensoriales que tú tienes naturalmente, pero no las habilidades sensoriales que obtienes de otros hechizos o tecnología. El sensor es una fuente independiente de entrada sensorial para ti, por lo que funciona normalmente incluso si has quedado ciego, sordo o sufres alguna discapacidad sensorial.<br><br>Una criatura puede notar un sensor de adivinación con una prueba exitosa de Percepción (DC = 20 + nivel del hechizo o efecto). El sensor puede ser disipado como si fuera un hechizo activo. Láminas de plomo, campos de fuerza y algunos materiales exóticos y protecciones mágicas bloquean efectos de adivinación; si es el caso, puedes percibir que el efecto ha sido bloqueado.",
+            "SenseDependent": "Dependiente del sentido",
+            "SenseDependentDescription": "Un efecto dependiente del sentido tiene elementos audibles o visuales, requiriendo vista o audición para tener efecto. Para que este tipo de efecto afecte a un objetivo, debes poder verlo o escucharlo, y el objetivo debe poder verte o escucharte.",
+            "Shadow": "Sombra",
+            "ShadowDescription": "Un efecto de sombra crea algo parcialmente real a partir de una amalgama de energía extradimensional. El daño causado por un efecto de sombra es real.",
+            "Sonic": "Sónico",
+            "Summoning": "Invocación",
+            "SummoningDescription": "Un efecto de invocación trae instantáneamente a una criatura u objeto a un lugar que designes. Cuando el efecto termina o es disipado, una criatura invocada es enviada instantáneamente de regreso a su lugar de origen (típicamente otro plano, pero no siempre), pero un objeto invocado no es devuelto a menos que la descripción del efecto indique lo contrario. Una criatura invocada también desaparece si es asesinada o si sus Puntos de Golpe llegan a 0, pero en realidad no está muerta. Tarda 24 horas en reformarse en el lugar desde donde fue invocada, durante las cuales no puede ser invocada nuevamente.<br><br>Cuando un efecto de invocación termina y la criatura invocada desaparece, todos los hechizos que haya lanzado expiran. Una criatura invocada no puede usar habilidades innatas de invocación que pueda tener.",
+            "Teleportation": "Teletransportación",
+            "TeleportationDescription": "Un efecto de teletransportación implica un viaje instantáneo a través del Plano Astral (ver página 471). Todo lo que bloquea el viaje astral también bloquea la teletransportación a menos que el efecto específico indique lo contrario, y los efectos de teletransportación funcionan dentro del Deriva.",
+            "Water": "Agua"
         },
-        "DCs": {
-            "Disable": "Desactivar",
-            "DisableTooltip": "Esta es la CD para desactivar la trampa usando la(s) habilidad(es) listada(s).",
-            "Header": "CDs",
-            "Notice": "Percepción",
-            "NoticePlaceholder": "ej. CD de Percepción 10",
-            "NoticeTooltip": "Esta es la CD para encontrar la trampa usando Percepción."
+        "Details": "Detalles",
+        "Dialogs": {
+            "InputDialog": {
+                "MultipleFieldsInvalid": "Entrada inválida para los siguientes campos:<br/>{fieldNames}",
+                "SingleFieldInvalid": "Entrada inválida para {fieldName}."
+            }
         },
-        "Effects": {
-            "Effect": "Efecto",
-            "EffectTooltip": "Esto lista el efecto que la trampa tiene sobre quienes la activan.",
-            "Header": "Efectos"
-        },
-        "Vitals": {
-            "Defenses": {
-                "EAC": "CAE",
-                "EACTooltip": "Si las partes mecánicas de tu trampa pueden ser atacadas, este valor ayuda a determinar qué tan fácil es acertar.",
-                "Hardness": "Dureza",
-                "HardnessTooltip": "Las trampas tienen una dureza basada en su material.",
-                "Header": "Defensas",
-                "Hitpoints": "Puntos de golpe",
-                "HitpointsTooltip": "Partes cruciales de algunas trampas pueden ser dañadas y deben tener el número listado de Puntos de Golpe. Las trampas son inmunes a todo aquello a lo que un objeto es inmune, salvo que se indique lo contrario. Una trampa reducida a 0 PG queda destruida. Destruir una trampa puede activar un componente final de la trampa, como una explosión. Las trampas nunca tienen Puntos de Resistencia.",
-                "KAC": "CAC",
-                "KACTooltip": "Si las partes mecánicas de tu trampa pueden ser atacadas, este valor ayuda a determinar qué tan fácil es acertar."
+        "Disabled": "Deshabilitado",
+        "DistAny": "Cualquiera",
+        "DroneSheet": {
+            "Chassis": {
+                "Details": {
+                    "AbilityScores": {
+                        "Charisma": "Carisma base",
+                        "Dexterity": "Destreza base",
+                        "Header": "Puntuaciones de habilidad",
+                        "Increases": "Incrementos de puntuación de habilidad",
+                        "Intelligence": "Inteligencia base",
+                        "Strength": "Fuerza base",
+                        "Wisdom": "Sabiduría base"
+                    },
+                    "BaseStatistics": {
+                        "Header": "Estadísticas base",
+                        "MechanicLevel": "Nivel de mecánico",
+                        "Size": "Tamaño",
+                        "SpeedBase": "Velocidad, base (numérico, en pies)",
+                        "SpeedSpecial": "Velocidad, especial"
+                    },
+                    "Defense": {
+                        "EAC": "EAC base",
+                        "Header": "Defensa",
+                        "KAC": "KAC base"
+                    },
+                    "Saves": {
+                        "Fortitude": "Progresión de salvación de Fortaleza",
+                        "Header": "Salvaciones",
+                        "Reflex": "Progresión de salvación de Reflejos",
+                        "Will": "Progresión de salvación de Voluntad"
+                    }
+                },
+                "Missing": "Chasis faltante",
+                "Name": {
+                    "Placeholder": "Nombre del chasis"
+                },
+                "NotInstalled": "No hay chasis instalado.",
+                "Source": "Fuente",
+                "SourceTooltip": "¿De dónde proviene este chasis? ¿Qué libro? ¿Qué página?"
             },
-            "Offense": {
-                "Attack": "Ataque",
-                "AttackTooltip": "(Opcional) El bono de ataque de la trampa se usa si ataca directamente a un objetivo.",
-                "Damage": "Daño",
-                "DamageTooltip": "(Opcional) El daño promedio de la trampa se usa si ataca directamente a un objetivo, pero considera reducir este daño si una trampa tiene múltiples ataques o afecta a múltiples objetivos.",
-                "Header": "Ofensiva"
-            },
-            "Saves": {
-                "Fortitude": "Salvación de Fortaleza",
-                "FortitudeTooltip": "Si los jugadores usan ataques especiales que pueden apuntar a objetos contra la trampa, este valor puede usarse para la salvación de Fortaleza de la trampa.",
-                "Header": "Tiradas de salvación",
-                "Reflex": "Salvación de Reflejos",
-                "ReflexTooltip": "Si los jugadores usan ataques especiales que pueden apuntar a objetos contra la trampa, este valor puede usarse para la salvación de Reflejos de la trampa.",
-                "Will": "Salvación de Voluntad",
-                "WillTooltip": "Las trampas normalmente no necesitan salvaciones de Voluntad, pero si es necesario, la salvación de Voluntad de una trampa es mala."
-            }
-        }
-    },
-
-            "Header": {
-    "NamePlaceholder": "Nombre del peligro",
-    "SourcePlaceholder": "Fuente",
-    "TypePlaceholder": "Analógico, Mágico, Tecnológico, Híbrido"
-},
-"Notifications": {
-    "NoDamage": "No se ingresó valor para el daño, no se puede hacer una tirada para {name}."
-},
-"Rolls": {
-    "Attack": "Ataque - {name}",
-    "Damage": "Daño - {name}",
-    "Fortitude": "Tirada de Salvación de Fortaleza - {name}",
-    "Reflex": "Tirada de Salvación de Reflejos - {name}",
-    "Will": "Tirada de Salvación de Voluntad - {name}"
-},
-"Tabs": {
-    "Vitals": "Datos vitales"
-            }
-        },
-"HealingTypesHealing": "Curación",
-"Health": "Puntos de Golpe",
-"HullPoints": "Puntos de Casco",
-"ImprovedInitiativeHint": "Hazaña de personaje que añade 4 a su tirada de iniciativa",
-"ImprovedInitiativeLabel": "Iniciativa Mejorada",
-"InitiativeDexModTooltip": "Modificador de Destreza: {mod}",
-"InitiativeLabel": "Iniciativa",
-"InitiativeModiferLabel": "Mod",
-"InitiativeModiferTooltip": "Bono de {type}: {mod} ({source})",
-"InvalidItem": "{name} es un objeto inválido para un {target}.",
-"InvalidStarshipItem": "{name} es un objeto inválido para una nave estelar.",
-"Inventory": "Inventario",
-"InventoryAdd": "Agregar",
-"InventoryBulk": "Peso",
-"InventoryCapacity": "Capacidad",
-"InventoryCurrency": "Moneda",
-"InventoryEquipped": "Equipado",
-"InventoryNotEquipped": "No equipado",
-"InventoryUsage": "Uso",
-"IronWillHint": "Hazaña de personaje que añade 2 a tiradas de salvación de Voluntad",
-"IronWillLabel": "Voluntad de Hierro",
-"ItemBonusTooltip": "Bono de objeto: {mod} ({source})",
-"ItemCollectionSheet": {
-    "ItemCollectionLocked": "Este contenedor está bloqueado y no se abrirá.",
-    "Settings": {
-        "DeleteIfEmpty": "Eliminar cuando esté vacío",
-        "DeleteIfEmptyTooltip": "<strong>Eliminar cuando esté vacío</strong><br/>¿Debe este token contenedor eliminarse automáticamente cuando se remueva el último objeto?",
-        "Header": "Configuración del GM:",
-        "Locked": "Bloqueado",
-        "LockedTooltip": "<strong>Bloqueado</strong><br/>Un contenedor bloqueado previene el acceso de los jugadores."
-    }
-},
-"ItemMacro": {
-    "Activate": "Activar",
-    "Attack": "Atacar",
-    "Cast": "Lanzar",
-    "Damage": "Daño",
-    "Healing": "Curación",
-    "Reload": "Recargar",
-    "Use": "Usar"
-},
-"ItemNoAmmo": "¡{name} no tiene munición!",
-"ItemSheet": {
-    "AbilityScoreIncrease": {
-        "Header": "Incrementos de puntuación de habilidad",
-        "Instruction": "Selecciona 4 puntuaciones de habilidad para aumentar.",
-        "InstructionRules": "Cada 5 niveles (en los niveles 5, 10, 15 y 20), puedes aumentar y personalizar tus puntuaciones de habilidad. Cada vez que alcances uno de estos niveles, elige cuatro puntuaciones de habilidad para aumentar. Si esa puntuación es 17 o más (excluyendo aumentos por mejoras personales—ver página 212), aumenta permanentemente en 1. Si es 16 o menos, aumenta permanentemente en 2. No puedes aplicar más de un aumento a la misma puntuación en un nivel dado, pero a diferencia del nivel 1, estos aumentos pueden llevar las puntuaciones por encima de 18.",
-        "ItemName": "Incremento de puntuación de habilidad: Nivel {level}",
-        "Label": "Habilidades"
-    },
-    "ActorResource": {
-        "Base": "Valor base",
-        "BaseTooltip": "(Requerido) El valor base define el valor base de este recurso. Los modificadores pueden alterarlo.<br/>Atributo: @resources.type.subtype.base",
-        "CombatTracker": "Rastreador de combate",
-        "CombatTrackerSettings": "Configuración del rastreador de combate",
-        "DisplayAbsoluteValue": "Mostrar valor absoluto",
-        "DisplayAbsoluteValueTooltip": "¿El valor mostrado en el rastreador de combate debe ser absoluto? Ejemplo: -1 se muestra como 1, -2 como 2, etc.",
-        "Enabled": "Habilitado",
-        "EnabledTooltip": "Si no está marcado, este recurso no producirá una clave en el formato de datos de recursos ni tendrá automatización activa.",
-        "ErrorDisabled": "El recurso está deshabilitado actualmente.",
-        "ErrorIncompleteData": "Al recurso le falta tipo, subtipo o valor base.",
-        "ErrorMissingFields": "Por favor completa los campos faltantes.",
-        "ErrorNoBase": "El valor base es obligatorio.",
-        "ErrorNoSubType": "El subtipo es obligatorio.",
-        "ErrorNoType": "El tipo es obligatorio.",
-        "Header": "Propiedades del recurso",
-        "Range": "Rango de valor",
-        "RangeMode": "Modo de rango",
-        "RangeModeImmediate": "Inmediato",
-        "RangeModePost": "Posterior",
-        "RangeModeTooltip": "(Avanzado) Define si las limitaciones de rango se aplican después de que se procesan todos los modificadores, o para cada modificador mientras se procesan.<br/><br/>Por ejemplo, si el rango máximo es 1, y el valor base es 0, con un modificador +2 y otro -1:<br/><br/>Post: 0 + 2 - 1 da 1, que no excede el máximo.<br/><br/>Inmediato: 0 + 2 se clampa a 1, luego -1 da 0.",
-        "RangeTooltip": "(Opcional) Valores mínimos y máximos para este recurso.<br/>El valor no puede ser menor que el mínimo ni mayor que el máximo.",
-        "ShowInCombatTracker": "Mostrar en el rastreador de combate",
-        "ShowInCombatTrackerTooltip": "Si está habilitado, este recurso será visible en el rastreador de combate para referencia rápida.",
-        "ShowOwnerAndGMOnly": "Solo visible para dueño y GM",
-        "ShowOwnerAndGMOnlyTooltip": "Si está habilitado, este recurso solo será visible en el rastreador de combate para el dueño de la ficha y el GM.",
-        "Stage": "Etapa de cálculo",
-        "StageEarly": "Temprano",
-        "StageLate": "Tardío",
-        "StageTooltip": "La etapa de cálculo determina cuándo se calculan los modificadores de este recurso.<br/><br/><strong>Temprano</strong><br/>Los recursos tempranos se calculan antes de que otras automatizaciones corran. En este punto, los valores computados del actor no son aún válidos, como modificadores de fuerza, bono de salvación, etc. Estos recursos pueden usarse en modificadores que afectan atributos del actor.<br/><br/><strong>Tardío</strong><br/>Los recursos tardíos se calculan al final de los modificadores del actor. Puedes incluir valores ya calculados del actor en este recurso. No puedes incluir recursos tardíos en cálculos que afectan atributos constantemente, pero sí en modificadores situacionales.",
-        "SubType": "Subtipo",
-        "SubTypeTooltip": "(Requerido) El subtipo forma la segunda parte del identificador del recurso.<br/>Ejemplo: @resources.type.subtype.value",
-        "Type": "Tipo",
-        "TypeTooltip": "(Requerido) El tipo forma la primera parte del identificador del recurso.<br/>Ejemplo: @resources.type.subtype.value",
-        "Usage": "Uso de atributo",
-        "UsageBaseValue": "Valor base",
-        "UsageComputedValue": "Valor calculado",
-        "UsageTooltip": "Aquí algunos ejemplos de atributos para acceder a este recurso en fórmulas:",
-        "Visualizations": "Visualización condicional",
-        "VisualizationsIntro": "Si el valor del recurso es...",
-        "VisualizationsModeEqual": "igual a",
-        "VisualizationsModeGreaterThan": "mayor que",
-        "VisualizationsModeGreaterThanEqual": "mayor o igual que",
-        "VisualizationsModeLesserThan": "menor que",
-        "VisualizationsModeLesserThanEqual": "menor o igual que",
-        "VisualizationsModeNotEqual": "diferente de",
-        "VisualizationsPart": "Parte de la visualización",
-        "VisualizationsThen": "Entonces:",
-        "VisualizationsTitle": "Título:"
-    },
-    "Class": {
-        "SpellCasting": {
-            "ClassLevel": "Nivel de clase",
-            "Header": "Lanzamiento de conjuros",
-            "IsCaster": "Conjurador",
-            "KeyAbilityScore": "Puntuación de habilidad clave",
-            "SpellsKnown": "Conjuros conocidos",
-            "SpellsKnownHeader": "Conjuros conocidos (por nivel de conjuro)",
-            "SpellsPerDay": "Conjuros por día",
-            "SpellsPerDayBonus": "Conjuros adicionales por día",
-            "SpellsPerDayBonusHeader": "Conjuros adicionales por día (por nivel de conjuro)",
-            "SpellsPerDayHeader": "Conjuros por día (por nivel de conjuro)"
-        }
-    },
-
-      "Consumables": {
-    "Category": "Tipo de Consumible"
-  },
-  "Containers": {
-    "ContainerTooltip": "Los contenedores pueden contener casi cualquier objeto. Aumenta la capacidad de almacenamiento para permitir añadir contenido."
-  },
-  "Details": {
-    "Section": {
-      "ArmorDetails": "Detalles de Armadura",
-      "ClassBasics": "Conceptos Básicos de Clase",
-      "ConsumableDetails": "Detalles del Consumible",
-      "Progressions": "Progresiones",
-      "SkillsAndProficiencies": "Habilidades y Competencias",
-      "Title": "Sección",
-      "Usage": "Uso"
-    },
-    "Tab": {
-      "AmmunitionContainer": "Munición y Contenedor",
-      "AttackDamage": "Ataque y Daño",
-      "ClassInformation": "Información de Clase",
-      "ContainerDetails": "Detalles del Contenedor",
-      "NPCSpecific": "Específico de PNJ",
-      "Properties": "Propiedades",
-      "Spellcasting": "Conjuración",
-      "UsageAction": "Uso y Acción"
-    }
-  },
-  "Header": {
-    "ArmorClass": "Clase de Armadura",
-    "ArmorClassTooltip": "<strong>Clase de Armadura</strong><br/>La clase de armadura de este objeto, si está desatendido. De lo contrario, se debe usar la clase de armadura del portador.<br/>Un objeto se considera desatendido si no está bajo la influencia de un personaje.",
-    "DetailsHeader": "Detalles",
-    "Hardness": "Dureza",
-    "HardnessTooltip": "<strong>Dureza</strong><br/>Al recibir daño, resta la dureza del objeto del daño recibido antes de aplicarlo.",
-    "Hitpoints": "Puntos de Golpe",
-    "HitpointsTooltip": "<strong>Puntos de Golpe</strong><br/>La cantidad de puntos de golpe disponibles para este objeto.<br/>Un objeto se considera 'dañado' si tiene puntos de daño.<br/>Un objeto se considera 'destruido' cuando sus puntos de golpe llegan a 0.",
-    "ItemName": "Nombre del Objeto",
-    "ItemNameTooltip": "<strong>Nombre del Objeto</strong><br/>El nombre asignado a este objeto.",
-    "Requirements": "Requisitos",
-    "Save": "CD de Salvación",
-    "SaveTooltip": "<strong>CD de Salvación</strong><br/>Fórmula: {formula}<br/>Este es el modificador de la tirada de salvación para este objeto.",
-    "Source": "Fuente",
-    "SourceTooltip": "<strong>Fuente</strong><br/><em>Usado principalmente para indicar de qué documento de reglas proviene este objeto</em>",
-    "Subtype": "Subtipo",
-    "Type": "Tipo"
-  },
-  "PhysicalProperties": {
-    "ArmorClass": "Clase de Armadura",
-    "ArmorClassTooltip": "<strong>Clase de Armadura</strong><br/>La clase de armadura de este objeto, si está desatendido. De lo contrario, se debe usar la clase de armadura del portador.<br/>Un objeto se considera desatendido si no está bajo la influencia de un personaje.",
-    "CustomBuilt": "Construido a Medida",
-    "CustomBuiltTooltip": "¿Fue este objeto fabricado por un personaje o producido en masa?",
-    "DexterityModifier": "Modificador de Destreza",
-    "DexterityModifierTooltip": "Si es inanimado, el modificador de destreza de un objeto es -5.",
-    "EquippedBulkMultiplier": "Multiplicador de Volumen Equipado",
-    "EquippedBulkMultiplierTooltip": "Este multiplicador se usa para alterar el volumen del objeto cuando está equipado.<br/>Establecerlo en 0 hará que el objeto no cuente su propio volumen para la carga del personaje cuando esté equipado.",
-    "Hardness": "Dureza",
-    "HardnessTooltip": "<strong>Dureza</strong><br/>Al recibir daño, resta la dureza del objeto del daño recibido antes de aplicarlo.",
-    "Header": "Propiedades Físicas",
-    "Hitpoints": {
-      "CurrentTooltip": "La cantidad de puntos de golpe que tiene este objeto.",
-      "Header": "Puntos de Golpe",
-      "HeaderTooltip": "<strong>Puntos de Golpe</strong><br/>La cantidad de puntos de golpe disponibles para este objeto.<br/>Un objeto se considera 'dañado' si tiene puntos de daño.<br/>Un objeto se considera 'destruido' cuando sus puntos de golpe llegan a 0.",
-      "MaxTooltip": "La cantidad máxima de puntos de golpe que este objeto puede tener. Deja en blanco para cálculo automático."
-    },
-    "ItemDescriptor": "Configuraciones Físicas",
-    "Size": "Tamaño",
-    "SizeTooltip": "Por defecto, el tamaño de un objeto es mediano. El tamaño afecta la clase de armadura del objeto, modifica según sea necesario.",
-    "Sturdy": "Robusto",
-    "SturdyTooltip": "El equipo, como armas y armaduras, se considera robusto."
-  },
-  "StarshipAblativeArmor": {
-    "AblativeValue": "Puntos de Golpe Adicionales Totales",
-    "AblativeValueTooltip": "La cantidad total de puntos de golpe de armadura ablativa para distribuir en los cuatro cuadrantes.",
-    "Header": "Propiedades de Armadura Ablativa",
-    "TargetLockPenalty": "Penalización de Fijación de Objetivo",
-    "TargetLockPenaltyTooltip": "La penalización aplicada a la puntuación de fijación de objetivo de la nave.",
-    "TurnDistancePenalty": "Penalización de Distancia de Giro",
-    "TurnDistancePenaltyTooltip": "La penalización aplicada a la puntuación de distancia de giro de la nave."
-  },
-  "StarshipAction": {
-    "ActionDC": "CD de Acción",
-    "AddSubactionTooltip": "<strong>Agregar Subacción</strong><br />Agregar una nueva subacción",
-    "CheckFormula": "Fórmula de Chequeo de Habilidad",
-    "CrewRole": "Rol de Tripulación",
-    "CriticalEffect": "Efecto Crítico",
-    "DCPlaceholder": "5 + 1-1/2 * Nivel Objetivo de la Nave",
-    "DeleteSubactionTooltip": "<strong>Eliminar Subacción</strong><br />Eliminar esta subacción",
-    "IsPushAction": "¿Acción Push?",
-    "NormalEffect": "Efecto Normal",
-    "Phase": "Fase",
-    "PhaseTooltip": "Tooltip de la Fase",
-    "PushResolve": "Push y Resolver",
-    "ResolveFormulaAutomatically": "Resolver esta fórmula automáticamente",
-    "ResolveFormulaAutomaticallyTooltip": "Si esta casilla está marcada, el CD objetivo se resolverá automáticamente como fórmula y el resultado se mostrará en el chat cuando se active la acción. De lo contrario, se mostrará la cadena sin procesar en el chat.",
-    "SkillFormulaAndSubactions": "Fórmula de Habilidad y Subacciones",
-    "SkillFormulaOrSubactions": "Fórmula de Habilidad / Subacciones",
-    "SkillOrSubaction": "Nombre de Habilidad o Subacción",
-    "SubactionPart": "Subacción {section}",
-    "Subactions": "Subacciones",
-    "TargetDC": "CD Objetivo",
-    "UsesResolve": "Usa Resolución"
-  },
-  "StarshipArmor": {
-    "ArmorBonus": "Bonificación de Armadura",
-    "ArmorBonusTooltip": "La bonificación de clase de armadura que proporciona esta armadura.",
-    "Header": "Propiedades de Armadura",
-    "TargetLockPenalty": "Penalización de Fijación de Objetivo",
-    "TargetLockPenaltyTooltip": "La penalización aplicada a la puntuación de fijación de objetivo de la nave.",
-    "TurnDistancePenalty": "Penalización de Distancia de Giro",
-    "TurnDistancePenaltyTooltip": "La penalización aplicada a la puntuación de distancia de giro de la nave."
-  },
-  "StarshipComponent": {
-    "Cost": "Costo en Puntos de Construcción",
-    "CostMultipliedBySize": "Costo en PC multiplicado por Tamaño",
-    "CostMultipliedBySizeTooltip": "¿El costo en PC se multiplica por el tamaño del casco de la nave?",
-    "CostTooltip": "La cantidad de puntos de construcción necesarios para obtener este componente.",
-    "Header": "Propiedades Comunes del Componente",
-    "IsCostMultipliedBySize": "Está multiplicado",
-    "IsPowered": "Está alimentado",
-    "PCU": "Uso de PCU",
-    "PCUTooltip": "La cantidad de energía que este componente requiere para funcionar.",
-    "PoweredState": "Estado de Alimentación",
-    "PoweredStateTooltip": "¿Está este componente de la nave alimentado?"
-  },
-  "StarshipComputer": {
-    "Header": "Propiedades de la Computadora",
-    "Modifier": "Modificador",
-    "ModifierTooltip": "El modificador de tirada proporcionado por esta computadora.",
-    "Nodes": "Nodos",
-    "NodesTooltip": "La cantidad de veces por turno que esta computadora puede proporcionar su bonificación."
-  },
-  "StarshipDefensiveCountermeasure": {
-    "Header": "Propiedades de Contramedidas Defensivas",
-    "TargetLockBonus": "Bonificación de Fijación de Objetivo",
-    "TargetLockBonusTooltip": "La bonificación aplicada a la puntuación de fijación de objetivo de la nave."
-  },
-  "StarshipDriftEngine": {
-    "EngineRating": "Calificación del Motor",
-    "EngineRatingTooltip": "La calificación del motor de deriva.",
-    "Header": "Propiedades del Motor de Deriva",
-    "MaxSize": "Tamaño Máximo de Nave",
-    "MaxSizeTooltip": "El tamaño máximo de nave en que se puede instalar este motor."
-  },
-  "StarshipFortifiedHull": {
-    "CriticalThresholdBonus": "Bonificación al Umbral Crítico",
-    "CriticalThresholdBonusTooltip": "La bonificación aplicada al umbral crítico de la nave.",
-    "Header": "Propiedades del Casco Fortificado"
-  },
-
-            "StarshipFrame": {
-    "Details": {
-        "Cost": "Costo en puntos de construcción",
-        "CostTooltip": "La cantidad de puntos de construcción necesarios para obtener este casco.",
-        "CrewMaximum": "Número máximo de tripulación",
-        "CrewMaximumTooltip": "El número máximo de miembros de la tripulación que pueden ocupar un rol en una nave estelar basada en este casco.",
-        "CrewMinimum": "Número mínimo de tripulación",
-        "CrewMinimumTooltip": "El número mínimo de miembros de la tripulación necesarios para operar una nave estelar basada en este casco.",
-        "DamageThreshold": "Umbral de daño",
-        "DamageThresholdTooltip": "Si una nave estelar tiene un umbral de daño, cualquier ataque que cause daño a sus Puntos de Casco igual o menor a este umbral no daña los Puntos de Casco de la nave. Si el daño es mayor que el umbral, la cantidad total de daño se aplica a los Puntos de Casco de la nave.",
-        "ExpansionBays": "Bahías de expansión",
-        "ExpansionBaysTooltip": "El número de bahías de expansión disponibles para este casco.",
-        "HeaderDefense": "Defensa",
-        "HeaderOffense": "Ofensa",
-        "HeaderSpecs": "Especificaciones",
-        "Hitpoints": "Puntos de Casco",
-        "HitpointsIncrement": "Incremento de Puntos de Casco",
-        "HitpointsIncrementTooltip": "La cantidad de Puntos de Casco que una nave estelar con este casco gana automáticamente cuando su nivel aumenta a 4 (y cada 4 niveles siguientes; ver página 294).",
-        "HitpointsTooltip": "La cantidad de Puntos de Casco que este casco tiene en el nivel 1.",
-        "Maneuverability": "Maniobrabilidad",
-        "ManeuverabilityTooltip": "La maniobrabilidad de la nave estelar afecta las habilidades de pilotaje y giro.<br/>Torpe: -2 a Pilotaje, Giro 4<br/>Pobre: -1 a Pilotaje, Giro 3<br/>Promedio: +0 a Pilotaje, Giro 2<br/>Buena: +1 a Pilotaje, Giro 1<br/>Perfecta: +2 a Pilotaje, Giro 0",
-        "Size": "Tamaño",
-        "SizeTooltip": "El tamaño del casco determina el tamaño de la nave estelar.",
-        "WeaponArcAft": "Arco trasero",
-        "WeaponArcForward": "Arco delantero",
-        "WeaponArcPort": "Arco babor",
-        "WeaponArcStarboard": "Arco estribor",
-        "WeaponArcTooltip": "La cantidad de monturas de armas disponibles para el arco de la nave, divididas en ligeras, pesadas y capitales.",
-        "WeaponArcTurret": "Torreta",
-        "WeaponMounts": "Monturas de armas",
-        "WeaponTypeCapital": "Capital",
-        "WeaponTypeHeavy": "Pesada",
-        "WeaponTypeLight": "Ligera",
-        "WeaponTypeSpinal": "Espinal"
-    }
-},
-"StarshipPowerCore": {
-    "Header": "Propiedades del núcleo de energía",
-    "ProvidedPower": "PCU proporcionada",
-    "ProvidedPowerTooltip": "La cantidad de PCU proporcionada por este núcleo de energía.",
-    "Sizes": "Tamaños de nave estelar soportados",
-    "SizesTooltip": "Selecciona los tamaños de nave estelar en los que se puede instalar este núcleo de energía."
-},
-"StarshipReinforcedBulkhead": {
-    "Fortification": "Fortificación",
-    "FortificationTooltip": "Cada vez que la nave sufriría daño crítico, existe un porcentaje de probabilidad basado en la calificación de fortificación del mamparo reforzado de que el efecto de daño crítico sea anulado (aunque el ataque aún cause daño a la nave).",
-    "Header": "Propiedades del mamparo reforzado"
-},
-"StarshipSensor": {
-    "Header": "Propiedades del sensor",
-    "Modifier": "Modificador de escaneo del sensor",
-    "ModifierTooltip": "Un modificador adicional al escanear planetas fuera de combate.",
-    "Range": "Alcance",
-    "RangeTooltip": "Incremento de alcance del escáner; corto es 5, medio es 10 y largo es 15 hexágonos."
-},
-"StarshipShield": {
-    "ArmorBonus": "Bono de armadura",
-    "ArmorBonusTooltip": "El bono a la clase de armadura proporcionado por este escudo.",
-    "DefenseValue": "Valor de defensa",
-    "DefenseValueTooltip": "El valor máximo de defensa disponible con este escudo deflector.",
-    "Header": "Propiedades del escudo",
-    "IsDeflector": "Es escudo deflector",
-    "Regeneration": "Regeneración por minuto",
-    "RegenerationTooltip": "La cantidad de puntos de escudo regenerados por minuto.",
-    "ShieldPoints": "Puntos de escudo",
-    "ShieldPointsTooltip": "La cantidad total de puntos de escudo proporcionados por este escudo.",
-    "ShieldType": "Tipo de escudo",
-    "ShieldTypeTooltip": "¿Es este escudo un escudo deflector?",
-    "TargetLockBonus": "Bono a bloqueo de objetivo",
-    "TargetLockBonusTooltip": "El bono aplicado a la puntuación de bloqueo de objetivo de la nave."
-},
-"StarshipThruster": {
-    "Booster": "Propulsor impulsor",
-    "BoosterTooltip": "Para más información, consulte la bahía de expansión para el alojamiento del propulsor impulsor.",
-    "Header": "Propiedades del propulsor",
-    "IsBooster": "Es un impulsor",
-    "IsEnabled": "Está activado",
-    "PilotingModifier": "Modificador de pilotaje",
-    "PilotingModifierTooltip": "Modificador adicional de pilotaje otorgado por este propulsor.",
-    "Size": "Tamaño de nave estelar soportado",
-    "SizeTooltip": "Seleccione el tamaño de nave estelar en el que se puede instalar este propulsor.",
-    "Speed": "Velocidad",
-    "SpeedTooltip": "Número de hexágonos que la nave podrá mover por turno usando este propulsor."
-}
-,
-            "StarshipWeapon": {
-    "Header": "Propiedades del arma de nave estelar",
-    "Placeholder": "ej. 5",
-    "Unmounted": "Desmontado"
-},
-"WeaponAccessory": {
-    "SupportedTypes": "Tipos de armas soportados"
-},
-"Weapons": {
-    "Category": "Tipo de arma",
-    "ContainerTooltip": "Las armas típicamente pueden contener fusiones y mejoras de armas. Aumenta la capacidad de almacenamiento para permitir agregar mejoras y fusiones."
-            }
-        },
-"Items": {
-    "ACP": "Penalización por chequeo de armadura",
-    "Action": {
-        "AbilityModifier": "Modificador de habilidad",
-        "ActionTarget": {
-            "AC15": "CA 15",
-            "AC5": "CA 5",
-            "ChatMessage": " contra {actionTarget}",
-            "EAC": "EAC",
-            "KAC": "KAC",
-            "KAC8": "KAC +8",
-            "None": "Sin objetivo",
-            "Other": "Otro",
-            "StarshipAC": "CA",
-            "StarshipTL": "TL",
-            "Tag": "Objetivos: {actionTarget}",
-            "Title": "Objetivo de la acción",
-            "Tooltip": "Si esta acción tiene como objetivo una propiedad específica, puedes configurarlo aquí."
-        },
-        "ActionType": "Tipo de acción",
-        "AddDamageSection": "Agregar sección de daño",
-        "AddDamageSectionTooltip": "Agrega otra sección de daño a este objeto.",
-        "AttackRollBonus": "Bono a la tirada de ataque",
-        "ChatMessageFlavor": "Texto del mensaje en chat",
-        "CriticalDamageFormula": "Fórmula de daño crítico",
-        "CriticalDamageHeader": "Secciones de daño crítico",
-        "CriticalEffect": "Efecto crítico",
-        "CriticalHealingFormula": "Fórmula de curación crítica",
-        "DamageFormula": "Fórmula de daño",
-        "DamageFormulaTooltip": "La tirada de daño para esta sección de daño.",
-        "DamageHeader": "Secciones de daño",
-        "DamageName": "Nombre del daño",
-        "DamageNameTooltip": "Un nombre que puedes especificar para referenciar fácilmente este elemento de ataque.",
-        "DamageNotes": "Notas de daño",
-        "DamageNotesTooltip": "Las notas de daño se muestran en la tarjeta de tirada de daño en el chat. Es una excelente forma de poner recordatorios útiles, especialmente para los directores de juego con PNJs complicados.",
-        "DamageSection": "Sección de daño {section}",
-        "DeleteDamageSection": "Eliminar sección de daño",
-        "Details": "Detalles de la acción",
-        "HealingFormula": "Fórmula de curación",
-        "OtherFormula": "Otra fórmula",
-        "RollNotes": "Notas de la tirada",
-        "RollNotesTooltip": "Las notas de la tirada se muestran en la tarjeta de tirada de acción en el chat. Es una excelente forma de poner recordatorios útiles, especialmente para los directores de juego con PNJs complicados.",
-        "SavingThrow": "Tirada de salvación",
-        "SkillCheck": "Chequeo de habilidad",
-        "TitleAction": "Acción",
-        "TitleActivation": "Activación"
-    },
-    "Activation": {
-        "Activation": "Activación",
-        "ActivationCondition": "Condición de activación",
-        "ActivationCost": "Costo de activación",
-        "Area": "Área",
-        "Duration": "Duración",
-        "LimitedUses": "Usos limitados",
-        "Range": "Alcance",
-        "RangeIncrement": "Incremento de alcance",
-        "Target": "Objetivo"
-    },
-    "Ammunition": {
-        "Ammo": "Munición",
-        "AmmunitionType": "Tipo de munición",
-        "Capacity": "Configuración de capacidad",
-        "Details": "Detalles de munición",
-        "Type": {
-            "Arrows": "Flechas",
-            "Caustrol": "Caustrol",
-            "Charges": "Cargas",
-            "Darts": "Dardos",
-            "Flares": "Bengalas",
-            "Flechettes": "Flechettes",
-            "Fuel": "Combustible",
-            "HeavyRounds": "Balas pesadas",
-            "Junk": "Chatarra",
-            "LongarmAndSniperRounds": "Balas para armas largas y francotirador",
-            "Missiles": "Misiles",
-            "MoodGoo": "Gel emocional",
-            "Nanites": "Nanites",
-            "None": "Ninguno",
-            "Rockets": "Mini-cohetes",
-            "Sclerites": "Escleritas",
-            "Shells": "Cartuchos",
-            "SmallArmRounds": "Balas para armas cortas",
-            "Thasphalt": "Thasphalt",
-            "ThasteronPellets": "Perdigones de Thasteron"
-        },
-        "UseCapacity": "Usar capacidad"
-    },
-    "Attuned": "Sintonizado",
-    "Augmentation": {
-        "Action": "Acción de aumento",
-        "Details": "Detalles del aumento",
-        "System": "Sistema",
-        "Type": "Tipo",
-        "Usage": "Uso del aumento"
-    },
-    "Capacity": {
-        "Capacity": "Capacidad",
-        "CapacityMaxTooltip": "La cantidad máxima de cargas que este objeto puede contener",
-        "CapacityValueTooltip": "La cantidad actual de cargas",
-        "HeaderTooltip": "La cantidad de rondas, cargas, etc. que puede contener este objeto (por ejemplo, la cantidad de cargas que puede contener una batería)",
-        "Usage": "Uso",
-        "UsageTooltip": "La cantidad de cargas, piezas de munición, etc. que se consumen cuando se usa este objeto.",
-        "UsageValueTooltip": "La unidad de tiempo usada para determinar cuándo se consume la capacidad del objeto."
-    },
-    "Categories": {
-        "AbilityScoreIncrease": "Incrementos de puntuación de habilidad",
-        "Ammunition": "Munición",
-        "Archetypes": "Arquetipos",
-        "Armor": "Armadura",
-        "ArmorUpgrades": "Mejoras de armadura",
-        "Augmentations": "Aumentos",
-        "Classes": "Clases",
-        "Consumables": "Consumibles",
-        "Containers": "Contenedores",
-        "DroneChassis": "Chasis de dron",
-        "DroneMods": "Modificaciones de dron",
-        "Effect": "Efecto",
-        "Equipment": "Armadura",
-        "Feats": "Hazañas",
-        "Goods": "Bienes",
-        "HybridItems": "Objetos híbridos",
-        "MagicItems": "Objetos mágicos",
-        "MiscellaneousItems": "Objetos varios",
-        "Races": "Especies",
-        "Shields": "Escudos",
-        "Spells": "Hechizos",
-        "StarshipAblativeArmors": "Armaduras ablativas para naves",
-        "StarshipArmors": "Armaduras para naves",
-        "StarshipComputers": "Computadoras para naves",
-        "StarshipCrewQuarters": "Alojamientos de tripulación para naves",
-        "StarshipDefensiveCountermeasures": "Contramedidas defensivas para naves",
-        "StarshipDriftEngine": "Motor de deriva para naves",
-        "StarshipExpansionBays": "Bahías de expansión para naves",
-        "StarshipFortifiedHulls": "Casco fortificado para naves",
-        "StarshipFrames": "Casco para naves",
-        "StarshipOtherSystems": "Otros sistemas para naves",
-        "StarshipPowerCores": "Núcleos de energía para naves",
-        "StarshipReinforcedBulkheads": "Mamparos reforzados para naves",
-        "StarshipSecuritySystems": "Sistemas de seguridad para naves",
-        "StarshipSensors": "Sensores para naves",
-        "StarshipShields": "Escudos para naves",
-        "StarshipThrusters": "Propulsores para naves",
-        "StarshipWeapons": "Armas para naves",
-        "TechnologicalItems": "Objetos tecnológicos",
-        "Themes": "Temas",
-        "VehicleAttacks": "Ataques de vehículos",
-        "VehicleSystems": "Sistemas de vehículos",
-        "WeaponAccessories": "Accesorios para armas",
-        "WeaponFusions": "Fusiones de armas",
-        "Weapons": "Armas"
-    }
-,
-           "Consumable": {
-    "Action": "Acción de consumible",
-    "DestroyWhenEmpty": "Destruir cuando esté vacío",
-    "ErrorNoUses": "¡{name} no tiene usos restantes!",
-    "OnUse": "Consumir al usar",
-    "Type": "Tipo de consumible",
-    "Usage": "Uso del consumible",
-    "UseAction": "Usar",
-    "UseChatMessage": "Usa {consumableName}."
-},
-"Description": {
-    "Bulk": "Volumen",
-    "Hands": "Manos",
-    "Level": "Nivel",
-    "Price": "Precio",
-    "Quantity": "Cantidad",
-    "QuantityPerPack": "Tamaño del paquete",
-    "QuantityPerPackTooltip": "El tamaño del paquete se usa para definir cuántos de un mismo objeto compras al precio completo. Por ejemplo, compras 30 balas pequeñas al costo de 40 créditos. Esto ayuda en cálculos de volumen y riqueza, así como en el seguimiento de munición."
-},
-"Equipment": {
-    "Action": "Acción de equipo",
-    "Category": "Tipo de armadura",
-    "ContainerTooltip": "La armadura normalmente puede contener mejoras de armadura u otros objetos. Aumenta la capacidad de almacenamiento para permitir agregar contenido.",
-    "EAC": "Clase de armadura energética",
-    "KAC": "Clase de armadura cinética",
-    "PowerArmorDetails": "Detalles de la armadura motorizada",
-    "SpeedAdjustment": "Ajuste de velocidad"
-},
-"EquipmentStatus": "Estado del equipo",
-"EquipmentUsage": "Uso del equipo",
-"Equippable": "Equipable",
-"Equipped": "Equipado",
-"Feat": {
-    "ActionRecharge": "Recarga de acción",
-    "Charged": "Cargado",
-    "CombatFeat": "Hazaña de combate",
-    "FeatureAttack": "Ataque de la característica",
-    "FeatureCategory": "Categoría de característica",
-    "FeatureDetails": "Detalles de la característica",
-    "FeatureUsage": "Uso de la característica",
-    "RechargeOn": "Recargar en",
-    "Requirements": "Requisitos",
-    "SpecialAbilityType": "Tipo de habilidad especial"
-},
-"Goods": {
-    "Details": "Detalles de bienes"
-},
-"Hybrid": {
-    "Details": "Detalles de objeto híbrido"
-},
-"Identified": "Identificado",
-"Magic": {
-    "Details": "Detalles de objeto mágico",
-    "LimitedWear": "Límite de objetos mágicos equipados",
-    "LimitedWearCheckbox": "Este objeto cuenta para el límite de objetos mágicos equipados.",
-    "LimitedWearExceeded": "¡Has equipado demasiados objetos mágicos!"
-},
-"MaxDex": "Modificador máximo de destreza",
-"NotProficient": "No competente",
-"Proficient": "Competente",
-"RangeInformation": "Información de alcance",
-"Shield": {
-    "ACP": "Penalización por chequeo de armadura: {acp}",
-    "AcMaxDex": "Bono máximo de destreza: {maxDex}",
-    "AcMaxDexLabel": "Bono máximo de destreza",
-    "Action": "Acción de escudo",
-    "Aligned": "Alineado",
-    "ArmorCheck": "Penalización por chequeo de armadura: {acp}",
-    "ArmorCheckLabel": "Penalización por chequeo de armadura",
-    "Bonus": "Bono del escudo",
-    "Bonuses": "Empuñado: {wielded} / Alineado: {aligned}",
-    "Details": "Detalles del escudo",
-    "Dex": "Destreza: {dex}",
-    "Shield": "Escudo",
-    "ShieldBonus": "Escudo: {wielded} / {aligned}",
-    "Wielded": "Empuñado"
-},
-"ShipWeapon": {
-    "Activated": "Activado",
-    "AttackBonus": "Bono de ataque",
-    "BpCost": "Costo de BP",
-    "ItemType": "Arma de nave estelar",
-    "Mounted": "Montado",
-    "NotMounted": "No montado",
-    "PowerCost": "Costo de energía",
-    "Range": "Alcance",
-    "ReloadCost": "10 minutos",
-    "Source": "Fuente",
-    "Speed": "Velocidad: {speed} hexágonos",
-    "WeaponArc": "Arco del arma",
-    "WeaponClass": "Clase del arma",
-    "WeaponStatus": "Estado del arma"
-},
-"SpecialMaterials": {
-    "Title": "Materiales especiales"
-},
-"Spell": {
-    "AllowedClasses": "Clases permitidas",
-    "Casting": "Lanzamiento de hechizo",
-    "Concentration": "Concentración",
-    "ConcentrationTooltip": "Este hechizo requiere concentración.<br/>Debes usar la acción 'Concentrarse para mantener el hechizo' (CRB pág. 246) para mantenerlo.",
-    "Consumed": "Consumido",
-    "Cost": "Costo (Cr)",
-    "Details": "Detalles del hechizo",
-    "Dismissible": "Descartable",
-    "Effects": "Efectos del hechizo",
-    "ErrorNoUses": "No se pudo lanzar el hechizo porque no quedan usos. Haz clic en este mensaje para descartarlo.",
-    "IsVariableLevel": "¿Nivel variable?",
-    "IsVariableLevelYes": "Sí",
-    "Level": "Nivel del hechizo",
-    "PreparationMode": "Modo de preparación del hechizo",
-    "Prepared": "Preparado",
-    "Properties": "Propiedades del hechizo",
-    "Resistance": "Resistencia al hechizo",
-    "School": "Escuela del hechizo",
-    "SpellcastingMaterials": "Materiales para lanzamiento",
-    "Supply": "Suministro"
-},
-"Technological": {
-    "Details": "Detalles del objeto tecnológico"
-},
-"Theme": {
-    "AbilityAdjustment": "Ajuste de habilidad",
-    "Details": "Detalles del tema",
-    "Skill": "Habilidad"
-},
-"Unlimited": "Ilimitado",
-"Upgrade": {
-    "AllowedArmorType": "Tipo de armadura permitida",
-    "Any": "Cualquiera",
-    "ArmorUpgradeDetails": "Detalles de mejora de armadura",
-    "Slots": "Ranuras"
-},
-"VehicleAttack": {
-    "Type": "Ataque de vehículo"
-},
-"VehicleSystem": {
-    "Type": "Sistema de vehículo"
-},
-"Weapon": {
-    "Attack": "Ataque de arma",
-    "Category": "Categoría de arma",
-    "Details": "Detalles del arma",
-    "IsEquipment": {
-        "Title": "El arma es equipo",
-        "Tooltip": "Esta casilla se marca si el arma es un equipo que se lleva, en lugar de un arma natural o sobrenatural innata. Para armas naturales, desmarca esta casilla."
-    },
-    "Properties": "Propiedades del arma",
-    "Type": "Tipo de arma",
-    "Usage": "Uso del arma"
-},
-"WeaponAccessory": {
-    "SupportedType": {
-        "Any": "Cualquiera",
-        "HeavyWeapon": "Arma pesada",
-        "MeleeWeapon": "Arma cuerpo a cuerpo",
-        "MeleeWeaponSA": "Arma cuerpo a cuerpo y arma pequeña",
-        "Projectile": "Proyectil",
-        "RailedWeapon": "Arma sobre riel",
-        "RailedWeaponSA": "Arma sobre riel y arma pequeña",
-        "SmallArm": "Arma pequeña"
-    }
-} }
-,
-        "KeyAbility": "Característica clave",
-"KineticArmorClass": "CA Cinética",
-"KineticArmorClassShort": "CAC",
-"Languages": "Idiomas",
-"LanguagesAballonian": "Aballonian",
-"LanguagesAbyssal": "Abisal",
-"LanguagesAglian": "Aglian",
-"LanguagesAkan": "Akan",
-"LanguagesAkitonian": "Akitonian",
-"LanguagesAklo": "Aklo",
-"LanguagesAlkainish": "Alkainish",
-"LanguagesAnassan": "Anassan",
-"LanguagesAncientDaimalkan": "Antiguo Daimalkan",
-"LanguagesAquan": "Aquan",
-"LanguagesArkanen": "Arkanen",
-"LanguagesAstriapi": "Astriapi",
-"LanguagesAuran": "Auran",
-"LanguagesAzlanti": "Azlanti",
-"LanguagesBantridi": "Bantridi",
-"LanguagesBarathu": "Barathu",
-"LanguagesBolidan": "Bolidan",
-"LanguagesBrenneri": "Brenneri",
-"LanguagesBrethedan": "Brethedan",
-"LanguagesCastrovelian": "Castrovelian",
-"LanguagesCelestial": "Celestial",
-"LanguagesCommon": "Común",
-"LanguagesCopaxi": "Copaxi",
-"LanguagesCyrunian": "Cyrunian",
-"LanguagesDaimalkan": "Daimalkan",
-"LanguagesDirindi": "Dirindi",
-"LanguagesDraconic": "Dracónico",
-"LanguagesDromadan": "Dromadan",
-"LanguagesDrow": "Drow",
-"LanguagesDwarven": "Enano",
-"LanguagesElven": "Elfo",
-"LanguagesEmbri": "Embri",
-"LanguagesEndiffian": "Endiffian",
-"LanguagesEoxian": "Eoxian",
-"LanguagesEspraksi": "Espraksi",
-"LanguagesFerran": "Ferran",
-"LanguagesFirstSpeech": "Primer Habla",
-"LanguagesFrujai": "Frujai",
-"LanguagesGaraggakal": "Garaggakal",
-"LanguagesGathol": "Gathol",
-"LanguagesGhibran": "Ghibran",
-"LanguagesGhoran": "Ghoran",
-"LanguagesGiant": "Gigante",
-"LanguagesGnome": "Gnomo",
-"LanguagesGoblin": "Goblin",
-"LanguagesGosclaw": "Gosclaw",
-"LanguagesGrioth": "Grioth",
-"LanguagesGytchean": "Gytchean",
-"LanguagesHadrogaan": "Hadrogaan",
-"LanguagesHalfling": "Mediano",
-"LanguagesHallas": "Hallas",
-"LanguagesHortaa": "Hortaa",
-"LanguagesIgnan": "Ignan",
-"LanguagesIhonva": "Ihonva",
-"LanguagesIji": "Iji",
-"LanguagesIlthisarian": "Ilthisarian",
-"LanguagesInfernal": "Infernal",
-"LanguagesIxtangi": "Ixtangi",
-"LanguagesIzalguun": "Izalguun",
-"LanguagesJinsul": "Jinsul",
-"LanguagesKalo": "Kalo",
-"LanguagesKasatha": "Kasatha",
-"LanguagesKatholbi": "Katholbi",
-"LanguagesKiirinta": "Kiirinta",
-"LanguagesKoshorian": "Koshorian",
-"LanguagesKothama": "Kothama",
-"LanguagesLexonian": "Lexonian",
-"LanguagesLumos": "Lumos",
-"LanguagesMaraquoi": "Maraquoi",
-"LanguagesMegalonic": "Megalonic",
-"LanguagesMi-Go": "Mi-Go",
-"LanguagesMorlamaw": "Morlamaw",
-"LanguagesMulkaxi": "Mulkaxi",
-"LanguagesNchaki": "Nchaki",
-"LanguagesNoma": "Noma",
-"LanguagesOrbian": "Orbian",
-"LanguagesOrc": "Orco",
-"LanguagesOrrian": "Orrian",
-"LanguagesOsharu": "Osharu",
-"LanguagesPahtra": "Pahtra",
-"LanguagesParalithi": "Paralithi",
-"LanguagesPerani": "Perani",
-"LanguagesProtean": "Proteano",
-"LanguagesPsacynoa": "Psacynoa",
-"LanguagesQuorlu": "Quorlu",
-"LanguagesRaxi": "Raxi",
-"LanguagesReptoid": "Reptoide",
-"LanguagesRequian": "Requian",
-"LanguagesSarcesian": "Sarcesian",
-"LanguagesSazaron": "Sazaron",
-"LanguagesScreedreep": "Screedreep",
-"LanguagesScyphozoan": "Scyphozoan",
-"LanguagesSelamidian": "Selamidian",
-"LanguagesSeprevoi": "Seprevoi",
-"LanguagesShadowtongue": "Lengua Sombría",
-"LanguagesShimreeni": "Shimreeni",
-"LanguagesShirren": "Shirren",
-"LanguagesShobhad": "Shobhad",
-"LanguagesSivvian": "Sivvian",
-"LanguagesSpathinae": "Spathinae",
-"LanguagesStarsong": "Canción Estelar",
-"LanguagesStroxha": "Stroxha",
-"LanguagesSylvan": "Silvano",
-"LanguagesTelian": "Telian",
-"LanguagesTerran": "Terrano",
-"LanguagesTriaxian": "Triaxian",
-"LanguagesTrinir": "Trinir",
-"LanguagesTromlin": "Tromlin",
-"LanguagesUrog": "Urog",
-"LanguagesVarratana": "Varratana",
-"LanguagesVercite": "Vercite",
-"LanguagesVesk": "Vesk",
-"LanguagesVlakan": "Vlakan (lengua de señas, hablada y táctil)",
-"LanguagesVulgarKishaleen": "Kishaleen vulgar",
-"LanguagesWoiokan": "Woiokan",
-"LanguagesWorlanisi": "Worlanisi",
-"LanguagesWrikreechee": "Wrikreechee",
-"LanguagesXaarb": "Xaarb",
-"LanguagesYsoki": "Ysoki",
-"LevelLabel": "Nivel de hechizo",
-"LevelLabelText": "Nivel",
-"Levels": {
-    "0": "0",
-    "1": "1º",
-    "10": "10º",
-    "11": "11º",
-    "12": "12º",
-    "13": "13º",
-    "14": "14º",
-    "15": "15º",
-    "16": "16º",
-    "17": "17º",
-    "18": "18º",
-    "19": "19º",
-    "2": "2º",
-    "20": "20º",
-    "3": "3º",
-    "4": "4º",
-    "5": "5º",
-    "6": "6º",
-    "7": "7º",
-    "8": "8º",
-    "9": "9º"
-
-        },
-        "LightningReflexesHint": "Hazaña de personaje que añade 2 a las tiradas de salvación de reflejos",
-"LightningReflexesLabel": "Reflejos Relámpago",
-"LimitedUsePeriodsCharges": "Cargas",
-"LimitedUsePeriodsDay": "Día",
-"LimitedUsePeriodsLong": "Descanso Completo",
-"LimitedUsePeriodsShort": "Descanso de 10 minutos",
-"LocalizationTerminator": "",
-"Long": "Largo",
-"Macro": {
-    "ViewActor": "Ver Personaje",
-    "ViewItem": "Ver Objeto"
-},
-"Magic": {
-    "Levels": {
-        "0": "Nivel 0",
-        "1": "1er Nivel",
-        "2": "2º Nivel",
-        "3": "3er Nivel",
-        "4": "4º Nivel",
-        "5": "5º Nivel",
-        "6": "6º Nivel"
-    },
-    "Schools": {
-        "Abjuration": "Abjuración",
-        "Conjuration": "Conjuración",
-        "Divination": "Adivinación",
-        "Enchantment": "Encantamiento",
-        "Evocation": "Evocación",
-        "Illusion": "Ilusión",
-        "Necromancy": "Nigromancia",
-        "Transmutation": "Transmutación",
-        "Universal": "Universal"
-    }
-},
-"Magitech": "Magitecnología",
-"Medium": "Medio",
-"Meter": "Metro",
-"Mi": "Millas",
-"MigrationBeginingMigration": "Intentando aplicar la migración del sistema Starfinder a la versión {systemVersion}. Por favor, tenga paciencia y no cierre su juego ni apague su servidor.",
-"MigrationEndMigration": "La migración del sistema Starfinder a la versión {systemVersion} fue exitosa.",
-"MigrationErrorMessage": "Hubo un error migrando sus datos de Starfinder, ¿seguro que hizo una copia de seguridad?",
-"MigrationSuccessfulMessage": "Sus datos de Starfinder se migraron correctamente a la versión actual.",
-"MigrationSuccessfulRefreshMessage": "Sus datos de Starfinder se migraron correctamente a la versión actual. Por favor, refresque el juego para finalizar la migración.",
-"ModifierACPEffectingArmorTypeAll": "Todas las armaduras",
-"ModifierACPEffectingArmorTypeHeavy": "Solo armaduras pesadas",
-"ModifierACPEffectingArmorTypeLight": "Solo armaduras ligeras",
-"ModifierACPEffectingArmorTypePower": "Solo armaduras potentes",
-"ModifierAppTitle": "Editar modificador: {name}",
-"ModifierArmorClassBoth": "Ambos",
-"ModifierEffectTypeAC": "Clase de Armadura",
-"ModifierEffectTypeACP": "Penalización por Armadura",
-"ModifierEffectTypeAbilityCheck": "Chequeo de Característica",
-"ModifierEffectTypeAbilityChecks": "Chequeos de Característica",
-"ModifierEffectTypeAbilityScore": "Puntuación de Característica",
-"ModifierEffectTypeAbilitySkills": "Habilidades de Característica",
-"ModifierEffectTypeAllSkills": "Todas las habilidades",
-"ModifierEffectTypeCMD": "CA vs Maniobras de Combate",
-"ModifierEffectTypeHeaderLabel": "Atributo afectado",
-"ModifierEffectTypeInit": "Iniciativa",
-"ModifierEffectTypeLabel": "Atributo afectado",
-"ModifierEffectTypeSave": "Tirada de salvación específica",
-"ModifierEffectTypeSaves": "Todas las tiradas de salvación",
-"ModifierEffectTypeSkill": "Habilidad específica",
-"ModifierEffectTypeTooltip": "Identifica el atributo general o atributos afectados por el modificador",
-"ModifierEnabledLabel": "Habilitado",
-"ModifierEnabledTooltip": "Determina si el modificador se tendrá en cuenta al calcular los modificadores de atributos",
-"ModifierLimitToContainer": "Contenedor del objeto padre",
-"ModifierLimitToLabel": "Limitar a",
-"ModifierLimitToParent": "Objeto padre",
-"ModifierLimitToTooltip": "<strong>Limitar a</strong><br><br><strong>Ninguno</strong><p>El modificador se aplicará a los objetos correspondientes normalmente.</p><strong>Objeto padre</strong><p>El modificador solo se aplicará al objeto en el que está este modificador.</p><strong>Contenedor del objeto padre</strong><p>El modificador solo se aplicará al contenedor que contiene el objeto con este modificador.</p>",
-"ModifierModifierLabel": "Modificador",
-"ModifierModifierTooltip": "El valor utilizado para modificar.",
-"ModifierModifierTypeLabel": "Tipo de modificador",
-"ModifierModifierTypeTooltip": "Un modificador puede ser un valor constante que siempre se aplica o un modificador situacional que solo se aplica en ciertas situaciones.",
-"ModifierNameLabel": "Nombre",
-"ModifierNameTooltip": "El nombre del modificador",
-"ModifierNotesLabel": "Notas",
-"ModifierNotesTooltip": "Notas específicas sobre este modificador",
-"ModifierSaveHighest": "Mayor",
-"ModifierSaveLowest": "Menor",
-"ModifierSourceLabel": "Origen",
-"ModifierSourceTooltip": "¿De dónde proviene este modificador? Ej. Un objeto, hechizo u otro personaje",
-"ModifierTitle": "Modificador",
-"ModifierTypeAbility": "Característica",
-"ModifierTypeArmor": "Armadura",
-"ModifierTypeBase": "Base",
-"ModifierTypeCircumstance": "Circunstancia",
-"ModifierTypeConstant": "Modificador constante",
-"ModifierTypeDivine": "Divino",
-"ModifierTypeEnhancement": "Mejora",
-"ModifierTypeFormula": "Modificador situacional",
-"ModifierTypeInsight": "Perspicacia",
-"ModifierTypeLabel": "Tipo",
-"ModifierTypeLuck": "Suerte",
-"ModifierTypeMorale": "Moral",
-"ModifierTypeRacial": "Racial",
-"ModifierTypeResistance": "Resistencia",
-"ModifierTypeTooltip": "Tipo de modificador. Usado para calcular cuál usar cuando hay múltiples del mismo tipo (generalmente el más alto).",
-"ModifierTypeUntyped": "Sin tipo",
-"ModifierTypeWeaponSpecialization": "Especialización de arma",
-"ModifierValueAffectedHeaderLabel": "Valor afectado",
-"ModifierValueAffectedLabel": "Valor específico afectado",
-"ModifierValueAffectedTooltip": "Identifica un valor específico afectado si el atributo general tiene muchos posibles valores",
-"Modifiers": "Modificadores",
-"ModifiersConditionsTabLabel": "Efectos",
-"ModifiersItemTabLabel": "Objeto",
-"ModifiersMiscTabLabel": "Misceláneo",
-"ModifiersPermanentTabLabel": "Permanente",
-"ModifiersTemporaryTabLabel": "Temporal",
-"NPCSheet": {
-    "Biography": {
-        "Organization": {
-            "GroupSize": "Tamaño de la organización",
-            "GroupSizeTooltip": "El tamaño de la organización va desde el grupo típico más pequeño (usualmente 1) hasta el grupo típico más grande. Esto se usa principalmente en el navegador de alienígenas para encontrar criaturas que coincidan con el filtro de tamaño de grupo."
-        }
-
-
+            "Details": {
+                "Speed": {
+                    "SpecialPlaceholder": "Sin movimiento especial"
+                }
             },
             "Features": {
-    "Actions": "Acciones",
-    "ActiveItems": "Hazañas Activas",
-    "Attacks": "Ataques",
-    "Drone": "Objetos del Drone",
-    "Features": "Hazañas Pasivas"
-},
-"Header": {
-    "AbilityDC": "DC de Habilidad",
-    "AbilityDCTooltip": "El DC de habilidad que tiene este PNJ. Todas las habilidades del PNJ que requieren una tirada de salvación normalmente usan este valor, a menos que sean conjuros.<br/><br/>Esto puede que no esté completamente integrado en todas las habilidades todavía.",
-    "AlignmentPlaceHolderText": "BN",
-    "AuraPlaceHolderText": "Aura",
-    "BaseSpellDC": "DC base de conjuro",
-    "BaseSpellDCTooltip": "El DC base de conjuro que tiene este PNJ. Todos los conjuros del PNJ que requieren tirada de salvación suelen usar este valor, más el nivel del conjuro.",
-    "NamePlaceHolderText": "Nombre del Personaje",
-    "RaceAndGraftsPlaceHolderText": "Género, Especie y Clase/Implantes",
-    "SourcePlaceHolderText": "Fuente",
-    "SubtypePlaceHolderText": "Subtipo",
-    "TypePlaceHolderText": "Tipo"
-},
-"Interface": {
-    "Conditions": {
-        "Warning": "Los PNJs de estilo antiguo no soportan cálculos automáticos de modificadores, convierte este PNJ al estilo nuevo usando el botón duplicar en la pestaña de Atributos."
-    },
-    "CreateItem": {
-        "Button": "Crear objeto",
-        "Name": "Objeto nuevo",
-        "Note": "Selecciona el tipo de objeto que quieres crear.",
-        "Title": "Crear nuevo objeto"
-    },
-    "DuplicateNewStyle": {
-        "Button": "Duplicar como PNJ estilo nuevo",
-        "ButtonTooltip": "Al hacer clic en este botón se creará una hoja de PNJ estilo nuevo, duplicando los datos y objetos de este actor.",
-        "DialogCancelButton": "Cancelar",
-        "DialogMessage": "Estás duplicando un token actor desvinculado, ¿quieres crear el PNJ estilo nuevo usando los datos del actor desvinculado o los datos de la hoja original?",
-        "DialogOriginalActorButton": "Duplicar actor original",
-        "DialogTitle": "¿Usar actor original?",
-        "DialogUnlinkedActorButton": "Duplicar actor desvinculado",
-        "ErrorCreateActor": "Hubo un error al convertir este actor. Revisa tus permisos de usuario.<br/><br/>Haz clic para cerrar."
-    },
-    "Navigation": {
-        "Conditions": "Condiciones"
-    }
-},
-"Inventory": {
-    "Inventory": "Inventario"
-         }
-        },
-"Necrograft": "Necroimplante",
-"None": "Ninguno",
-"Notes": "Notas",
-"NpcToggleSkillsDialogTitle": "Alternar habilidades del PNJ",
-"NumberOfArms": "Número de brazos",
-"Organization": "Organización",
-"Passive": "Pasivo",
-"Personal": "Personal",
-"PersonalUpgrade": "Mejora personal",
-"Plane": "Plano",
-"Planetary": "Planetario",
-"RaceAbilityAdjustmentAny": "Cualquiera",
-"RaceAbilityAdjustments": "Ajustes de habilidad",
-"RaceAddAbilityAdjustment": "Agregar ajuste",
-"RaceHitPoints": "Puntos de vida",
-"RacePlaceHolderText": "Especie",
-"RaceSize": "Tamaño",
-"RacialTraits": "Rasgos de especie",
-"RangeCalculated": "{rangeType} ({total} pies)",
-"RangeClose": "Corto (25 pies + 5 pies/2 niveles)",
-"RangeLong": "Largo (400 pies + 40 pies/nivel)",
-"RangeMedium": "Medio (100 pies + 10 pies/nivel)",
-"Reach": "Alcance",
-"ReflexSave": "Reflejos",
-"RepairDroneChatMessage": "{name} fue reparado por {regainedHP} puntos de vida.",
-"RepairDroneDialogCancelButton": "Cancelar",
-"RepairDroneDialogDescription": "¿Reparar tu drone? La tasa por defecto es hasta el 10% del HP máximo del drone cada 10 minutos. Si tienes la hazaña Reparar Drone (Ex), puedes reparar hasta el 25% del HP máximo del drone.",
-"RepairDroneDialogImprovedFeat": "Usar reglas de la hazaña Reparar Drone (Ex)",
-"RepairDroneDialogRepairButton": "Reparar",
-"RepairDroneDialogTitle": "Reparar Drone",
-"RepairDroneUnnecessary": "{name} ya tiene el máximo de puntos de vida, no necesita reparaciones.",
-"Resolve": "Determinación",
-"Rest": {
-    "Button": "Descansar",
-    "Cancel": "Cancelar",
-    "Long": {
-        "ChatMessage": {
-            "AbilityDamage": "Daño reducido en {amount} de {ability}",
-            "Header": "{name} toma un descanso completo y recupera:",
-            "HeaderNoRecovery": "{name} toma un descanso completo.",
-            "HitPoints": "{deltaHP} puntos de vida",
-            "Item": "El objeto '{itemName}' ha recargado sus usos.",
-            "ResolvePoints": "{deltaRP} puntos de determinación",
-            "SpellSlots": "{deltaSS} espacios de conjuro",
-            "StaminaPoints": "{deltaSP} puntos de resistencia"
-        },
-        "Dialog": {
-            "Description": "<p>¿Tomar un descanso completo?</p><p>Con un descanso completo recuperarás 1 punto de vida por nivel de personaje, todos los puntos de resistencia, puntos de determinación, recursos de clase, cargas de objetos de uso limitado y espacios de conjuro.</p>",
-            "Title": "Descanso Completo"
-        },
-        "Title": "Descanso completo"
-    },
-    "Short": {
-        "ActionHeader": "¿Gastar un punto de determinación?",
-        "ChatMessage": {
-            "Message": "{name} toma un descanso de 10 minutos.",
-            "Restored": "{name} toma un descanso de 10 minutos y gastó {spentRP} puntos de determinación para recuperar {regainedSP} puntos de resistencia."
-        },
-        "DialogDescription": "¿Tomar un descanso de 10 minutos? En un descanso de 10 minutos puedes gastar un punto de determinación para recuperar todos los puntos de resistencia.",
-        "DialogTitle": "Descanso de 10 minutos",
-        "Title": "Descanso corto"
+                "Chassis": "Chasis",
+                "Feats": {
+                    "Active": "Hazañas activas",
+                    "Header": "Hazañas (Cantidad: {current} de {max})",
+                    "Passive": "Hazañas pasivas"
+                },
+                "Mods": "Modificaciones (Cantidad: {current} de {max})",
+                "ModsFree": "Gratis"
+            },
+            "Header": {
+                "Actions": {
+                    "Header": "Acciones",
+                    "Repair": "Reparar"
+                },
+                "Defense": "Defensa",
+                "Owner": "Propietario"
+            },
+            "Inventory": {
+                "ArmorUpgrades": "Mejoras de armadura (Equipadas {current} de {max} ranuras de armadura)",
+                "CarriedItems": "Objetos transportados",
+                "Weapons": {
+                    "Both": "Armas (Montajes de armas equipados: Cuerpo a cuerpo {meleeCurrent} de {meleeMax}, A distancia {rangedCurrent} de {rangedMax})",
+                    "MeleeOnly": "Armas (Montajes de armas equipados: Cuerpo a cuerpo {meleeCurrent} de {meleeMax})",
+                    "None": "Armas",
+                    "RangedOnly": "Armas (Montajes de armas equipados: A distancia {rangedCurrent} de {rangedMax})"
+                }
+            },
 
+            "Mod": {
+                "Details": {
+                    "Arms": {
+                        "Amount": "Número de brazos",
+                        "ArmType": {
+                            "General": "Uso general",
+                            "Label": "Tipo de brazo",
+                            "Melee": "Montura de arma cuerpo a cuerpo",
+                            "Ranged": "Montura de arma a distancia"
+                        },
+                        "Header": "Brazos"
+                    },
+                    "BaseStatistics": {
+                        "FreeInstall": "Módulo gratuito",
+                        "FreeInstallLabel": "Excluir módulo del conteo de módulos",
+                        "Header": "Estadísticas base",
+                        "MaxInstalls": "Máximo de instalaciones"
+                    },
+                    "OtherEffects": {
+                        "AdditionalSenses": "Sentidos adicionales",
+                        "ArmorSlot": "Es ranura de armadura",
+                        "BonusSkill": "Habilidad adicional",
+                        "Header": "Otros efectos",
+                        "SpeedSpecial": "Movimiento especial",
+                        "SpellResistance": "Resistencia a conjuros",
+                        "WeaponProficiency": "Competencia con armas"
+                    }
+                },
+                "Name": {
+                    "Placeholder": "Nombre del mod"
+                },
+                "Source": "Fuente",
+                "SourceTooltip": "¿De dónde proviene este mod del dron? ¿Qué libro? ¿Qué página?"
+            },
+            "Skills": {
+                "NoSkillsAvailable": "Este dron no tiene habilidades disponibles."
+            },
+            "Traits": {
+                "ArmorSlots": "Ranuras de armadura",
+                "GeneralPurposeArms": "Brazos de uso general",
+                "MeleeWeaponMounts": "Monturas de armas cuerpo a cuerpo",
+                "RangedWeaponMounts": "Monturas de armas a distancia"
+            }
+        },
+        "DurationTypesInstantaneous": "Instantáneo",
+        "Effect": {
+            "DetailsEnabledLabel": "Habilitado",
+            "DetailsHeader": "Detalles del efecto",
+            "DetailsShowOnToken": "Mostrar en ficha",
+            "DurationTypesDays": "Días",
+            "DurationTypesHours": "Horas",
+            "DurationTypesLabel": "Duración",
+            "DurationTypesMinutes": "Minutos",
+            "DurationTypesNone": "Ninguno",
+            "DurationTypesPermanent": "Permanente",
+            "DurationTypesRounds": "Asaltos",
+            "EndTypesLabel": "Termina en",
+            "EndTypesOnTurnEnd": "Fin del turno",
+            "EndTypesOnTurnStart": "Inicio del turno",
+            "EndsOnTooltip": "<br><strong>Turno del actor principal</strong><p>El efecto expirará al inicio/fin del turno del actor al que pertenece.</p><strong>Turno del actor de origen</strong><p>El efecto expirará al inicio/fin del turno del actor del que fue arrastrado.</p><strong>Iniciativa más cercana</strong><p>El efecto expirará al inicio/fin del turno con la iniciativa más cercana al turno en que se activó.</p><strong>Turnos del combatiente</strong><p>El efecto expirará al inicio/fin del turno del combatiente especificado.</p>",
+            "Expired": "Expirado",
+            "ExpiryModeInit": "Conteo de iniciativa",
+            "ExpiryModeLabel": "Modo de expiración",
+            "ExpiryModeTooltip": "<br><strong>Turno del combatiente</strong><p>El efecto expirará al inicio/fin de un turno especificado.</p><strong>Conteo de iniciativa</strong><p>El efecto expirará cuando el combate actual alcance el conteo de iniciativa especificado.</p>",
+            "ExpiryModeTurn": "Turno del combatiente"
+        },
+        "Enabled": "Habilitado",
+        "EnergyArmorClass": "CA de energía",
+        "EnergyArmorClassShort": "CAE",
+        "Enrichers": {
+            "Icon": {
+                "Types": {
+                    "Graviton": "Gravitón",
+                    "LanguageDependent": "Dependiente del lenguaje",
+                    "MindAffecting": "Afecta la mente",
+                    "Photon": "Fotón",
+                    "SenseDependent": "Dependiente del sentido"
+                }
+            },
+            "SendToChat": "Enviar al chat",
+            "TypeError": "¡Fallo al analizar {enricherType}! Tipo inválido."
+        },
+        "Environment": "Entorno",
+        "FeatTypes": {
+            "Combat": "Hazañas de combate",
+            "General": "Hazañas generales"
+        },
+        "FeatureCategory": {
+            "ArchetypeFeature": "Característica de arquetipo",
+            "ClassFeature": "Característica de clase",
+            "Feat": "Hazaña",
+            "OtherFeature": "Otra característica",
+            "SpeciesFeature": "Característica de especie",
+            "ThemeFeature": "Característica temática",
+            "UniversalCreatureRule": "Regla universal de criatura"
+        },
+        "Features": "Características",
+        "FeaturesAdd": "Agregar",
+        "FeaturesCharges": "Cargas",
+        "FeaturesFilter": "Filtrar",
+        "FeaturesUsage": "Uso",
+        "FlagDeprecationNotice": "<strong>NOTA:</strong> Estos valores están siendo reemplazados por el nuevo sistema de modificadores y serán eliminados en una actualización futura. Se recomienda desmarcar cualquiera de estos valores y agregarlos como modificador en la pestaña de Modificadores.",
+        "FlagsEmptySolarian": "No hay rasgos especiales por el momento. Si buscas Sintonía Solariana, usa el nuevo sistema de recursos de actor dentro de la característica de clase Modo Estelar.",
+        "FlagsInstructions": "Configura características y rasgos de personaje que ajustan los comportamientos del sistema Starfinder.",
+        "FlagsSave": "Actualizar rasgos especiales",
+        "FlagsTitle": "Configurar rasgos especiales",
+        "FloatingHP": {
+            "HP": "PG",
+            "Sh.A.": "Sh.A.",
+            "Sh.F.": "Sh.F.",
+            "Sh.P.": "Sh.P.",
+            "Sh.S.": "Sh.S.",
+            "stamina": "PE",
+            "temp": "Temp"
+        },
+        "FloatingHPVerbose": {
+            "HP": "PG",
+            "Sh.A.": "Escudos traseros",
+            "Sh.F.": "Escudos frontales",
+            "Sh.P.": "Escudos de babor",
+            "Sh.S.": "Escudos de estribor",
+            "stamina": "PE",
+            "temp": "Temp"
+        },
+        "FortitudeSave": "Fortaleza",
+        "Ft": "Pies",
+        "GreatFortitudeHint": "Hazaña de personaje que añade 2 a tiradas de salvación de Fortaleza",
+        "GreatFortitudeLabel": "Gran fortaleza",
+        "HazardSheet": {
+            "Details": {
+                "Attributes": {
+                    "Bypass": "Bypass",
+                    "BypassTooltip": "(Opcional) Algunas trampas tienen un mecanismo de bypass que permite al creador de la trampa u otros usuarios desactivarla temporalmente.",
+                    "Duration": "Duración",
+                    "DurationTooltip": "(Opcional) Si una trampa tiene una duración mayor que instantánea, se indica aquí. Tal trampa continúa produciendo su efecto durante varios asaltos en su conteo de iniciativa.",
+                    "Header": "Atributos",
+                    "Initiative": "Iniciativa",
+                    "InitiativeTooltip": "(Opcional) Algunas trampas lanzan iniciativa para determinar cuándo se activan en una ronda de combate.",
+                    "Reset": "Reiniciar",
+                    "ResetPlaceholder": "Ninguno, Manual, 1 minuto, etc.",
+                    "ResetTooltip": "Esto indica cuánto tiempo tarda una trampa en reiniciarse automáticamente.",
+                    "Trigger": "Disparador",
+                    "TriggerPlaceholder": "Ubicación, proximidad, toque, etc.",
+                    "TriggerTooltip": "El disparador de una trampa determina cómo se activa. Salvo que se indique lo contrario, las criaturas más pequeñas que diminutas no activan trampas normalmente."
+                },
+                "DCs": {
+                    "Disable": "Desactivar",
+                    "DisableTooltip": "Esta es la CD para desactivar la trampa usando la(s) habilidad(es) listada(s).",
+                    "Header": "CDs",
+                    "Notice": "Percepción",
+                    "NoticePlaceholder": "ej. CD de Percepción 10",
+                    "NoticeTooltip": "Esta es la CD para encontrar la trampa usando Percepción."
+                },
+                "Effects": {
+                    "Effect": "Efecto",
+                    "EffectTooltip": "Esto lista el efecto que la trampa tiene sobre quienes la activan.",
+                    "Header": "Efectos"
+                },
+                "Vitals": {
+                    "Defenses": {
+                        "EAC": "CAE",
+                        "EACTooltip": "Si las partes mecánicas de tu trampa pueden ser atacadas, este valor ayuda a determinar qué tan fácil es acertar.",
+                        "Hardness": "Dureza",
+                        "HardnessTooltip": "Las trampas tienen una dureza basada en su material.",
+                        "Header": "Defensas",
+                        "Hitpoints": "Puntos de golpe",
+                        "HitpointsTooltip": "Partes cruciales de algunas trampas pueden ser dañadas y deben tener el número listado de Puntos de Golpe. Las trampas son inmunes a todo aquello a lo que un objeto es inmune, salvo que se indique lo contrario. Una trampa reducida a 0 PG queda destruida. Destruir una trampa puede activar un componente final de la trampa, como una explosión. Las trampas nunca tienen Puntos de Resistencia.",
+                        "KAC": "CAC",
+                        "KACTooltip": "Si las partes mecánicas de tu trampa pueden ser atacadas, este valor ayuda a determinar qué tan fácil es acertar."
+                    },
+                    "Offense": {
+                        "Attack": "Ataque",
+                        "AttackTooltip": "(Opcional) El bono de ataque de la trampa se usa si ataca directamente a un objetivo.",
+                        "Damage": "Daño",
+                        "DamageTooltip": "(Opcional) El daño promedio de la trampa se usa si ataca directamente a un objetivo, pero considera reducir este daño si una trampa tiene múltiples ataques o afecta a múltiples objetivos.",
+                        "Header": "Ofensiva"
+                    },
+                    "Saves": {
+                        "Fortitude": "Salvación de Fortaleza",
+                        "FortitudeTooltip": "Si los jugadores usan ataques especiales que pueden apuntar a objetos contra la trampa, este valor puede usarse para la salvación de Fortaleza de la trampa.",
+                        "Header": "Tiradas de salvación",
+                        "Reflex": "Salvación de Reflejos",
+                        "ReflexTooltip": "Si los jugadores usan ataques especiales que pueden apuntar a objetos contra la trampa, este valor puede usarse para la salvación de Reflejos de la trampa.",
+                        "Will": "Salvación de Voluntad",
+                        "WillTooltip": "Las trampas normalmente no necesitan salvaciones de Voluntad, pero si es necesario, la salvación de Voluntad de una trampa es mala."
+                    }
+                }
+            },
+
+            "Header": {
+                "NamePlaceholder": "Nombre del peligro",
+                "SourcePlaceholder": "Fuente",
+                "TypePlaceholder": "Analógico, Mágico, Tecnológico, Híbrido"
+            },
+            "Notifications": {
+                "NoDamage": "No se ingresó valor para el daño, no se puede hacer una tirada para {name}."
+            },
+            "Rolls": {
+                "Attack": "Ataque - {name}",
+                "Damage": "Daño - {name}",
+                "Fortitude": "Tirada de Salvación de Fortaleza - {name}",
+                "Reflex": "Tirada de Salvación de Reflejos - {name}",
+                "Will": "Tirada de Salvación de Voluntad - {name}"
+            },
+            "Tabs": {
+                "Vitals": "Datos vitales"
+            }
+        },
+        "HealingTypesHealing": "Curación",
+        "Health": "Puntos de Golpe",
+        "HullPoints": "Puntos de Casco",
+        "ImprovedInitiativeHint": "Hazaña de personaje que añade 4 a su tirada de iniciativa",
+        "ImprovedInitiativeLabel": "Iniciativa Mejorada",
+        "InitiativeDexModTooltip": "Modificador de Destreza: {mod}",
+        "InitiativeLabel": "Iniciativa",
+        "InitiativeModiferLabel": "Mod",
+        "InitiativeModiferTooltip": "Bono de {type}: {mod} ({source})",
+        "InvalidItem": "{name} es un objeto inválido para un {target}.",
+        "InvalidStarshipItem": "{name} es un objeto inválido para una nave estelar.",
+        "Inventory": "Inventario",
+        "InventoryAdd": "Agregar",
+        "InventoryBulk": "Peso",
+        "InventoryCapacity": "Capacidad",
+        "InventoryCurrency": "Moneda",
+        "InventoryEquipped": "Equipado",
+        "InventoryNotEquipped": "No equipado",
+        "InventoryUsage": "Uso",
+        "IronWillHint": "Hazaña de personaje que añade 2 a tiradas de salvación de Voluntad",
+        "IronWillLabel": "Voluntad de Hierro",
+        "ItemBonusTooltip": "Bono de objeto: {mod} ({source})",
+        "ItemCollectionSheet": {
+            "ItemCollectionLocked": "Este contenedor está bloqueado y no se abrirá.",
+            "Settings": {
+                "DeleteIfEmpty": "Eliminar cuando esté vacío",
+                "DeleteIfEmptyTooltip": "<strong>Eliminar cuando esté vacío</strong><br/>¿Debe este token contenedor eliminarse automáticamente cuando se remueva el último objeto?",
+                "Header": "Configuración del GM:",
+                "Locked": "Bloqueado",
+                "LockedTooltip": "<strong>Bloqueado</strong><br/>Un contenedor bloqueado previene el acceso de los jugadores."
+            }
+        },
+        "ItemMacro": {
+            "Activate": "Activar",
+            "Attack": "Atacar",
+            "Cast": "Lanzar",
+            "Damage": "Daño",
+            "Healing": "Curación",
+            "Reload": "Recargar",
+            "Use": "Usar"
+        },
+        "ItemNoAmmo": "¡{name} no tiene munición!",
+        "ItemSheet": {
+            "AbilityScoreIncrease": {
+                "Header": "Incrementos de puntuación de habilidad",
+                "Instruction": "Selecciona 4 puntuaciones de habilidad para aumentar.",
+                "InstructionRules": "Cada 5 niveles (en los niveles 5, 10, 15 y 20), puedes aumentar y personalizar tus puntuaciones de habilidad. Cada vez que alcances uno de estos niveles, elige cuatro puntuaciones de habilidad para aumentar. Si esa puntuación es 17 o más (excluyendo aumentos por mejoras personales—ver página 212), aumenta permanentemente en 1. Si es 16 o menos, aumenta permanentemente en 2. No puedes aplicar más de un aumento a la misma puntuación en un nivel dado, pero a diferencia del nivel 1, estos aumentos pueden llevar las puntuaciones por encima de 18.",
+                "ItemName": "Incremento de puntuación de habilidad: Nivel {level}",
+                "Label": "Habilidades"
+            },
+            "ActorResource": {
+                "Base": "Valor base",
+                "BaseTooltip": "(Requerido) El valor base define el valor base de este recurso. Los modificadores pueden alterarlo.<br/>Atributo: @resources.type.subtype.base",
+                "CombatTracker": "Rastreador de combate",
+                "CombatTrackerSettings": "Configuración del rastreador de combate",
+                "DisplayAbsoluteValue": "Mostrar valor absoluto",
+                "DisplayAbsoluteValueTooltip": "¿El valor mostrado en el rastreador de combate debe ser absoluto? Ejemplo: -1 se muestra como 1, -2 como 2, etc.",
+                "Enabled": "Habilitado",
+                "EnabledTooltip": "Si no está marcado, este recurso no producirá una clave en el formato de datos de recursos ni tendrá automatización activa.",
+                "ErrorDisabled": "El recurso está deshabilitado actualmente.",
+                "ErrorIncompleteData": "Al recurso le falta tipo, subtipo o valor base.",
+                "ErrorMissingFields": "Por favor completa los campos faltantes.",
+                "ErrorNoBase": "El valor base es obligatorio.",
+                "ErrorNoSubType": "El subtipo es obligatorio.",
+                "ErrorNoType": "El tipo es obligatorio.",
+                "Header": "Propiedades del recurso",
+                "Range": "Rango de valor",
+                "RangeMode": "Modo de rango",
+                "RangeModeImmediate": "Inmediato",
+                "RangeModePost": "Posterior",
+                "RangeModeTooltip": "(Avanzado) Define si las limitaciones de rango se aplican después de que se procesan todos los modificadores, o para cada modificador mientras se procesan.<br/><br/>Por ejemplo, si el rango máximo es 1, y el valor base es 0, con un modificador +2 y otro -1:<br/><br/>Post: 0 + 2 - 1 da 1, que no excede el máximo.<br/><br/>Inmediato: 0 + 2 se clampa a 1, luego -1 da 0.",
+                "RangeTooltip": "(Opcional) Valores mínimos y máximos para este recurso.<br/>El valor no puede ser menor que el mínimo ni mayor que el máximo.",
+                "ShowInCombatTracker": "Mostrar en el rastreador de combate",
+                "ShowInCombatTrackerTooltip": "Si está habilitado, este recurso será visible en el rastreador de combate para referencia rápida.",
+                "ShowOwnerAndGMOnly": "Solo visible para dueño y GM",
+                "ShowOwnerAndGMOnlyTooltip": "Si está habilitado, este recurso solo será visible en el rastreador de combate para el dueño de la ficha y el GM.",
+                "Stage": "Etapa de cálculo",
+                "StageEarly": "Temprano",
+                "StageLate": "Tardío",
+                "StageTooltip": "La etapa de cálculo determina cuándo se calculan los modificadores de este recurso.<br/><br/><strong>Temprano</strong><br/>Los recursos tempranos se calculan antes de que otras automatizaciones corran. En este punto, los valores computados del actor no son aún válidos, como modificadores de fuerza, bono de salvación, etc. Estos recursos pueden usarse en modificadores que afectan atributos del actor.<br/><br/><strong>Tardío</strong><br/>Los recursos tardíos se calculan al final de los modificadores del actor. Puedes incluir valores ya calculados del actor en este recurso. No puedes incluir recursos tardíos en cálculos que afectan atributos constantemente, pero sí en modificadores situacionales.",
+                "SubType": "Subtipo",
+                "SubTypeTooltip": "(Requerido) El subtipo forma la segunda parte del identificador del recurso.<br/>Ejemplo: @resources.type.subtype.value",
+                "Type": "Tipo",
+                "TypeTooltip": "(Requerido) El tipo forma la primera parte del identificador del recurso.<br/>Ejemplo: @resources.type.subtype.value",
+                "Usage": "Uso de atributo",
+                "UsageBaseValue": "Valor base",
+                "UsageComputedValue": "Valor calculado",
+                "UsageTooltip": "Aquí algunos ejemplos de atributos para acceder a este recurso en fórmulas:",
+                "Visualizations": "Visualización condicional",
+                "VisualizationsIntro": "Si el valor del recurso es...",
+                "VisualizationsModeEqual": "igual a",
+                "VisualizationsModeGreaterThan": "mayor que",
+                "VisualizationsModeGreaterThanEqual": "mayor o igual que",
+                "VisualizationsModeLesserThan": "menor que",
+                "VisualizationsModeLesserThanEqual": "menor o igual que",
+                "VisualizationsModeNotEqual": "diferente de",
+                "VisualizationsPart": "Parte de la visualización",
+                "VisualizationsThen": "Entonces:",
+                "VisualizationsTitle": "Título:"
+            },
+            "Class": {
+                "SpellCasting": {
+                    "ClassLevel": "Nivel de clase",
+                    "Header": "Lanzamiento de conjuros",
+                    "IsCaster": "Conjurador",
+                    "KeyAbilityScore": "Puntuación de habilidad clave",
+                    "SpellsKnown": "Conjuros conocidos",
+                    "SpellsKnownHeader": "Conjuros conocidos (por nivel de conjuro)",
+                    "SpellsPerDay": "Conjuros por día",
+                    "SpellsPerDayBonus": "Conjuros adicionales por día",
+                    "SpellsPerDayBonusHeader": "Conjuros adicionales por día (por nivel de conjuro)",
+                    "SpellsPerDayHeader": "Conjuros por día (por nivel de conjuro)"
+                }
+            },
+
+            "Consumables": {
+                "Category": "Tipo de Consumible"
+            },
+            "Containers": {
+                "ContainerTooltip": "Los contenedores pueden contener casi cualquier objeto. Aumenta la capacidad de almacenamiento para permitir añadir contenido."
+            },
+            "Details": {
+                "Section": {
+                    "ArmorDetails": "Detalles de Armadura",
+                    "ClassBasics": "Conceptos Básicos de Clase",
+                    "ConsumableDetails": "Detalles del Consumible",
+                    "Progressions": "Progresiones",
+                    "SkillsAndProficiencies": "Habilidades y Competencias",
+                    "Title": "Sección",
+                    "Usage": "Uso"
+                },
+                "Tab": {
+                    "AmmunitionContainer": "Munición y Contenedor",
+                    "AttackDamage": "Ataque y Daño",
+                    "ClassInformation": "Información de Clase",
+                    "ContainerDetails": "Detalles del Contenedor",
+                    "NPCSpecific": "Específico de PNJ",
+                    "Properties": "Propiedades",
+                    "Spellcasting": "Conjuración",
+                    "UsageAction": "Uso y Acción"
+                }
+            },
+            "Header": {
+                "ArmorClass": "Clase de Armadura",
+                "ArmorClassTooltip": "<strong>Clase de Armadura</strong><br/>La clase de armadura de este objeto, si está desatendido. De lo contrario, se debe usar la clase de armadura del portador.<br/>Un objeto se considera desatendido si no está bajo la influencia de un personaje.",
+                "DetailsHeader": "Detalles",
+                "Hardness": "Dureza",
+                "HardnessTooltip": "<strong>Dureza</strong><br/>Al recibir daño, resta la dureza del objeto del daño recibido antes de aplicarlo.",
+                "Hitpoints": "Puntos de Golpe",
+                "HitpointsTooltip": "<strong>Puntos de Golpe</strong><br/>La cantidad de puntos de golpe disponibles para este objeto.<br/>Un objeto se considera 'dañado' si tiene puntos de daño.<br/>Un objeto se considera 'destruido' cuando sus puntos de golpe llegan a 0.",
+                "ItemName": "Nombre del Objeto",
+                "ItemNameTooltip": "<strong>Nombre del Objeto</strong><br/>El nombre asignado a este objeto.",
+                "Requirements": "Requisitos",
+                "Save": "CD de Salvación",
+                "SaveTooltip": "<strong>CD de Salvación</strong><br/>Fórmula: {formula}<br/>Este es el modificador de la tirada de salvación para este objeto.",
+                "Source": "Fuente",
+                "SourceTooltip": "<strong>Fuente</strong><br/><em>Usado principalmente para indicar de qué documento de reglas proviene este objeto</em>",
+                "Subtype": "Subtipo",
+                "Type": "Tipo"
+            },
+            "PhysicalProperties": {
+                "ArmorClass": "Clase de Armadura",
+                "ArmorClassTooltip": "<strong>Clase de Armadura</strong><br/>La clase de armadura de este objeto, si está desatendido. De lo contrario, se debe usar la clase de armadura del portador.<br/>Un objeto se considera desatendido si no está bajo la influencia de un personaje.",
+                "CustomBuilt": "Construido a Medida",
+                "CustomBuiltTooltip": "¿Fue este objeto fabricado por un personaje o producido en masa?",
+                "DexterityModifier": "Modificador de Destreza",
+                "DexterityModifierTooltip": "Si es inanimado, el modificador de destreza de un objeto es -5.",
+                "EquippedBulkMultiplier": "Multiplicador de Volumen Equipado",
+                "EquippedBulkMultiplierTooltip": "Este multiplicador se usa para alterar el volumen del objeto cuando está equipado.<br/>Establecerlo en 0 hará que el objeto no cuente su propio volumen para la carga del personaje cuando esté equipado.",
+                "Hardness": "Dureza",
+                "HardnessTooltip": "<strong>Dureza</strong><br/>Al recibir daño, resta la dureza del objeto del daño recibido antes de aplicarlo.",
+                "Header": "Propiedades Físicas",
+                "Hitpoints": {
+                    "CurrentTooltip": "La cantidad de puntos de golpe que tiene este objeto.",
+                    "Header": "Puntos de Golpe",
+                    "HeaderTooltip": "<strong>Puntos de Golpe</strong><br/>La cantidad de puntos de golpe disponibles para este objeto.<br/>Un objeto se considera 'dañado' si tiene puntos de daño.<br/>Un objeto se considera 'destruido' cuando sus puntos de golpe llegan a 0.",
+                    "MaxTooltip": "La cantidad máxima de puntos de golpe que este objeto puede tener. Deja en blanco para cálculo automático."
+                },
+                "ItemDescriptor": "Configuraciones Físicas",
+                "Size": "Tamaño",
+                "SizeTooltip": "Por defecto, el tamaño de un objeto es mediano. El tamaño afecta la clase de armadura del objeto, modifica según sea necesario.",
+                "Sturdy": "Robusto",
+                "SturdyTooltip": "El equipo, como armas y armaduras, se considera robusto."
+            },
+            "StarshipAblativeArmor": {
+                "AblativeValue": "Puntos de Golpe Adicionales Totales",
+                "AblativeValueTooltip": "La cantidad total de puntos de golpe de armadura ablativa para distribuir en los cuatro cuadrantes.",
+                "Header": "Propiedades de Armadura Ablativa",
+                "TargetLockPenalty": "Penalización de Fijación de Objetivo",
+                "TargetLockPenaltyTooltip": "La penalización aplicada a la puntuación de fijación de objetivo de la nave.",
+                "TurnDistancePenalty": "Penalización de Distancia de Giro",
+                "TurnDistancePenaltyTooltip": "La penalización aplicada a la puntuación de distancia de giro de la nave."
+            },
+            "StarshipAction": {
+                "ActionDC": "CD de Acción",
+                "AddSubactionTooltip": "<strong>Agregar Subacción</strong><br />Agregar una nueva subacción",
+                "CheckFormula": "Fórmula de Chequeo de Habilidad",
+                "CrewRole": "Rol de Tripulación",
+                "CriticalEffect": "Efecto Crítico",
+                "DCPlaceholder": "5 + 1-1/2 * Nivel Objetivo de la Nave",
+                "DeleteSubactionTooltip": "<strong>Eliminar Subacción</strong><br />Eliminar esta subacción",
+                "IsPushAction": "¿Acción Push?",
+                "NormalEffect": "Efecto Normal",
+                "Phase": "Fase",
+                "PhaseTooltip": "Tooltip de la Fase",
+                "PushResolve": "Push y Resolver",
+                "ResolveFormulaAutomatically": "Resolver esta fórmula automáticamente",
+                "ResolveFormulaAutomaticallyTooltip": "Si esta casilla está marcada, el CD objetivo se resolverá automáticamente como fórmula y el resultado se mostrará en el chat cuando se active la acción. De lo contrario, se mostrará la cadena sin procesar en el chat.",
+                "SkillFormulaAndSubactions": "Fórmula de Habilidad y Subacciones",
+                "SkillFormulaOrSubactions": "Fórmula de Habilidad / Subacciones",
+                "SkillOrSubaction": "Nombre de Habilidad o Subacción",
+                "SubactionPart": "Subacción {section}",
+                "Subactions": "Subacciones",
+                "TargetDC": "CD Objetivo",
+                "UsesResolve": "Usa Resolución"
+            },
+            "StarshipArmor": {
+                "ArmorBonus": "Bonificación de Armadura",
+                "ArmorBonusTooltip": "La bonificación de clase de armadura que proporciona esta armadura.",
+                "Header": "Propiedades de Armadura",
+                "TargetLockPenalty": "Penalización de Fijación de Objetivo",
+                "TargetLockPenaltyTooltip": "La penalización aplicada a la puntuación de fijación de objetivo de la nave.",
+                "TurnDistancePenalty": "Penalización de Distancia de Giro",
+                "TurnDistancePenaltyTooltip": "La penalización aplicada a la puntuación de distancia de giro de la nave."
+            },
+            "StarshipComponent": {
+                "Cost": "Costo en Puntos de Construcción",
+                "CostMultipliedBySize": "Costo en PC multiplicado por Tamaño",
+                "CostMultipliedBySizeTooltip": "¿El costo en PC se multiplica por el tamaño del casco de la nave?",
+                "CostTooltip": "La cantidad de puntos de construcción necesarios para obtener este componente.",
+                "Header": "Propiedades Comunes del Componente",
+                "IsCostMultipliedBySize": "Está multiplicado",
+                "IsPowered": "Está alimentado",
+                "PCU": "Uso de PCU",
+                "PCUTooltip": "La cantidad de energía que este componente requiere para funcionar.",
+                "PoweredState": "Estado de Alimentación",
+                "PoweredStateTooltip": "¿Está este componente de la nave alimentado?"
+            },
+            "StarshipComputer": {
+                "Header": "Propiedades de la Computadora",
+                "Modifier": "Modificador",
+                "ModifierTooltip": "El modificador de tirada proporcionado por esta computadora.",
+                "Nodes": "Nodos",
+                "NodesTooltip": "La cantidad de veces por turno que esta computadora puede proporcionar su bonificación."
+            },
+            "StarshipDefensiveCountermeasure": {
+                "Header": "Propiedades de Contramedidas Defensivas",
+                "TargetLockBonus": "Bonificación de Fijación de Objetivo",
+                "TargetLockBonusTooltip": "La bonificación aplicada a la puntuación de fijación de objetivo de la nave."
+            },
+            "StarshipDriftEngine": {
+                "EngineRating": "Calificación del Motor",
+                "EngineRatingTooltip": "La calificación del motor de deriva.",
+                "Header": "Propiedades del Motor de Deriva",
+                "MaxSize": "Tamaño Máximo de Nave",
+                "MaxSizeTooltip": "El tamaño máximo de nave en que se puede instalar este motor."
+            },
+            "StarshipFortifiedHull": {
+                "CriticalThresholdBonus": "Bonificación al Umbral Crítico",
+                "CriticalThresholdBonusTooltip": "La bonificación aplicada al umbral crítico de la nave.",
+                "Header": "Propiedades del Casco Fortificado"
+            },
+
+            "StarshipFrame": {
+                "Details": {
+                    "Cost": "Costo en puntos de construcción",
+                    "CostTooltip": "La cantidad de puntos de construcción necesarios para obtener este casco.",
+                    "CrewMaximum": "Número máximo de tripulación",
+                    "CrewMaximumTooltip": "El número máximo de miembros de la tripulación que pueden ocupar un rol en una nave estelar basada en este casco.",
+                    "CrewMinimum": "Número mínimo de tripulación",
+                    "CrewMinimumTooltip": "El número mínimo de miembros de la tripulación necesarios para operar una nave estelar basada en este casco.",
+                    "DamageThreshold": "Umbral de daño",
+                    "DamageThresholdTooltip": "Si una nave estelar tiene un umbral de daño, cualquier ataque que cause daño a sus Puntos de Casco igual o menor a este umbral no daña los Puntos de Casco de la nave. Si el daño es mayor que el umbral, la cantidad total de daño se aplica a los Puntos de Casco de la nave.",
+                    "ExpansionBays": "Bahías de expansión",
+                    "ExpansionBaysTooltip": "El número de bahías de expansión disponibles para este casco.",
+                    "HeaderDefense": "Defensa",
+                    "HeaderOffense": "Ofensa",
+                    "HeaderSpecs": "Especificaciones",
+                    "Hitpoints": "Puntos de Casco",
+                    "HitpointsIncrement": "Incremento de Puntos de Casco",
+                    "HitpointsIncrementTooltip": "La cantidad de Puntos de Casco que una nave estelar con este casco gana automáticamente cuando su nivel aumenta a 4 (y cada 4 niveles siguientes; ver página 294).",
+                    "HitpointsTooltip": "La cantidad de Puntos de Casco que este casco tiene en el nivel 1.",
+                    "Maneuverability": "Maniobrabilidad",
+                    "ManeuverabilityTooltip": "La maniobrabilidad de la nave estelar afecta las habilidades de pilotaje y giro.<br/>Torpe: -2 a Pilotaje, Giro 4<br/>Pobre: -1 a Pilotaje, Giro 3<br/>Promedio: +0 a Pilotaje, Giro 2<br/>Buena: +1 a Pilotaje, Giro 1<br/>Perfecta: +2 a Pilotaje, Giro 0",
+                    "Size": "Tamaño",
+                    "SizeTooltip": "El tamaño del casco determina el tamaño de la nave estelar.",
+                    "WeaponArcAft": "Arco trasero",
+                    "WeaponArcForward": "Arco delantero",
+                    "WeaponArcPort": "Arco babor",
+                    "WeaponArcStarboard": "Arco estribor",
+                    "WeaponArcTooltip": "La cantidad de monturas de armas disponibles para el arco de la nave, divididas en ligeras, pesadas y capitales.",
+                    "WeaponArcTurret": "Torreta",
+                    "WeaponMounts": "Monturas de armas",
+                    "WeaponTypeCapital": "Capital",
+                    "WeaponTypeHeavy": "Pesada",
+                    "WeaponTypeLight": "Ligera",
+                    "WeaponTypeSpinal": "Espinal"
+                }
+            },
+            "StarshipPowerCore": {
+                "Header": "Propiedades del núcleo de energía",
+                "ProvidedPower": "PCU proporcionada",
+                "ProvidedPowerTooltip": "La cantidad de PCU proporcionada por este núcleo de energía.",
+                "Sizes": "Tamaños de nave estelar soportados",
+                "SizesTooltip": "Selecciona los tamaños de nave estelar en los que se puede instalar este núcleo de energía."
+            },
+            "StarshipReinforcedBulkhead": {
+                "Fortification": "Fortificación",
+                "FortificationTooltip": "Cada vez que la nave sufriría daño crítico, existe un porcentaje de probabilidad basado en la calificación de fortificación del mamparo reforzado de que el efecto de daño crítico sea anulado (aunque el ataque aún cause daño a la nave).",
+                "Header": "Propiedades del mamparo reforzado"
+            },
+            "StarshipSensor": {
+                "Header": "Propiedades del sensor",
+                "Modifier": "Modificador de escaneo del sensor",
+                "ModifierTooltip": "Un modificador adicional al escanear planetas fuera de combate.",
+                "Range": "Alcance",
+                "RangeTooltip": "Incremento de alcance del escáner; corto es 5, medio es 10 y largo es 15 hexágonos."
+            },
+            "StarshipShield": {
+                "ArmorBonus": "Bono de armadura",
+                "ArmorBonusTooltip": "El bono a la clase de armadura proporcionado por este escudo.",
+                "DefenseValue": "Valor de defensa",
+                "DefenseValueTooltip": "El valor máximo de defensa disponible con este escudo deflector.",
+                "Header": "Propiedades del escudo",
+                "IsDeflector": "Es escudo deflector",
+                "Regeneration": "Regeneración por minuto",
+                "RegenerationTooltip": "La cantidad de puntos de escudo regenerados por minuto.",
+                "ShieldPoints": "Puntos de escudo",
+                "ShieldPointsTooltip": "La cantidad total de puntos de escudo proporcionados por este escudo.",
+                "ShieldType": "Tipo de escudo",
+                "ShieldTypeTooltip": "¿Es este escudo un escudo deflector?",
+                "TargetLockBonus": "Bono a bloqueo de objetivo",
+                "TargetLockBonusTooltip": "El bono aplicado a la puntuación de bloqueo de objetivo de la nave."
+            },
+            "StarshipThruster": {
+                "Booster": "Propulsor impulsor",
+                "BoosterTooltip": "Para más información, consulte la bahía de expansión para el alojamiento del propulsor impulsor.",
+                "Header": "Propiedades del propulsor",
+                "IsBooster": "Es un impulsor",
+                "IsEnabled": "Está activado",
+                "PilotingModifier": "Modificador de pilotaje",
+                "PilotingModifierTooltip": "Modificador adicional de pilotaje otorgado por este propulsor.",
+                "Size": "Tamaño de nave estelar soportado",
+                "SizeTooltip": "Seleccione el tamaño de nave estelar en el que se puede instalar este propulsor.",
+                "Speed": "Velocidad",
+                "SpeedTooltip": "Número de hexágonos que la nave podrá mover por turno usando este propulsor."
+            },
+            "StarshipWeapon": {
+                "Header": "Propiedades del arma de nave estelar",
+                "Placeholder": "ej. 5",
+                "Unmounted": "Desmontado"
+            },
+            "WeaponAccessory": {
+                "SupportedTypes": "Tipos de armas soportados"
+            },
+            "Weapons": {
+                "Category": "Tipo de arma",
+                "ContainerTooltip": "Las armas típicamente pueden contener fusiones y mejoras de armas. Aumenta la capacidad de almacenamiento para permitir agregar mejoras y fusiones."
+            }
+        },
+        "Items": {
+            "ACP": "Penalización por chequeo de armadura",
+            "Action": {
+                "AbilityModifier": "Modificador de habilidad",
+                "ActionTarget": {
+                    "AC15": "CA 15",
+                    "AC5": "CA 5",
+                    "ChatMessage": " contra {actionTarget}",
+                    "EAC": "EAC",
+                    "KAC": "KAC",
+                    "KAC8": "KAC +8",
+                    "None": "Sin objetivo",
+                    "Other": "Otro",
+                    "StarshipAC": "CA",
+                    "StarshipTL": "TL",
+                    "Tag": "Objetivos: {actionTarget}",
+                    "Title": "Objetivo de la acción",
+                    "Tooltip": "Si esta acción tiene como objetivo una propiedad específica, puedes configurarlo aquí."
+                },
+                "ActionType": "Tipo de acción",
+                "AddDamageSection": "Agregar sección de daño",
+                "AddDamageSectionTooltip": "Agrega otra sección de daño a este objeto.",
+                "AttackRollBonus": "Bono a la tirada de ataque",
+                "ChatMessageFlavor": "Texto del mensaje en chat",
+                "CriticalDamageFormula": "Fórmula de daño crítico",
+                "CriticalDamageHeader": "Secciones de daño crítico",
+                "CriticalEffect": "Efecto crítico",
+                "CriticalHealingFormula": "Fórmula de curación crítica",
+                "DamageFormula": "Fórmula de daño",
+                "DamageFormulaTooltip": "La tirada de daño para esta sección de daño.",
+                "DamageHeader": "Secciones de daño",
+                "DamageName": "Nombre del daño",
+                "DamageNameTooltip": "Un nombre que puedes especificar para referenciar fácilmente este elemento de ataque.",
+                "DamageNotes": "Notas de daño",
+                "DamageNotesTooltip": "Las notas de daño se muestran en la tarjeta de tirada de daño en el chat. Es una excelente forma de poner recordatorios útiles, especialmente para los directores de juego con PNJs complicados.",
+                "DamageSection": "Sección de daño {section}",
+                "DeleteDamageSection": "Eliminar sección de daño",
+                "Details": "Detalles de la acción",
+                "HealingFormula": "Fórmula de curación",
+                "OtherFormula": "Otra fórmula",
+                "RollNotes": "Notas de la tirada",
+                "RollNotesTooltip": "Las notas de la tirada se muestran en la tarjeta de tirada de acción en el chat. Es una excelente forma de poner recordatorios útiles, especialmente para los directores de juego con PNJs complicados.",
+                "SavingThrow": "Tirada de salvación",
+                "SkillCheck": "Chequeo de habilidad",
+                "TitleAction": "Acción",
+                "TitleActivation": "Activación"
+            },
+            "Activation": {
+                "Activation": "Activación",
+                "ActivationCondition": "Condición de activación",
+                "ActivationCost": "Costo de activación",
+                "Area": "Área",
+                "Duration": "Duración",
+                "LimitedUses": "Usos limitados",
+                "Range": "Alcance",
+                "RangeIncrement": "Incremento de alcance",
+                "Target": "Objetivo"
+            },
+            "Ammunition": {
+                "Ammo": "Munición",
+                "AmmunitionType": "Tipo de munición",
+                "Capacity": "Configuración de capacidad",
+                "Details": "Detalles de munición",
+                "Type": {
+                    "Arrows": "Flechas",
+                    "Caustrol": "Caustrol",
+                    "Charges": "Cargas",
+                    "Darts": "Dardos",
+                    "Flares": "Bengalas",
+                    "Flechettes": "Flechettes",
+                    "Fuel": "Combustible",
+                    "HeavyRounds": "Balas pesadas",
+                    "Junk": "Chatarra",
+                    "LongarmAndSniperRounds": "Balas para armas largas y francotirador",
+                    "Missiles": "Misiles",
+                    "MoodGoo": "Gel emocional",
+                    "Nanites": "Nanites",
+                    "None": "Ninguno",
+                    "Rockets": "Mini-cohetes",
+                    "Sclerites": "Escleritas",
+                    "Shells": "Cartuchos",
+                    "SmallArmRounds": "Balas para armas cortas",
+                    "Thasphalt": "Thasphalt",
+                    "ThasteronPellets": "Perdigones de Thasteron"
+                },
+                "UseCapacity": "Usar capacidad"
+            },
+            "Attuned": "Sintonizado",
+            "Augmentation": {
+                "Action": "Acción de aumento",
+                "Details": "Detalles del aumento",
+                "System": "Sistema",
+                "Type": "Tipo",
+                "Usage": "Uso del aumento"
+            },
+            "Capacity": {
+                "Capacity": "Capacidad",
+                "CapacityMaxTooltip": "La cantidad máxima de cargas que este objeto puede contener",
+                "CapacityValueTooltip": "La cantidad actual de cargas",
+                "HeaderTooltip": "La cantidad de rondas, cargas, etc. que puede contener este objeto (por ejemplo, la cantidad de cargas que puede contener una batería)",
+                "Usage": "Uso",
+                "UsageTooltip": "La cantidad de cargas, piezas de munición, etc. que se consumen cuando se usa este objeto.",
+                "UsageValueTooltip": "La unidad de tiempo usada para determinar cuándo se consume la capacidad del objeto."
+            },
+            "Categories": {
+                "AbilityScoreIncrease": "Incrementos de puntuación de habilidad",
+                "Ammunition": "Munición",
+                "Archetypes": "Arquetipos",
+                "Armor": "Armadura",
+                "ArmorUpgrades": "Mejoras de armadura",
+                "Augmentations": "Aumentos",
+                "Classes": "Clases",
+                "Consumables": "Consumibles",
+                "Containers": "Contenedores",
+                "DroneChassis": "Chasis de dron",
+                "DroneMods": "Modificaciones de dron",
+                "Effect": "Efecto",
+                "Equipment": "Armadura",
+                "Feats": "Hazañas",
+                "Goods": "Bienes",
+                "HybridItems": "Objetos híbridos",
+                "MagicItems": "Objetos mágicos",
+                "MiscellaneousItems": "Objetos varios",
+                "Races": "Especies",
+                "Shields": "Escudos",
+                "Spells": "Hechizos",
+                "StarshipAblativeArmors": "Armaduras ablativas para naves",
+                "StarshipArmors": "Armaduras para naves",
+                "StarshipComputers": "Computadoras para naves",
+                "StarshipCrewQuarters": "Alojamientos de tripulación para naves",
+                "StarshipDefensiveCountermeasures": "Contramedidas defensivas para naves",
+                "StarshipDriftEngine": "Motor de deriva para naves",
+                "StarshipExpansionBays": "Bahías de expansión para naves",
+                "StarshipFortifiedHulls": "Casco fortificado para naves",
+                "StarshipFrames": "Casco para naves",
+                "StarshipOtherSystems": "Otros sistemas para naves",
+                "StarshipPowerCores": "Núcleos de energía para naves",
+                "StarshipReinforcedBulkheads": "Mamparos reforzados para naves",
+                "StarshipSecuritySystems": "Sistemas de seguridad para naves",
+                "StarshipSensors": "Sensores para naves",
+                "StarshipShields": "Escudos para naves",
+                "StarshipThrusters": "Propulsores para naves",
+                "StarshipWeapons": "Armas para naves",
+                "TechnologicalItems": "Objetos tecnológicos",
+                "Themes": "Temas",
+                "VehicleAttacks": "Ataques de vehículos",
+                "VehicleSystems": "Sistemas de vehículos",
+                "WeaponAccessories": "Accesorios para armas",
+                "WeaponFusions": "Fusiones de armas",
+                "Weapons": "Armas"
+            },
+            "Consumable": {
+                "Action": "Acción de consumible",
+                "DestroyWhenEmpty": "Destruir cuando esté vacío",
+                "ErrorNoUses": "¡{name} no tiene usos restantes!",
+                "OnUse": "Consumir al usar",
+                "Type": "Tipo de consumible",
+                "Usage": "Uso del consumible",
+                "UseAction": "Usar",
+                "UseChatMessage": "Usa {consumableName}."
+            },
+            "Description": {
+                "Bulk": "Volumen",
+                "Hands": "Manos",
+                "Level": "Nivel",
+                "Price": "Precio",
+                "Quantity": "Cantidad",
+                "QuantityPerPack": "Tamaño del paquete",
+                "QuantityPerPackTooltip": "El tamaño del paquete se usa para definir cuántos de un mismo objeto compras al precio completo. Por ejemplo, compras 30 balas pequeñas al costo de 40 créditos. Esto ayuda en cálculos de volumen y riqueza, así como en el seguimiento de munición."
+            },
+            "Equipment": {
+                "Action": "Acción de equipo",
+                "Category": "Tipo de armadura",
+                "ContainerTooltip": "La armadura normalmente puede contener mejoras de armadura u otros objetos. Aumenta la capacidad de almacenamiento para permitir agregar contenido.",
+                "EAC": "Clase de armadura energética",
+                "KAC": "Clase de armadura cinética",
+                "PowerArmorDetails": "Detalles de la armadura motorizada",
+                "SpeedAdjustment": "Ajuste de velocidad"
+            },
+            "EquipmentStatus": "Estado del equipo",
+            "EquipmentUsage": "Uso del equipo",
+            "Equippable": "Equipable",
+            "Equipped": "Equipado",
+            "Feat": {
+                "ActionRecharge": "Recarga de acción",
+                "Charged": "Cargado",
+                "CombatFeat": "Hazaña de combate",
+                "FeatureAttack": "Ataque de la característica",
+                "FeatureCategory": "Categoría de característica",
+                "FeatureDetails": "Detalles de la característica",
+                "FeatureUsage": "Uso de la característica",
+                "RechargeOn": "Recargar en",
+                "Requirements": "Requisitos",
+                "SpecialAbilityType": "Tipo de habilidad especial"
+            },
+            "Goods": {
+                "Details": "Detalles de bienes"
+            },
+            "Hybrid": {
+                "Details": "Detalles de objeto híbrido"
+            },
+            "Identified": "Identificado",
+            "Magic": {
+                "Details": "Detalles de objeto mágico",
+                "LimitedWear": "Límite de objetos mágicos equipados",
+                "LimitedWearCheckbox": "Este objeto cuenta para el límite de objetos mágicos equipados.",
+                "LimitedWearExceeded": "¡Has equipado demasiados objetos mágicos!"
+            },
+            "MaxDex": "Modificador máximo de destreza",
+            "NotProficient": "No competente",
+            "Proficient": "Competente",
+            "RangeInformation": "Información de alcance",
+            "Shield": {
+                "ACP": "Penalización por chequeo de armadura: {acp}",
+                "AcMaxDex": "Bono máximo de destreza: {maxDex}",
+                "AcMaxDexLabel": "Bono máximo de destreza",
+                "Action": "Acción de escudo",
+                "Aligned": "Alineado",
+                "ArmorCheck": "Penalización por chequeo de armadura: {acp}",
+                "ArmorCheckLabel": "Penalización por chequeo de armadura",
+                "Bonus": "Bono del escudo",
+                "Bonuses": "Empuñado: {wielded} / Alineado: {aligned}",
+                "Details": "Detalles del escudo",
+                "Dex": "Destreza: {dex}",
+                "Shield": "Escudo",
+                "ShieldBonus": "Escudo: {wielded} / {aligned}",
+                "Wielded": "Empuñado"
+            },
+            "ShipWeapon": {
+                "Activated": "Activado",
+                "AttackBonus": "Bono de ataque",
+                "BpCost": "Costo de BP",
+                "ItemType": "Arma de nave estelar",
+                "Mounted": "Montado",
+                "NotMounted": "No montado",
+                "PowerCost": "Costo de energía",
+                "Range": "Alcance",
+                "ReloadCost": "10 minutos",
+                "Source": "Fuente",
+                "Speed": "Velocidad: {speed} hexágonos",
+                "WeaponArc": "Arco del arma",
+                "WeaponClass": "Clase del arma",
+                "WeaponStatus": "Estado del arma"
+            },
+            "SpecialMaterials": {
+                "Title": "Materiales especiales"
+            },
+            "Spell": {
+                "AllowedClasses": "Clases permitidas",
+                "Casting": "Lanzamiento de hechizo",
+                "Concentration": "Concentración",
+                "ConcentrationTooltip": "Este hechizo requiere concentración.<br/>Debes usar la acción 'Concentrarse para mantener el hechizo' (CRB pág. 246) para mantenerlo.",
+                "Consumed": "Consumido",
+                "Cost": "Costo (Cr)",
+                "Details": "Detalles del hechizo",
+                "Dismissible": "Descartable",
+                "Effects": "Efectos del hechizo",
+                "ErrorNoUses": "No se pudo lanzar el hechizo porque no quedan usos. Haz clic en este mensaje para descartarlo.",
+                "IsVariableLevel": "¿Nivel variable?",
+                "IsVariableLevelYes": "Sí",
+                "Level": "Nivel del hechizo",
+                "PreparationMode": "Modo de preparación del hechizo",
+                "Prepared": "Preparado",
+                "Properties": "Propiedades del hechizo",
+                "Resistance": "Resistencia al hechizo",
+                "School": "Escuela del hechizo",
+                "SpellcastingMaterials": "Materiales para lanzamiento",
+                "Supply": "Suministro"
+            },
+            "Technological": {
+                "Details": "Detalles del objeto tecnológico"
+            },
+            "Theme": {
+                "AbilityAdjustment": "Ajuste de habilidad",
+                "Details": "Detalles del tema",
+                "Skill": "Habilidad"
+            },
+            "Unlimited": "Ilimitado",
+            "Upgrade": {
+                "AllowedArmorType": "Tipo de armadura permitida",
+                "Any": "Cualquiera",
+                "ArmorUpgradeDetails": "Detalles de mejora de armadura",
+                "Slots": "Ranuras"
+            },
+            "VehicleAttack": {
+                "Type": "Ataque de vehículo"
+            },
+            "VehicleSystem": {
+                "Type": "Sistema de vehículo"
+            },
+            "Weapon": {
+                "Attack": "Ataque de arma",
+                "Category": "Categoría de arma",
+                "Details": "Detalles del arma",
+                "IsEquipment": {
+                    "Title": "El arma es equipo",
+                    "Tooltip": "Esta casilla se marca si el arma es un equipo que se lleva, en lugar de un arma natural o sobrenatural innata. Para armas naturales, desmarca esta casilla."
+                },
+                "Properties": "Propiedades del arma",
+                "Type": "Tipo de arma",
+                "Usage": "Uso del arma"
+            },
+            "WeaponAccessory": {
+                "SupportedType": {
+                    "Any": "Cualquiera",
+                    "HeavyWeapon": "Arma pesada",
+                    "MeleeWeapon": "Arma cuerpo a cuerpo",
+                    "MeleeWeaponSA": "Arma cuerpo a cuerpo y arma pequeña",
+                    "Projectile": "Proyectil",
+                    "RailedWeapon": "Arma sobre riel",
+                    "RailedWeaponSA": "Arma sobre riel y arma pequeña",
+                    "SmallArm": "Arma pequeña"
+                }
+            }
+        },
+        "KeyAbility": "Característica clave",
+        "KineticArmorClass": "CA Cinética",
+        "KineticArmorClassShort": "CAC",
+        "Languages": "Idiomas",
+        "LanguagesAballonian": "Aballonian",
+        "LanguagesAbyssal": "Abisal",
+        "LanguagesAglian": "Aglian",
+        "LanguagesAkan": "Akan",
+        "LanguagesAkitonian": "Akitonian",
+        "LanguagesAklo": "Aklo",
+        "LanguagesAlkainish": "Alkainish",
+        "LanguagesAnassan": "Anassan",
+        "LanguagesAncientDaimalkan": "Antiguo Daimalkan",
+        "LanguagesAquan": "Aquan",
+        "LanguagesArkanen": "Arkanen",
+        "LanguagesAstriapi": "Astriapi",
+        "LanguagesAuran": "Auran",
+        "LanguagesAzlanti": "Azlanti",
+        "LanguagesBantridi": "Bantridi",
+        "LanguagesBarathu": "Barathu",
+        "LanguagesBolidan": "Bolidan",
+        "LanguagesBrenneri": "Brenneri",
+        "LanguagesBrethedan": "Brethedan",
+        "LanguagesCastrovelian": "Castrovelian",
+        "LanguagesCelestial": "Celestial",
+        "LanguagesCommon": "Común",
+        "LanguagesCopaxi": "Copaxi",
+        "LanguagesCyrunian": "Cyrunian",
+        "LanguagesDaimalkan": "Daimalkan",
+        "LanguagesDirindi": "Dirindi",
+        "LanguagesDraconic": "Dracónico",
+        "LanguagesDromadan": "Dromadan",
+        "LanguagesDrow": "Drow",
+        "LanguagesDwarven": "Enano",
+        "LanguagesElven": "Elfo",
+        "LanguagesEmbri": "Embri",
+        "LanguagesEndiffian": "Endiffian",
+        "LanguagesEoxian": "Eoxian",
+        "LanguagesEspraksi": "Espraksi",
+        "LanguagesFerran": "Ferran",
+        "LanguagesFirstSpeech": "Primer Habla",
+        "LanguagesFrujai": "Frujai",
+        "LanguagesGaraggakal": "Garaggakal",
+        "LanguagesGathol": "Gathol",
+        "LanguagesGhibran": "Ghibran",
+        "LanguagesGhoran": "Ghoran",
+        "LanguagesGiant": "Gigante",
+        "LanguagesGnome": "Gnomo",
+        "LanguagesGoblin": "Goblin",
+        "LanguagesGosclaw": "Gosclaw",
+        "LanguagesGrioth": "Grioth",
+        "LanguagesGytchean": "Gytchean",
+        "LanguagesHadrogaan": "Hadrogaan",
+        "LanguagesHalfling": "Mediano",
+        "LanguagesHallas": "Hallas",
+        "LanguagesHortaa": "Hortaa",
+        "LanguagesIgnan": "Ignan",
+        "LanguagesIhonva": "Ihonva",
+        "LanguagesIji": "Iji",
+        "LanguagesIlthisarian": "Ilthisarian",
+        "LanguagesInfernal": "Infernal",
+        "LanguagesIxtangi": "Ixtangi",
+        "LanguagesIzalguun": "Izalguun",
+        "LanguagesJinsul": "Jinsul",
+        "LanguagesKalo": "Kalo",
+        "LanguagesKasatha": "Kasatha",
+        "LanguagesKatholbi": "Katholbi",
+        "LanguagesKiirinta": "Kiirinta",
+        "LanguagesKoshorian": "Koshorian",
+        "LanguagesKothama": "Kothama",
+        "LanguagesLexonian": "Lexonian",
+        "LanguagesLumos": "Lumos",
+        "LanguagesMaraquoi": "Maraquoi",
+        "LanguagesMegalonic": "Megalonic",
+        "LanguagesMi-Go": "Mi-Go",
+        "LanguagesMorlamaw": "Morlamaw",
+        "LanguagesMulkaxi": "Mulkaxi",
+        "LanguagesNchaki": "Nchaki",
+        "LanguagesNoma": "Noma",
+        "LanguagesOrbian": "Orbian",
+        "LanguagesOrc": "Orco",
+        "LanguagesOrrian": "Orrian",
+        "LanguagesOsharu": "Osharu",
+        "LanguagesPahtra": "Pahtra",
+        "LanguagesParalithi": "Paralithi",
+        "LanguagesPerani": "Perani",
+        "LanguagesProtean": "Proteano",
+        "LanguagesPsacynoa": "Psacynoa",
+        "LanguagesQuorlu": "Quorlu",
+        "LanguagesRaxi": "Raxi",
+        "LanguagesReptoid": "Reptoide",
+        "LanguagesRequian": "Requian",
+        "LanguagesSarcesian": "Sarcesian",
+        "LanguagesSazaron": "Sazaron",
+        "LanguagesScreedreep": "Screedreep",
+        "LanguagesScyphozoan": "Scyphozoan",
+        "LanguagesSelamidian": "Selamidian",
+        "LanguagesSeprevoi": "Seprevoi",
+        "LanguagesShadowtongue": "Lengua Sombría",
+        "LanguagesShimreeni": "Shimreeni",
+        "LanguagesShirren": "Shirren",
+        "LanguagesShobhad": "Shobhad",
+        "LanguagesSivvian": "Sivvian",
+        "LanguagesSpathinae": "Spathinae",
+        "LanguagesStarsong": "Canción Estelar",
+        "LanguagesStroxha": "Stroxha",
+        "LanguagesSylvan": "Silvano",
+        "LanguagesTelian": "Telian",
+        "LanguagesTerran": "Terrano",
+        "LanguagesTriaxian": "Triaxian",
+        "LanguagesTrinir": "Trinir",
+        "LanguagesTromlin": "Tromlin",
+        "LanguagesUrog": "Urog",
+        "LanguagesVarratana": "Varratana",
+        "LanguagesVercite": "Vercite",
+        "LanguagesVesk": "Vesk",
+        "LanguagesVlakan": "Vlakan (lengua de señas, hablada y táctil)",
+        "LanguagesVulgarKishaleen": "Kishaleen vulgar",
+        "LanguagesWoiokan": "Woiokan",
+        "LanguagesWorlanisi": "Worlanisi",
+        "LanguagesWrikreechee": "Wrikreechee",
+        "LanguagesXaarb": "Xaarb",
+        "LanguagesYsoki": "Ysoki",
+        "LevelLabel": "Nivel de hechizo",
+        "LevelLabelText": "Nivel",
+        "Levels": {
+            "0": "0",
+            "1": "1º",
+            "10": "10º",
+            "11": "11º",
+            "12": "12º",
+            "13": "13º",
+            "14": "14º",
+            "15": "15º",
+            "16": "16º",
+            "17": "17º",
+            "18": "18º",
+            "19": "19º",
+            "2": "2º",
+            "20": "20º",
+            "3": "3º",
+            "4": "4º",
+            "5": "5º",
+            "6": "6º",
+            "7": "7º",
+            "8": "8º",
+            "9": "9º"
+        },
+        "LightningReflexesHint": "Hazaña de personaje que añade 2 a las tiradas de salvación de reflejos",
+        "LightningReflexesLabel": "Reflejos Relámpago",
+        "LimitedUsePeriodsCharges": "Cargas",
+        "LimitedUsePeriodsDay": "Día",
+        "LimitedUsePeriodsLong": "Descanso Completo",
+        "LimitedUsePeriodsShort": "Descanso de 10 minutos",
+        "LocalizationTerminator": "",
+        "Long": "Largo",
+        "Macro": {
+            "ViewActor": "Ver Personaje",
+            "ViewItem": "Ver Objeto"
+        },
+        "Magic": {
+            "Levels": {
+                "0": "Nivel 0",
+                "1": "1er Nivel",
+                "2": "2º Nivel",
+                "3": "3er Nivel",
+                "4": "4º Nivel",
+                "5": "5º Nivel",
+                "6": "6º Nivel"
+            },
+            "Schools": {
+                "Abjuration": "Abjuración",
+                "Conjuration": "Conjuración",
+                "Divination": "Adivinación",
+                "Enchantment": "Encantamiento",
+                "Evocation": "Evocación",
+                "Illusion": "Ilusión",
+                "Necromancy": "Nigromancia",
+                "Transmutation": "Transmutación",
+                "Universal": "Universal"
+            }
+        },
+        "Magitech": "Magitecnología",
+        "Medium": "Medio",
+        "Meter": "Metro",
+        "Mi": "Millas",
+        "MigrationBeginingMigration": "Intentando aplicar la migración del sistema Starfinder a la versión {systemVersion}. Por favor, tenga paciencia y no cierre su juego ni apague su servidor.",
+        "MigrationEndMigration": "La migración del sistema Starfinder a la versión {systemVersion} fue exitosa.",
+        "MigrationErrorMessage": "Hubo un error migrando sus datos de Starfinder, ¿seguro que hizo una copia de seguridad?",
+        "MigrationSuccessfulMessage": "Sus datos de Starfinder se migraron correctamente a la versión actual.",
+        "MigrationSuccessfulRefreshMessage": "Sus datos de Starfinder se migraron correctamente a la versión actual. Por favor, refresque el juego para finalizar la migración.",
+        "ModifierACPEffectingArmorTypeAll": "Todas las armaduras",
+        "ModifierACPEffectingArmorTypeHeavy": "Solo armaduras pesadas",
+        "ModifierACPEffectingArmorTypeLight": "Solo armaduras ligeras",
+        "ModifierACPEffectingArmorTypePower": "Solo armaduras potentes",
+        "ModifierAppTitle": "Editar modificador: {name}",
+        "ModifierArmorClassBoth": "Ambos",
+        "ModifierEffectTypeAC": "Clase de Armadura",
+        "ModifierEffectTypeACP": "Penalización por Armadura",
+        "ModifierEffectTypeAbilityCheck": "Chequeo de Característica",
+        "ModifierEffectTypeAbilityChecks": "Chequeos de Característica",
+        "ModifierEffectTypeAbilityScore": "Puntuación de Característica",
+        "ModifierEffectTypeAbilitySkills": "Habilidades de Característica",
+        "ModifierEffectTypeAllSkills": "Todas las habilidades",
+        "ModifierEffectTypeCMD": "CA vs Maniobras de Combate",
+        "ModifierEffectTypeHeaderLabel": "Atributo afectado",
+        "ModifierEffectTypeInit": "Iniciativa",
+        "ModifierEffectTypeLabel": "Atributo afectado",
+        "ModifierEffectTypeSave": "Tirada de salvación específica",
+        "ModifierEffectTypeSaves": "Todas las tiradas de salvación",
+        "ModifierEffectTypeSkill": "Habilidad específica",
+        "ModifierEffectTypeTooltip": "Identifica el atributo general o atributos afectados por el modificador",
+        "ModifierEnabledLabel": "Habilitado",
+        "ModifierEnabledTooltip": "Determina si el modificador se tendrá en cuenta al calcular los modificadores de atributos",
+        "ModifierLimitToContainer": "Contenedor del objeto padre",
+        "ModifierLimitToLabel": "Limitar a",
+        "ModifierLimitToParent": "Objeto padre",
+        "ModifierLimitToTooltip": "<strong>Limitar a</strong><br><br><strong>Ninguno</strong><p>El modificador se aplicará a los objetos correspondientes normalmente.</p><strong>Objeto padre</strong><p>El modificador solo se aplicará al objeto en el que está este modificador.</p><strong>Contenedor del objeto padre</strong><p>El modificador solo se aplicará al contenedor que contiene el objeto con este modificador.</p>",
+        "ModifierModifierLabel": "Modificador",
+        "ModifierModifierTooltip": "El valor utilizado para modificar.",
+        "ModifierModifierTypeLabel": "Tipo de modificador",
+        "ModifierModifierTypeTooltip": "Un modificador puede ser un valor constante que siempre se aplica o un modificador situacional que solo se aplica en ciertas situaciones.",
+        "ModifierNameLabel": "Nombre",
+        "ModifierNameTooltip": "El nombre del modificador",
+        "ModifierNotesLabel": "Notas",
+        "ModifierNotesTooltip": "Notas específicas sobre este modificador",
+        "ModifierSaveHighest": "Mayor",
+        "ModifierSaveLowest": "Menor",
+        "ModifierSourceLabel": "Origen",
+        "ModifierSourceTooltip": "¿De dónde proviene este modificador? Ej. Un objeto, hechizo u otro personaje",
+        "ModifierTitle": "Modificador",
+        "ModifierTypeAbility": "Característica",
+        "ModifierTypeArmor": "Armadura",
+        "ModifierTypeBase": "Base",
+        "ModifierTypeCircumstance": "Circunstancia",
+        "ModifierTypeConstant": "Modificador constante",
+        "ModifierTypeDivine": "Divino",
+        "ModifierTypeEnhancement": "Mejora",
+        "ModifierTypeFormula": "Modificador situacional",
+        "ModifierTypeInsight": "Perspicacia",
+        "ModifierTypeLabel": "Tipo",
+        "ModifierTypeLuck": "Suerte",
+        "ModifierTypeMorale": "Moral",
+        "ModifierTypeRacial": "Racial",
+        "ModifierTypeResistance": "Resistencia",
+        "ModifierTypeTooltip": "Tipo de modificador. Usado para calcular cuál usar cuando hay múltiples del mismo tipo (generalmente el más alto).",
+        "ModifierTypeUntyped": "Sin tipo",
+        "ModifierTypeWeaponSpecialization": "Especialización de arma",
+        "ModifierValueAffectedHeaderLabel": "Valor afectado",
+        "ModifierValueAffectedLabel": "Valor específico afectado",
+        "ModifierValueAffectedTooltip": "Identifica un valor específico afectado si el atributo general tiene muchos posibles valores",
+        "Modifiers": "Modificadores",
+        "ModifiersConditionsTabLabel": "Efectos",
+        "ModifiersItemTabLabel": "Objeto",
+        "ModifiersMiscTabLabel": "Misceláneo",
+        "ModifiersPermanentTabLabel": "Permanente",
+        "ModifiersTemporaryTabLabel": "Temporal",
+        "NPCSheet": {
+            "Biography": {
+                "Organization": {
+                    "GroupSize": "Tamaño de la organización",
+                    "GroupSizeTooltip": "El tamaño de la organización va desde el grupo típico más pequeño (usualmente 1) hasta el grupo típico más grande. Esto se usa principalmente en el navegador de alienígenas para encontrar criaturas que coincidan con el filtro de tamaño de grupo."
+                }
+            },
+            "Features": {
+                "Actions": "Acciones",
+                "ActiveItems": "Hazañas Activas",
+                "Attacks": "Ataques",
+                "Drone": "Objetos del Drone",
+                "Features": "Hazañas Pasivas"
+            },
+            "Header": {
+                "AbilityDC": "DC de Habilidad",
+                "AbilityDCTooltip": "El DC de habilidad que tiene este PNJ. Todas las habilidades del PNJ que requieren una tirada de salvación normalmente usan este valor, a menos que sean conjuros.<br/><br/>Esto puede que no esté completamente integrado en todas las habilidades todavía.",
+                "AlignmentPlaceHolderText": "BN",
+                "AuraPlaceHolderText": "Aura",
+                "BaseSpellDC": "DC base de conjuro",
+                "BaseSpellDCTooltip": "El DC base de conjuro que tiene este PNJ. Todos los conjuros del PNJ que requieren tirada de salvación suelen usar este valor, más el nivel del conjuro.",
+                "NamePlaceHolderText": "Nombre del Personaje",
+                "RaceAndGraftsPlaceHolderText": "Género, Especie y Clase/Implantes",
+                "SourcePlaceHolderText": "Fuente",
+                "SubtypePlaceHolderText": "Subtipo",
+                "TypePlaceHolderText": "Tipo"
+            },
+            "Interface": {
+                "Conditions": {
+                    "Warning": "Los PNJs de estilo antiguo no soportan cálculos automáticos de modificadores, convierte este PNJ al estilo nuevo usando el botón duplicar en la pestaña de Atributos."
+                },
+                "CreateItem": {
+                    "Button": "Crear objeto",
+                    "Name": "Objeto nuevo",
+                    "Note": "Selecciona el tipo de objeto que quieres crear.",
+                    "Title": "Crear nuevo objeto"
+                },
+                "DuplicateNewStyle": {
+                    "Button": "Duplicar como PNJ estilo nuevo",
+                    "ButtonTooltip": "Al hacer clic en este botón se creará una hoja de PNJ estilo nuevo, duplicando los datos y objetos de este actor.",
+                    "DialogCancelButton": "Cancelar",
+                    "DialogMessage": "Estás duplicando un token actor desvinculado, ¿quieres crear el PNJ estilo nuevo usando los datos del actor desvinculado o los datos de la hoja original?",
+                    "DialogOriginalActorButton": "Duplicar actor original",
+                    "DialogTitle": "¿Usar actor original?",
+                    "DialogUnlinkedActorButton": "Duplicar actor desvinculado",
+                    "ErrorCreateActor": "Hubo un error al convertir este actor. Revisa tus permisos de usuario.<br/><br/>Haz clic para cerrar."
+                },
+                "Navigation": {
+                    "Conditions": "Condiciones"
+                }
+            },
+            "Inventory": {
+                "Inventory": "Inventario"
+            }
+        },
+        "Necrograft": "Necroimplante",
+        "None": "Ninguno",
+        "Notes": "Notas",
+        "NpcToggleSkillsDialogTitle": "Alternar habilidades del PNJ",
+        "NumberOfArms": "Número de brazos",
+        "Organization": "Organización",
+        "Passive": "Pasivo",
+        "Personal": "Personal",
+        "PersonalUpgrade": "Mejora personal",
+        "Plane": "Plano",
+        "Planetary": "Planetario",
+        "RaceAbilityAdjustmentAny": "Cualquiera",
+        "RaceAbilityAdjustments": "Ajustes de habilidad",
+        "RaceAddAbilityAdjustment": "Agregar ajuste",
+        "RaceHitPoints": "Puntos de vida",
+        "RacePlaceHolderText": "Especie",
+        "RaceSize": "Tamaño",
+        "RacialTraits": "Rasgos de especie",
+        "RangeCalculated": "{rangeType} ({total} pies)",
+        "RangeClose": "Corto (25 pies + 5 pies/2 niveles)",
+        "RangeLong": "Largo (400 pies + 40 pies/nivel)",
+        "RangeMedium": "Medio (100 pies + 10 pies/nivel)",
+        "Reach": "Alcance",
+        "ReflexSave": "Reflejos",
+        "RepairDroneChatMessage": "{name} fue reparado por {regainedHP} puntos de vida.",
+        "RepairDroneDialogCancelButton": "Cancelar",
+        "RepairDroneDialogDescription": "¿Reparar tu drone? La tasa por defecto es hasta el 10% del HP máximo del drone cada 10 minutos. Si tienes la hazaña Reparar Drone (Ex), puedes reparar hasta el 25% del HP máximo del drone.",
+        "RepairDroneDialogImprovedFeat": "Usar reglas de la hazaña Reparar Drone (Ex)",
+        "RepairDroneDialogRepairButton": "Reparar",
+        "RepairDroneDialogTitle": "Reparar Drone",
+        "RepairDroneUnnecessary": "{name} ya tiene el máximo de puntos de vida, no necesita reparaciones.",
+        "Resolve": "Determinación",
+        "Rest": {
+            "Button": "Descansar",
+            "Cancel": "Cancelar",
+            "Long": {
+                "ChatMessage": {
+                    "AbilityDamage": "Daño reducido en {amount} de {ability}",
+                    "Header": "{name} toma un descanso completo y recupera:",
+                    "HeaderNoRecovery": "{name} toma un descanso completo.",
+                    "HitPoints": "{deltaHP} puntos de vida",
+                    "Item": "El objeto '{itemName}' ha recargado sus usos.",
+                    "ResolvePoints": "{deltaRP} puntos de determinación",
+                    "SpellSlots": "{deltaSS} espacios de conjuro",
+                    "StaminaPoints": "{deltaSP} puntos de resistencia"
+                },
+                "Dialog": {
+                    "Description": "<p>¿Tomar un descanso completo?</p><p>Con un descanso completo recuperarás 1 punto de vida por nivel de personaje, todos los puntos de resistencia, puntos de determinación, recursos de clase, cargas de objetos de uso limitado y espacios de conjuro.</p>",
+                    "Title": "Descanso Completo"
+                },
+                "Title": "Descanso completo"
+            },
+            "Short": {
+                "ActionHeader": "¿Gastar un punto de determinación?",
+                "ChatMessage": {
+                    "Message": "{name} toma un descanso de 10 minutos.",
+                    "Restored": "{name} toma un descanso de 10 minutos y gastó {spentRP} puntos de determinación para recuperar {regainedSP} puntos de resistencia."
+                },
+                "DialogDescription": "¿Tomar un descanso de 10 minutos? En un descanso de 10 minutos puedes gastar un punto de determinación para recuperar todos los puntos de resistencia.",
+                "DialogTitle": "Descanso de 10 minutos",
+                "Title": "Descanso corto"
             }
         },
         "Rolls": {
-    "AttackRoll": "Tirada de Ataque",
-    "AttackRollFull": "Tirada de Ataque - {name}",
-    "Character": {
-        "Charge": "Carga",
-        "ChargeTooltip": "Después de moverte, puedes hacer un ataque cuerpo a cuerpo único. Recibes un penalizador de –2 a la tirada de ataque y un penalizador de –2 a tu CA hasta el inicio de tu próximo turno.",
-        "FightDefensively": "Luchar Defensivamente",
-        "FightDefensivelyTooltip": "Aceptas un penalizador a las tiradas de ataque este turno para ganar un bono de +2 a tu CA hasta el inicio de tu próximo turno.",
-        "Flanking": "Flanqueo",
-        "FlankingTooltip": "Al hacer un ataque cuerpo a cuerpo, obtienes un bono a la tirada de ataque si tu oponente está amenazado por otra criatura en el borde opuesto o esquina opuesta.",
-        "FullAttack": "Ataque Completo",
-        "FullAttackTooltip": "Puedes gastar una acción completa para hacer dos ataques, cada uno con un penalizador a las tiradas de ataque.",
-        "HarryingFire": "Bono de Fuego Molesto",
-        "HarryingFireTooltip": "Activa este bono al atacar a un objetivo afectado por Fuego Molesto.",
-        "Nonlethal": "No letal",
-        "NonlethalTooltip": "Puedes usar un arma que inflige daño letal para infligir daño no letal, pero sufres un penalizador a la tirada de ataque."
-    },
-    "DamageRoll": "Tirada de Daño",
-    "DamageRollFull": "Tirada de Daño - {name}",
-    "Dialog": {
-        "AvailableModifiers": "Modificadores disponibles",
-        "AvailableModifiersTooltip": "Lista de modificadores disponibles para esta tirada.",
-        "Formula": "Fórmula",
-        "FormulaTooltip": "La fórmula usada para calcular la tirada.",
-        "ModifierEffect": "Efecto",
-        "ModifierName": "Nombre",
-        "RollMode": "Modo de Tirada",
-        "RollModeTooltip": "El modo de tirada determina quién puede ver esta tirada.",
-        "Selector": "Seleccionar '{name}'",
-        "SelectorTooltip": "Selección dinámica del actor para el contexto de la fórmula '{name}'.",
-        "SimplifiedFormulaTooltip": "<p>La fórmula mostrada en el diálogo ha sido calculada a partir de la siguiente fórmula:</p><p>{formula}</p>",
-        "SituationalBonus": "Bono situacional",
-        "SituationalBonusTooltip": "¿Hay bonos adicionales que se apliquen a esta tirada? (Por ejemplo, incrementos de alcance)"
-    },
-    "Dice": {
-        "AbilityCheckTitle": "Chequeo de Habilidad - {label}",
-        "Advantage": "Ventaja",
-        "AdvantageTooltip": "Tirar con ventaja.",
-        "CriticalDamage": "Crítico",
-        "CriticalDamageTooltip": "Tirar daño crítico.",
-        "CriticalEffect": "Efecto Crítico: {criticalEffect}",
-        "CriticalFlavor": "{title} (Crítico)",
-        "CriticalFlavorWithEffect": "{title} (Crítico; {criticalEffect})",
-        "CriticalHit": "Golpe Crítico",
-        "Disadvantage": "Desventaja",
-        "DisadvantageTooltip": "Tirar con desventaja.",
-        "Formula": {
-            "AdditionalBonus": " {bonus} [Bono Adicional]"
-        },
-        "Normal": "Normal",
-        "NormalDamage": "Normal",
-        "NormalDamageTooltip": "Tirar daño normal.",
-        "NormalTooltip": "Tirada normal.",
-        "Roll": "Tirar",
-        "SaveTitle": "Tirada de Salvación - {label}",
-        "SkillCheckTitle": "Chequeo de Destreza - {skill}",
-        "SkillCheckTitleWithProfession": "Chequeo de Destreza - {skill} ({profession})"
-    },
-    "HealingRoll": "Tirada de Curación",
-    "HealingRollFull": "Tirada de Curación - {name}",
-    "InitiativeRollFull": "Tirada de Iniciativa - {name}",
-    "Starship": {
-        "Broadside": "Banda",
-        "CaptainDemand": "Orden del Capitán",
-        "CaptainEncouragement": "Ánimo del Capitán",
-        "ComputerBonus": "Bono de Computadora",
-        "FireAtWill": "Dispara a Voluntad",
-        "ScienceOfficerLockOn": "Fijación del Oficial Científico",
-        "SnapShot": "Disparo Rápido"
-    },
-    "StarshipAction": "Acción de Nave Estelar: {action}",
-    "StarshipActions": {
-        "ActionNotFoundError": "¡La acción de nave estelar con id '{actionId}' no existe!",
-        "Chat": {
-            "CriticalEffect": "Efecto Crítico",
-            "DC": "DC",
-            "NormalEffect": "Efecto",
-            "Role": "{role} de la Nave Estelar: '{name}'"
-        },
-        "Choice": {
-            "AvailableRolls": "Tiradas disponibles",
-            "Message": "La acción de nave estelar '{name}' ofrece múltiples tiradas para elegir. Por favor selecciona una.",
-            "Title": "{name} - Seleccione la tirada deseada"
-        },
-        "NoActorError": "No hay tripulante disponible para este rol.",
-        "NoFormulaError": "No hay fórmula en los datos para la acción de nave estelar '{name}'.",
-        "Quadrant": {
-            "Aft": "Popa",
-            "Forward": "Proa",
-            "Message": "Las acciones de artillería requieren seleccionar un cuadrante. Las torretas pueden elegir libremente. Por favor selecciona uno.",
-            "Port": "Babor",
-            "Quadrant": "Cuadrante",
-            "Starboard": "Estribor",
-            "Title": "{name} - Seleccione el cuadrante del arma usado."
-
+            "AttackRoll": "Tirada de Ataque",
+            "AttackRollFull": "Tirada de Ataque - {name}",
+            "Character": {
+                "Charge": "Carga",
+                "ChargeTooltip": "Después de moverte, puedes hacer un ataque cuerpo a cuerpo único. Recibes un penalizador de –2 a la tirada de ataque y un penalizador de –2 a tu CA hasta el inicio de tu próximo turno.",
+                "FightDefensively": "Luchar Defensivamente",
+                "FightDefensivelyTooltip": "Aceptas un penalizador a las tiradas de ataque este turno para ganar un bono de +2 a tu CA hasta el inicio de tu próximo turno.",
+                "Flanking": "Flanqueo",
+                "FlankingTooltip": "Al hacer un ataque cuerpo a cuerpo, obtienes un bono a la tirada de ataque si tu oponente está amenazado por otra criatura en el borde opuesto o esquina opuesta.",
+                "FullAttack": "Ataque Completo",
+                "FullAttackTooltip": "Puedes gastar una acción completa para hacer dos ataques, cada uno con un penalizador a las tiradas de ataque.",
+                "HarryingFire": "Bono de Fuego Molesto",
+                "HarryingFireTooltip": "Activa este bono al atacar a un objetivo afectado por Fuego Molesto.",
+                "Nonlethal": "No letal",
+                "NonlethalTooltip": "Puedes usar un arma que inflige daño letal para infligir daño no letal, pero sufres un penalizador a la tirada de ataque."
+            },
+            "DamageRoll": "Tirada de Daño",
+            "DamageRollFull": "Tirada de Daño - {name}",
+            "Dialog": {
+                "AvailableModifiers": "Modificadores disponibles",
+                "AvailableModifiersTooltip": "Lista de modificadores disponibles para esta tirada.",
+                "Formula": "Fórmula",
+                "FormulaTooltip": "La fórmula usada para calcular la tirada.",
+                "ModifierEffect": "Efecto",
+                "ModifierName": "Nombre",
+                "RollMode": "Modo de Tirada",
+                "RollModeTooltip": "El modo de tirada determina quién puede ver esta tirada.",
+                "Selector": "Seleccionar '{name}'",
+                "SelectorTooltip": "Selección dinámica del actor para el contexto de la fórmula '{name}'.",
+                "SimplifiedFormulaTooltip": "<p>La fórmula mostrada en el diálogo ha sido calculada a partir de la siguiente fórmula:</p><p>{formula}</p>",
+                "SituationalBonus": "Bono situacional",
+                "SituationalBonusTooltip": "¿Hay bonos adicionales que se apliquen a esta tirada? (Por ejemplo, incrementos de alcance)"
+            },
+            "Dice": {
+                "AbilityCheckTitle": "Chequeo de Habilidad - {label}",
+                "Advantage": "Ventaja",
+                "AdvantageTooltip": "Tirar con ventaja.",
+                "CriticalDamage": "Crítico",
+                "CriticalDamageTooltip": "Tirar daño crítico.",
+                "CriticalEffect": "Efecto Crítico: {criticalEffect}",
+                "CriticalFlavor": "{title} (Crítico)",
+                "CriticalFlavorWithEffect": "{title} (Crítico; {criticalEffect})",
+                "CriticalHit": "Golpe Crítico",
+                "Disadvantage": "Desventaja",
+                "DisadvantageTooltip": "Tirar con desventaja.",
+                "Formula": {
+                    "AdditionalBonus": " {bonus} [Bono Adicional]"
+                },
+                "Normal": "Normal",
+                "NormalDamage": "Normal",
+                "NormalDamageTooltip": "Tirar daño normal.",
+                "NormalTooltip": "Tirada normal.",
+                "Roll": "Tirar",
+                "SaveTitle": "Tirada de Salvación - {label}",
+                "SkillCheckTitle": "Chequeo de Destreza - {skill}",
+                "SkillCheckTitleWithProfession": "Chequeo de Destreza - {skill} ({profession})"
+            },
+            "HealingRoll": "Tirada de Curación",
+            "HealingRollFull": "Tirada de Curación - {name}",
+            "InitiativeRollFull": "Tirada de Iniciativa - {name}",
+            "Starship": {
+                "Broadside": "Banda",
+                "CaptainDemand": "Orden del Capitán",
+                "CaptainEncouragement": "Ánimo del Capitán",
+                "ComputerBonus": "Bono de Computadora",
+                "FireAtWill": "Dispara a Voluntad",
+                "ScienceOfficerLockOn": "Fijación del Oficial Científico",
+                "SnapShot": "Disparo Rápido"
+            },
+            "StarshipAction": "Acción de Nave Estelar: {action}",
+            "StarshipActions": {
+                "ActionNotFoundError": "¡La acción de nave estelar con id '{actionId}' no existe!",
+                "Chat": {
+                    "CriticalEffect": "Efecto Crítico",
+                    "DC": "DC",
+                    "NormalEffect": "Efecto",
+                    "Role": "{role} de la Nave Estelar: '{name}'"
+                },
+                "Choice": {
+                    "AvailableRolls": "Tiradas disponibles",
+                    "Message": "La acción de nave estelar '{name}' ofrece múltiples tiradas para elegir. Por favor selecciona una.",
+                    "Title": "{name} - Seleccione la tirada deseada"
+                },
+                "NoActorError": "No hay tripulante disponible para este rol.",
+                "NoFormulaError": "No hay fórmula en los datos para la acción de nave estelar '{name}'.",
+                "Quadrant": {
+                    "Aft": "Popa",
+                    "Forward": "Proa",
+                    "Message": "Las acciones de artillería requieren seleccionar un cuadrante. Las torretas pueden elegir libremente. Por favor selecciona uno.",
+                    "Port": "Babor",
+                    "Quadrant": "Cuadrante",
+                    "Starboard": "Estribor",
+                    "Title": "{name} - Seleccione el cuadrante del arma usado."
                 }
             }
         },
         "Save": "Salvación",
-"SaveAbilityModTooltip": "Modificador de Habilidad: {mod} ({ability})",
-"SaveBaseModifier": "Salvación Base: {base}",
-"SaveClassModTooltip": "Modificador de Clase: {mod} ({class})",
-"SaveDescriptorDisbelieve": "incredulidad",
-"SaveDescriptorHalf": "mitad",
-"SaveDescriptorHarmless": "inofensivo",
-"SaveDescriptorNegates": "anula",
-"SaveDescriptorObject": "objeto",
-"SaveDescriptorPartial": "parcial",
-"SaveMiscModifierLabel": "Varios",
-"SaveModifiersTooltip": "Bono de {type}: {mod} ({source})",
-"SaveProgressionFast": "Rápido",
-"SaveProgressionSlow": "Lento",
-"SensesTypes": {
-    "GlobalIlluminationThresholdMessage": "<strong>Sistema Starfinder</strong><br />Se recomienda mantener estas configuraciones activadas para que funciones como Visión en Penumbra operen correctamente.",
-    "Senses": "Sentidos",
-    "SensesBL": "Vista Ciega",
-    "SensesBS": "Sensación Ciega",
-    "SensesDark": "Visión en la Oscuridad",
-    "SensesLLV": "Visión en Penumbra",
-    "SensesLLVDark": "Visión en Penumbra y en la Oscuridad",
-    "SensesST": "Sentir a Través de"
-},
-"Settings": {
-    "Advantage": {
-        "Hint": "Habilita la posibilidad de alternar ventaja o desventaja en las tiradas de dados.",
-        "Name": "¿Usar ventaja y desventaja?"
-    },
-    "AlwaysShowQuantity": {
-        "Hint": "Siempre muestra la cantidad de objetos, incluso si es 0 o 1.",
-        "Name": "Mostrar siempre la cantidad de objetos"
-    },
-    "AutoAddUnarmedStrike": {
-        "Hint": "Al estar marcado, el objeto Golpe Sin Armas se añadirá automáticamente a cualquier nuevo personaje jugador.",
-        "Name": "Añadir automáticamente Golpe Sin Armas a personajes nuevos"
-    },
-    "AutoCollapseCard": {
-        "Hint": "Colapsa automáticamente las descripciones de las Cartas de Objetos en el chat.",
-        "Name": "Colapsar Cartas de Objetos en el chat"
-    },
-    "AutoRollCritEffect": {
-        "Hint": "Al aplicar daño a una nave desde una carta de chat, si el daño supera un umbral crítico, se tirará automáticamente en la tabla de Efectos de Daño Crítico (CRB pág. 320).",
-        "Name": "Tirar automáticamente efectos de daño crítico de nave estelar"
-    },
-    "ChatNotificationDuration": {
-        "Hint": "Tiempo (en MS) que las notificaciones del chat permanecen visibles antes de desaparecer (Predeterminado 5000).",
-        "Name": "Duración de notificaciones en el chat"
-    },
-    "CombatCards": {
-        "NormalHint": "Cambiar qué cartas de combate se muestran durante el combate normal.",
-        "NormalName": "Combate normal",
-        "StarshipHint": "Cambiar qué cartas de combate se muestran durante el combate de naves estelares.",
-        "StarshipName": "Combate de nave estelar",
-        "Values": {
-            "Disabled": "Desactivado",
-            "Enabled": "Rondas, fases y turnos",
-            "OnlyRounds": "Solo rondas",
-            "RoundsPhases": "Rondas y fases",
-            "RoundsTurns": "Rondas y turnos"
+        "SaveAbilityModTooltip": "Modificador de Habilidad: {mod} ({ability})",
+        "SaveBaseModifier": "Salvación Base: {base}",
+        "SaveClassModTooltip": "Modificador de Clase: {mod} ({class})",
+        "SaveDescriptorDisbelieve": "incredulidad",
+        "SaveDescriptorHalf": "mitad",
+        "SaveDescriptorHarmless": "inofensivo",
+        "SaveDescriptorNegates": "anula",
+        "SaveDescriptorObject": "objeto",
+        "SaveDescriptorPartial": "parcial",
+        "SaveMiscModifierLabel": "Varios",
+        "SaveModifiersTooltip": "Bono de {type}: {mod} ({source})",
+        "SaveProgressionFast": "Rápido",
+        "SaveProgressionSlow": "Lento",
+        "SensesTypes": {
+            "GlobalIlluminationThresholdMessage": "<strong>Sistema Starfinder</strong><br />Se recomienda mantener estas configuraciones activadas para que funciones como Visión en Penumbra operen correctamente.",
+            "Senses": "Sentidos",
+            "SensesBL": "Vista Ciega",
+            "SensesBS": "Sensación Ciega",
+            "SensesDark": "Visión en la Oscuridad",
+            "SensesLLV": "Visión en Penumbra",
+            "SensesLLVDark": "Visión en Penumbra y en la Oscuridad",
+            "SensesST": "Sentir a Través de"
         },
-        "VehicleChaseHint": "Cambiar qué cartas de combate se muestran durante persecuciones de vehículos.",
-        "VehicleChaseName": "Persecuciones de vehículos"
-    },
-    "CombatTiebreaker": {
-        "Hint": "Agrega automáticamente el modificador de iniciativa dividido por 100 a la tirada para desempates.",
-        "Name": "Desempate en tirada de iniciativa"
-    },
-    "CurrencyLocale": {
-        "Hint": "Qué configuración regional usar para mostrar la moneda en inventarios, etc.",
-        "Name": "Configuración regional de moneda"
-    },
-    "DamageRoundingAdvantage": {
-        "Hint": "En caso de daño fraccionario, alternar redondeo a favor del atacante o del defensor.",
-        "Name": "Ventaja en redondeo de daño",
-        "ValueAttacker": "Atacante",
-        "ValueDefender": "Defensor"
-    },
-    "DamageWithAttack": {
-        "Hint": "Automáticamente seguir una tirada de ataque con una de daño.",
-        "Name": "Tirar daño junto con ataque"
-    },
-    "DecimalSpeed": {
-        "Hint": "Permitir valores decimales en la configuración de velocidad del actor.",
-        "Name": "Valores decimales para velocidad"
-    },
-    "DiagonalMovementRule": {
-        "Hint": "Configurar qué regla de movimiento diagonal usar para juegos en este sistema.",
-        "Name": "Regla de movimiento diagonal",
-        "Values": {
-            "Core": "Libro Básico (5/10/5)",
-            "Optional": "Opcional (5/5/5)"
-        }
-    },
-    "DifficultyDisplay": {
-        "Hint": "Habilita el cálculo y visualización de dificultad en la pestaña del rastreador de combate.",
-        "Name": "Mostrar dificultad"
-    },
-    "ExperienceTracking": {
-        "Hint": "Eliminar barras de experiencia en las hojas de personaje.",
-        "Name": "Desactivar seguimiento de experiencia"
-    },
-    "FloatingHP": {
-        "Button": "Configurar números flotantes",
-        "Hint": "Configura los números flotantes que aparecen en un token cuando cambia su HP/SP.",
-        "Menu": {
-            "CanSeeBars": {
-                "Hint": "Usuarios que pueden ver las barras de recursos del token podrán ver los números flotantes.",
-                "Name": "¿Puede ver barras de recursos?"
+        "Settings": {
+            "Advantage": {
+                "Hint": "Habilita la posibilidad de alternar ventaja o desventaja en las tiradas de dados.",
+                "Name": "¿Usar ventaja y desventaja?"
             },
-            "CanSeeName": {
-                "Hint": "Usuarios que pueden ver el nombre del token podrán ver los números flotantes.",
-                "Name": "¿Puede ver el nombre?"
+            "AlwaysShowQuantity": {
+                "Hint": "Siempre muestra la cantidad de objetos, incluso si es 0 o 1.",
+                "Name": "Mostrar siempre la cantidad de objetos"
             },
-            "Enabled": {
-                "Hint": "Habilitar números flotantes cuando cambian HP/SP del token.",
-                "Name": "¿Habilitar números flotantes?"
+            "AutoAddUnarmedStrike": {
+                "Hint": "Al estar marcado, el objeto Golpe Sin Armas se añadirá automáticamente a cualquier nuevo personaje jugador.",
+                "Name": "Añadir automáticamente Golpe Sin Armas a personajes nuevos"
             },
-            "Label": "Configuración de números flotantes",
-            "LimitByCriteria": {
-                "Hint": "Si está activado, los números flotantes se mostrarán solo a usuarios que cumplan al menos uno de los criterios. Si está desactivado, se mostrarán a todos.",
-                "Name": "¿Limitar por criterios?"
+            "AutoCollapseCard": {
+                "Hint": "Colapsa automáticamente las descripciones de las Cartas de Objetos en el chat.",
+                "Name": "Colapsar Cartas de Objetos en el chat"
             },
-            "MinPerm": {
-                "Hint": "Usuarios con este permiso o superior sobre el token podrán ver los números flotantes.",
-                "Name": "Permiso mínimo"
+            "AutoRollCritEffect": {
+                "Hint": "Al aplicar daño a una nave desde una carta de chat, si el daño supera un umbral crítico, se tirará automáticamente en la tabla de Efectos de Daño Crítico (CRB pág. 320).",
+                "Name": "Tirar automáticamente efectos de daño crítico de nave estelar"
             },
-            "VerboseFloatyText": {
-                "Hint": "Si está activado, se mostrarán los nombres completos de los arcos de escudo.",
-                "Name": "Modo detallado"
-            }
-        },
-        "Name": "Configuración de números flotantes"
-    },
-    "GalacticTrade": {
-        "Hint": "Habilita el subsistema de Comercio Galáctico, permitiendo que el máximo de BP de una nave sea 5% mayor de lo normal y añade BP al inventario de la nave como créditos.",
-        "Name": "Habilitar Comercio Galáctico"
-    },
-    "HideHostileStarshipCrit": {
-        "Hint": "Al publicar notificaciones sobre críticos o umbrales de naves, solo enviar al GM si la nave es un Token Hostil.",
-        "Name": "Ocultar mensaje crítico de nave hostil"
-    },
-
+            "ChatNotificationDuration": {
+                "Hint": "Tiempo (en MS) que las notificaciones del chat permanecen visibles antes de desaparecer (Predeterminado 5000).",
+                "Name": "Duración de notificaciones en el chat"
+            },
+            "CombatCards": {
+                "NormalHint": "Cambiar qué cartas de combate se muestran durante el combate normal.",
+                "NormalName": "Combate normal",
+                "StarshipHint": "Cambiar qué cartas de combate se muestran durante el combate de naves estelares.",
+                "StarshipName": "Combate de nave estelar",
+                "Values": {
+                    "Disabled": "Desactivado",
+                    "Enabled": "Rondas, fases y turnos",
+                    "OnlyRounds": "Solo rondas",
+                    "RoundsPhases": "Rondas y fases",
+                    "RoundsTurns": "Rondas y turnos"
+                },
+                "VehicleChaseHint": "Cambiar qué cartas de combate se muestran durante persecuciones de vehículos.",
+                "VehicleChaseName": "Persecuciones de vehículos"
+            },
+            "CombatTiebreaker": {
+                "Hint": "Agrega automáticamente el modificador de iniciativa dividido por 100 a la tirada para desempates.",
+                "Name": "Desempate en tirada de iniciativa"
+            },
+            "CurrencyLocale": {
+                "Hint": "Qué configuración regional usar para mostrar la moneda en inventarios, etc.",
+                "Name": "Configuración regional de moneda"
+            },
+            "DamageRoundingAdvantage": {
+                "Hint": "En caso de daño fraccionario, alternar redondeo a favor del atacante o del defensor.",
+                "Name": "Ventaja en redondeo de daño",
+                "ValueAttacker": "Atacante",
+                "ValueDefender": "Defensor"
+            },
+            "DamageWithAttack": {
+                "Hint": "Automáticamente seguir una tirada de ataque con una de daño.",
+                "Name": "Tirar daño junto con ataque"
+            },
+            "DecimalSpeed": {
+                "Hint": "Permitir valores decimales en la configuración de velocidad del actor.",
+                "Name": "Valores decimales para velocidad"
+            },
+            "DiagonalMovementRule": {
+                "Hint": "Configurar qué regla de movimiento diagonal usar para juegos en este sistema.",
+                "Name": "Regla de movimiento diagonal",
+                "Values": {
+                    "Core": "Libro Básico (5/10/5)",
+                    "Optional": "Opcional (5/5/5)"
+                }
+            },
+            "DifficultyDisplay": {
+                "Hint": "Habilita el cálculo y visualización de dificultad en la pestaña del rastreador de combate.",
+                "Name": "Mostrar dificultad"
+            },
+            "ExperienceTracking": {
+                "Hint": "Eliminar barras de experiencia en las hojas de personaje.",
+                "Name": "Desactivar seguimiento de experiencia"
+            },
+            "FloatingHP": {
+                "Button": "Configurar números flotantes",
+                "Hint": "Configura los números flotantes que aparecen en un token cuando cambia su HP/SP.",
+                "Menu": {
+                    "CanSeeBars": {
+                        "Hint": "Usuarios que pueden ver las barras de recursos del token podrán ver los números flotantes.",
+                        "Name": "¿Puede ver barras de recursos?"
+                    },
+                    "CanSeeName": {
+                        "Hint": "Usuarios que pueden ver el nombre del token podrán ver los números flotantes.",
+                        "Name": "¿Puede ver el nombre?"
+                    },
+                    "Enabled": {
+                        "Hint": "Habilitar números flotantes cuando cambian HP/SP del token.",
+                        "Name": "¿Habilitar números flotantes?"
+                    },
+                    "Label": "Configuración de números flotantes",
+                    "LimitByCriteria": {
+                        "Hint": "Si está activado, los números flotantes se mostrarán solo a usuarios que cumplan al menos uno de los criterios. Si está desactivado, se mostrarán a todos.",
+                        "Name": "¿Limitar por criterios?"
+                    },
+                    "MinPerm": {
+                        "Hint": "Usuarios con este permiso o superior sobre el token podrán ver los números flotantes.",
+                        "Name": "Permiso mínimo"
+                    },
+                    "VerboseFloatyText": {
+                        "Hint": "Si está activado, se mostrarán los nombres completos de los arcos de escudo.",
+                        "Name": "Modo detallado"
+                    }
+                },
+                "Name": "Configuración de números flotantes"
+            },
+            "GalacticTrade": {
+                "Hint": "Habilita el subsistema de Comercio Galáctico, permitiendo que el máximo de BP de una nave sea 5% mayor de lo normal y añade BP al inventario de la nave como créditos.",
+                "Name": "Habilitar Comercio Galáctico"
+            },
+            "HideHostileStarshipCrit": {
+                "Hint": "Al publicar notificaciones sobre críticos o umbrales de naves, solo enviar al GM si la nave es un Token Hostil.",
+                "Name": "Ocultar mensaje crítico de nave hostil"
+            },
+            "LockArtworkRotationDefault": {
+                "Hint": "When enabled, enables Lock Artwork Rotation on character scale actors by default (Characters/NPC/Drones/Hazards). This can be overridden by the actor's prototype token settings.",
+                "Name": "Lock Artwork Rotation by Default"
+            },
             "SFRPGTheme": {
-    "Hint": "Al activarse, se harán algunos ajustes menores a los colores de Foundry para coincidir con el esquema de colores de Starfinder.",
-    "Name": "Tema personalizado de SFRPG"
-},
-"ScalingCantrips": {
-    "Hint": "Habilita la regla variante de Cantrips escalables del Galactic Magic pág. 88. Cambiar esta configuración modificará las fórmulas de todos los conjuros afectados en todos los actores, por lo que puede tardar si tienes muchos.",
-    "Name": "Habilitar Cantrips Escalables"
-},
-"StarshipActionsCrit": {
-    "Hint": "Muestra el estado del efecto crítico de las acciones de naves estelares.",
-    "Name": "Efecto Crítico de Acciones de Nave Estelar",
-    "Values": {
-        "Always": "Mostrar siempre efectos críticos.",
-        "CritOnly": "Mostrar efectos críticos solo en tiradas críticas.",
-        "Never": "Nunca mostrar efectos críticos."
-    }
-},
-"StarshipActionsSource": {
-    "Hint": "Clave del compendio que contiene las definiciones de acciones de naves estelares.",
-    "Name": "Compendio fuente de acciones de nave estelar"
-},
-"TokenConditionLabels": {
-    "Hint": "Añade etiquetas de texto a las condiciones de los tokens.",
-    "Name": "Etiquetas de condición de tokens"
-},
-"UseCustomChatCard": {
-    "Hint": "Alternar entre usar las nuevas cartas personalizadas de chat o las originales.",
-    "Name": "¿Usar carta de chat personalizada de Starfinder?"
-},
-"UseQuickRollAsDefault": {
-    "Hint": "Al activarse, las habilidades que tiran dados omitirán por defecto la ventana de diálogo de tirada. Si se mantiene presionada la tecla shift al hacer clic, la ventana se mostrará.",
-    "Name": "¿Usar tirada rápida por defecto?"
-},
-"UseStarfinderAOETemplates": {
-    "Hint": "Usar el método de medición de AOE de Starfinder en lugar del método predeterminado de Foundry VTT.",
-    "Name": "Usar plantillas AOE de Starfinder"
-},
-"WarnInvalidRollData": {
-    "Hint": "Si está activado, mostrará advertencias cuando los modificadores contengan fórmulas de tirada inválidas. Esto puede causar spam de advertencias, por ejemplo, si tienes una característica de clase pero no el objeto de clase correspondiente.",
-    "Name": "Advertir sobre fórmulas de tirada inválidas"
-},
-"WorldSchemaVersion": {
-    "Hint": "Registra la versión del esquema de datos para el sistema Starfinder. ¡ADVERTENCIA: No edites este valor a menos que sepas lo que haces!",
-    "Name": "Versión del esquema de datos de Starfinder"
+                "Hint": "Al activarse, se harán algunos ajustes menores a los colores de Foundry para coincidir con el esquema de colores de Starfinder.",
+                "Name": "Tema personalizado de SFRPG"
+            },
+            "ScalingCantrips": {
+                "Hint": "Habilita la regla variante de Cantrips escalables del Galactic Magic pág. 88. Cambiar esta configuración modificará las fórmulas de todos los conjuros afectados en todos los actores, por lo que puede tardar si tienes muchos.",
+                "Name": "Habilitar Cantrips Escalables"
+            },
+            "StarshipActionsCrit": {
+                "Hint": "Muestra el estado del efecto crítico de las acciones de naves estelares.",
+                "Name": "Efecto Crítico de Acciones de Nave Estelar",
+                "Values": {
+                    "Always": "Mostrar siempre efectos críticos.",
+                    "CritOnly": "Mostrar efectos críticos solo en tiradas críticas.",
+                    "Never": "Nunca mostrar efectos críticos."
+                }
+            },
+            "StarshipActionsSource": {
+                "Hint": "Clave del compendio que contiene las definiciones de acciones de naves estelares.",
+                "Name": "Compendio fuente de acciones de nave estelar"
+            },
+            "TokenConditionLabels": {
+                "Hint": "Añade etiquetas de texto a las condiciones de los tokens.",
+                "Name": "Etiquetas de condición de tokens"
+            },
+            "UseCustomChatCard": {
+                "Hint": "Alternar entre usar las nuevas cartas personalizadas de chat o las originales.",
+                "Name": "¿Usar carta de chat personalizada de Starfinder?"
+            },
+            "UseQuickRollAsDefault": {
+                "Hint": "Al activarse, las habilidades que tiran dados omitirán por defecto la ventana de diálogo de tirada. Si se mantiene presionada la tecla shift al hacer clic, la ventana se mostrará.",
+                "Name": "¿Usar tirada rápida por defecto?"
+            },
+            "UseStarfinderAOETemplates": {
+                "Hint": "Usar el método de medición de AOE de Starfinder en lugar del método predeterminado de Foundry VTT.",
+                "Name": "Usar plantillas AOE de Starfinder"
+            },
+            "WarnInvalidRollData": {
+                "Hint": "Si está activado, mostrará advertencias cuando los modificadores contengan fórmulas de tirada inválidas. Esto puede causar spam de advertencias, por ejemplo, si tienes una característica de clase pero no el objeto de clase correspondiente.",
+                "Name": "Advertir sobre fórmulas de tirada inválidas"
+            },
+            "WorldSchemaVersion": {
+                "Hint": "Registra la versión del esquema de datos para el sistema Starfinder. ¡ADVERTENCIA: No edites este valor a menos que sepas lo que haces!",
+                "Name": "Versión del esquema de datos de Starfinder"
             }
         },
-"ShipFrameLabel": "Chasis",
-"ShipModelLabel": "Modelo",
-"ShipNameLabel": "Nombre de la nave",
-"ShipSystems": {
-    "CrewQuarterSystems": {
-        "Common": "Común",
-        "Good": "Bueno",
-        "Luxurious": "Lujoso"
-    },
-    "ExpansionBaySystems": {
-        "Arclab": "Laboratorio arcano",
-        "Cargo": "Bodega de carga",
-        "Escape": "Botes de escape",
-        "Guest": "Cuartos de invitados",
-        "Hac": "Suite recreativa (HAC)",
-        "Hangar": "Hangar",
-        "Life": "Botes salvavidas",
-        "Med": "Sala médica",
-        "Pass": "Asientos para pasajeros",
-        "Pwrhouse": "Carcasa del núcleo de energía",
-        "Recg": "Suite recreativa (gimnasio)",
-        "Rect": "Suite recreativa (sala trivid)",
-        "Science": "Laboratorio científico",
-        "Senv": "Cámara de ambiente sellado",
-        "Shuttle": "Bahía de lanzadera",
-        "Smuggler": "Compartimento de contrabandistas",
-        "Syth": "Bahía de síntesis",
-        "Tech": "Taller tecnológico"
-    },
-    "Maneuverability": {
-        "Average": "Promedio",
-        "Clumsy": "Torpe",
-        "Good": "Buena",
-        "Perfect": "Perfecta",
-        "Poor": "Pobre"
-    },
-    "SecuritySystems": {
-        "Antihack": "Sistemas anti-hacking",
-        "Antiper": "Arma antipersonal",
-        "Bio": "Cerraduras biométricas",
-        "Compcounter": "Contramedidas informáticas",
-        "Selfdestruct": "Sistema de autodestrucción"
-    },
-    "Size": {
-        "Supercolossal": "Supercolosal"
-    },
-    "StarshipArcs": {
-        "Aft": "Popa",
-        "Forward": "Proa",
-        "Port": "Babor",
-        "Starboard": "Estribor",
-        "Turret": "Torreta"
-    },
-    "StarshipRoles": {
-        "Captain": "Capitán",
-        "Engineers": "Ingenieros",
-        "Gunners": "Artilleros",
-        "Passengers": "Pasajeros",
-        "Pilot": "Piloto",
-        "ScienceOfficers": "Oficiales científicos"
-    },
-    "StarshipWeaponClass": {
-        "Capital": "Capital",
-        "Heavy": "Pesada",
-        "Light": "Ligera",
-        "Spinal": "Espinal"
-    },
+        "ShipFrameLabel": "Chasis",
+        "ShipModelLabel": "Modelo",
+        "ShipNameLabel": "Nombre de la nave",
+        "ShipSystems": {
+            "CrewQuarterSystems": {
+                "Common": "Común",
+                "Good": "Bueno",
+                "Luxurious": "Lujoso"
+            },
+            "ExpansionBaySystems": {
+                "Arclab": "Laboratorio arcano",
+                "Cargo": "Bodega de carga",
+                "Escape": "Botes de escape",
+                "Guest": "Cuartos de invitados",
+                "Hac": "Suite recreativa (HAC)",
+                "Hangar": "Hangar",
+                "Life": "Botes salvavidas",
+                "Med": "Sala médica",
+                "Pass": "Asientos para pasajeros",
+                "Pwrhouse": "Carcasa del núcleo de energía",
+                "Recg": "Suite recreativa (gimnasio)",
+                "Rect": "Suite recreativa (sala trivid)",
+                "Science": "Laboratorio científico",
+                "Senv": "Cámara de ambiente sellado",
+                "Shuttle": "Bahía de lanzadera",
+                "Smuggler": "Compartimento de contrabandistas",
+                "Syth": "Bahía de síntesis",
+                "Tech": "Taller tecnológico"
+            },
+            "Maneuverability": {
+                "Average": "Promedio",
+                "Clumsy": "Torpe",
+                "Good": "Buena",
+                "Perfect": "Perfecta",
+                "Poor": "Pobre"
+            },
+            "SecuritySystems": {
+                "Antihack": "Sistemas anti-hacking",
+                "Antiper": "Arma antipersonal",
+                "Bio": "Cerraduras biométricas",
+                "Compcounter": "Contramedidas informáticas",
+                "Selfdestruct": "Sistema de autodestrucción"
+            },
+            "Size": {
+                "Supercolossal": "Supercolosal"
+            },
+            "StarshipArcs": {
+                "Aft": "Popa",
+                "Forward": "Proa",
+                "Port": "Babor",
+                "Starboard": "Estribor",
+                "Turret": "Torreta"
+            },
+            "StarshipRoles": {
+                "Captain": "Capitán",
+                "Engineers": "Ingenieros",
+                "Gunners": "Artilleros",
+                "Passengers": "Pasajeros",
+                "Pilot": "Piloto",
+                "ScienceOfficers": "Oficiales científicos"
+            },
+            "StarshipWeaponClass": {
+                "Capital": "Capital",
+                "Heavy": "Pesada",
+                "Light": "Ligera",
+                "Spinal": "Espinal"
+            },
 
             "StarshipWeaponProperties": {
-    "Anchoring": "Anclaje",
-    "Antimagic": "Antimagia",
-    "Array": "Matriz",
-    "Automated": "Automatizado",
-    "Broad": "Arco Amplio",
-    "Bugging": "Interferencia",
-    "Burrowing": "Excavación",
-    "Buster": "Destructor",
-    "Cacophonous": "Cacofónico",
-    "Connecting": "Conexión",
-    "DeathField": "Campo Mortal",
-    "Deployed": "Desplegado",
-    "Drone": "Dron",
-    "Emp": "EMP",
-    "FlakArea": "Área de Flak",
-    "ForceField": "Campo de Fuerza",
-    "GravityTether": "Gravedad Atada",
-    "GravityWell": "Pozo Gravitacional",
-    "Hacking": "Hackeo",
-    "Immobilize": "Inmovilizar",
-    "Intimidating": "Intimidante",
-    "IrradiateH": "Irradiar (alto)",
-    "IrradiateL": "Irradiar (bajo)",
-    "IrradiateM": "Irradiar (medio)",
-    "IrradiateS": "Irradiar (severo)",
-    "Jamming": "Bloqueo",
-    "Limited": "Fuego Limitado",
-    "Line": "Línea",
-    "Mine": "Mina",
-    "Mystical": "Místico",
-    "NavScram": "Interferencia de Navegación",
-    "Numbing": "Entumecedor",
-    "Orbital": "Orbital",
-    "Pod": "Módulo",
-    "Point": "Punto",
-    "Quantum": "Cuántico",
-    "Radiant": "Radiante",
-    "Rail": "Riel",
-    "Ramming": "Arremetida",
-    "Redirect": "Redireccionar",
-    "Restricted": "Restringido",
-    "Ripper": "Desgarrador",
-    "Scatterscan": "Escaneo Disperso",
-    "Smart": "Inteligente",
-    "Smoldering": "Humeante",
-    "Spore": "Espora",
-    "Suspending": "Suspendido",
-    "Sustained": "Sostenido",
-    "Teleportation": "Teletransportación",
-    "Tractor": "Rayo Tractor",
-    "Transposition": "Transposición",
-    "Unerring": "Certero",
-    "VandalDrones": "Drones Vándalos",
-    "Volatile": "Volátil",
-    "Vortex": "Vórtice"
-},
-"StarshipWeaponRanges": {
-    "Long": "Largo",
-    "Medium": "Medio",
-    "None": "Ninguno",
-    "Short": "Corto"
-},
-"StarshipWeaponTypes": {
-    "Direct": "Disparo Directo",
-    "ECM": "Módulo ECM",
-    "Melee": "Arma Cuerpo a Cuerpo",
-    "Tracking": "Seguimiento"
+                "Anchoring": "Anclaje",
+                "Antimagic": "Antimagia",
+                "Array": "Matriz",
+                "Automated": "Automatizado",
+                "Broad": "Arco Amplio",
+                "Bugging": "Interferencia",
+                "Burrowing": "Excavación",
+                "Buster": "Destructor",
+                "Cacophonous": "Cacofónico",
+                "Connecting": "Conexión",
+                "DeathField": "Campo Mortal",
+                "Deployed": "Desplegado",
+                "Drone": "Dron",
+                "Emp": "EMP",
+                "FlakArea": "Área de Flak",
+                "ForceField": "Campo de Fuerza",
+                "GravityTether": "Gravedad Atada",
+                "GravityWell": "Pozo Gravitacional",
+                "Hacking": "Hackeo",
+                "Immobilize": "Inmovilizar",
+                "Intimidating": "Intimidante",
+                "IrradiateH": "Irradiar (alto)",
+                "IrradiateL": "Irradiar (bajo)",
+                "IrradiateM": "Irradiar (medio)",
+                "IrradiateS": "Irradiar (severo)",
+                "Jamming": "Bloqueo",
+                "Limited": "Fuego Limitado",
+                "Line": "Línea",
+                "Mine": "Mina",
+                "Mystical": "Místico",
+                "NavScram": "Interferencia de Navegación",
+                "Numbing": "Entumecedor",
+                "Orbital": "Orbital",
+                "Pod": "Módulo",
+                "Point": "Punto",
+                "Quantum": "Cuántico",
+                "Radiant": "Radiante",
+                "Rail": "Riel",
+                "Ramming": "Arremetida",
+                "Redirect": "Redireccionar",
+                "Restricted": "Restringido",
+                "Ripper": "Desgarrador",
+                "Scatterscan": "Escaneo Disperso",
+                "Smart": "Inteligente",
+                "Smoldering": "Humeante",
+                "Spore": "Espora",
+                "Suspending": "Suspendido",
+                "Sustained": "Sostenido",
+                "Teleportation": "Teletransportación",
+                "Tractor": "Rayo Tractor",
+                "Transposition": "Transposición",
+                "Unerring": "Certero",
+                "VandalDrones": "Drones Vándalos",
+                "Volatile": "Volátil",
+                "Vortex": "Vórtice"
+            },
+            "StarshipWeaponRanges": {
+                "Long": "Largo",
+                "Medium": "Medio",
+                "None": "Ninguno",
+                "Short": "Corto"
+            },
+            "StarshipWeaponTypes": {
+                "Direct": "Disparo Directo",
+                "ECM": "Módulo ECM",
+                "Melee": "Arma Cuerpo a Cuerpo",
+                "Tracking": "Seguimiento"
             }
         },
-"ShipTierLabel": "Nivel",
-"Size": "Tamaño",
-"SizeColossal": "Colosal",
-"SizeDim": "Diminuto",
-"SizeFine": "Fino",
-"SizeGargantuan": "Gigantesco",
-"SizeHuge": "Enorme",
-"SizeLarge": "Grande",
-"SizeMedium": "Mediano",
-"SizeSmall": "Pequeño",
-"SizeTiny": "Muy Pequeño",
-"SkillAcr": "Acrobacias",
-"SkillAth": "Atletismo",
-"SkillBlu": "Engaño",
-"SkillCom": "Informática",
-"SkillCul": "Cultura",
-"SkillDelete": "¿Eliminar?",
-"SkillDip": "Diplomacia",
-"SkillDis": "Disfraz",
-"SkillEng": "Ingeniería",
-"SkillGun": "Artillería",
-"SkillInt": "Intimidación",
-"SkillLsc": "Ciencias de la Vida",
-"SkillMed": "Medicina",
-"SkillMiscModifiersLabel": "Modificadores Varios",
-"SkillModifierTooltip": "Bono de {type}: {mod} ({source})",
-"SkillMys": "Misticismo",
-"SkillNotes": "Notas de habilidad",
-"SkillPer": "Percepción",
-"SkillPil": "Pilotaje",
-"SkillPro": "Profesión",
-"SkillProfessionName": "Nombre de profesión",
-"SkillProficiencyLevelClassSkill": "Habilidad de Clase",
-"SkillPsc": "Ciencia Física",
-"SkillSen": "Sospecha",
-"SkillSle": "Juego de Manos",
-"SkillSte": "Sigilo",
-"SkillSur": "Supervivencia",
-"SkillTooltipAbilityMod": "Modificador de habilidad: {abilityMod} ({abilityAbbr})",
-"SkillTooltipMiscMod": "Modificadores varios: {mod}",
-"SkillTooltipSkillRanks": "Rangos en habilidad: {ranks}",
-"SkillTooltipThemeMod": "Modificador de tema: {mod}",
-"SkillTooltipTrainedClassSkill": "Modificador por habilidad entrenada de clase: {mod}",
-"SkillTrained": "Entrenado",
-"SkillTrainedOnly": "Solo entrenado",
-"SkillTrainedOnlyDialog": {
-    "Content": "{skill} es una habilidad solo para entrenados, pero {name} no está entrenado en esa habilidad. ¿Quieres tirar de todos modos?",
-    "Title": "{skill} solo entrenada"
-},
-"SkillUntrained": "No entrenado",
-"SkillsHeaderAbility": "Hab",
-"SkillsHeaderModifier": "Mod",
-"SkillsHeaderName": "Nombre",
-"SkillsHeaderRanks": "Rangos",
-"SkillsToggleHeader": "Habilidades",
-"SortByFilterLevel": "Nivel",
-"SortByFilterName": "Nombre",
-"Space": "Espacio",
-"Special": "Especial",
-"SpecialAbilityTypes": {
-    "Extraordinary": "Extraordinaria (Ex)",
-    "SpellLike": "Habilidad tipo hechizo (Sp)",
-    "Supernatural": "Sobrenatural (Su)"
-},
-"SpecialMaterials": {
-    "Abysium": "Abisium",
-    "Adamantine": "Aleación de Adamantina",
-    "ColdIron": "Hierro Frío",
-    "Diatha": "Diatha",
-    "Djezet": "Djezet",
-    "Horacalcum": "Horacalcum",
-    "Inubrix": "Inubrix",
-    "Khefak": "Armadura Khefak",
-    "Noqual": "Noqual",
-    "Nyblantine": "Nyblantina",
-    "PurpleCores": "Núcleos Morados",
-    "Siccatite": "Siccatite",
-    "Silver": "Plata",
-    "Voidglass": "Vidrio del Vacío"
-},
-"SpecialTraits": "Rasgos Especiales",
-"SpeciesGraft": "Injerto de Especie",
-"Speed": "Velocidad",
-"SpeedSpecial": "Movimiento Especial",
-"SpellAreaEffects": {
-    "Burst": "Explosión",
-    "Emanation": "Emanación",
-    "Spread": "Extensión"
-},
-"SpellAreaShapesCone": "Cono",
-"SpellAreaShapesCube": "Cubo",
-"SpellAreaShapesCylinder": "Cilindro",
-"SpellAreaShapesLine": "Línea",
-"SpellAreaShapesOther": "Otro",
-"SpellAreaShapesShapable": "Modificable",
-"SpellAreaShapesSphere": "Esfera",
-"SpellBook": {
-    "Add": "Agregar",
-    "AddSpells": "Agregar Hechizo",
-    "AttributesNone": "Ninguno",
-    "Browse": "Explorar libro de hechizos",
-    "CreateFromCompendium": "Agregar hechizo desde compendio",
-    "CreateSpell": "Crear hechizo",
-    "DeleteItem": "Eliminar objeto",
-    "EditItem": "Editar objeto",
-    "NoSpells": "No se encontraron hechizos con este filtro.",
-    "SearchSpell": "Buscar hechizo",
-    "SpellCastingAbility": "Habilidad de lanzamiento",
-    "SpellSchool": "Escuela de magia",
-    "SpellUsage": "Uso de hechizo",
-    "Spellbook": "Libro de hechizos",
-    "Uses": "Usos"
-
+        "ShipTierLabel": "Nivel",
+        "Size": "Tamaño",
+        "SizeColossal": "Colosal",
+        "SizeDim": "Diminuto",
+        "SizeFine": "Fino",
+        "SizeGargantuan": "Gigantesco",
+        "SizeHuge": "Enorme",
+        "SizeLarge": "Grande",
+        "SizeMedium": "Mediano",
+        "SizeSmall": "Pequeño",
+        "SizeTiny": "Muy Pequeño",
+        "SkillAcr": "Acrobacias",
+        "SkillAth": "Atletismo",
+        "SkillBlu": "Engaño",
+        "SkillCom": "Informática",
+        "SkillCul": "Cultura",
+        "SkillDelete": "¿Eliminar?",
+        "SkillDip": "Diplomacia",
+        "SkillDis": "Disfraz",
+        "SkillEng": "Ingeniería",
+        "SkillGun": "Artillería",
+        "SkillInt": "Intimidación",
+        "SkillLsc": "Ciencias de la Vida",
+        "SkillMed": "Medicina",
+        "SkillMiscModifiersLabel": "Modificadores Varios",
+        "SkillModifierTooltip": "Bono de {type}: {mod} ({source})",
+        "SkillMys": "Misticismo",
+        "SkillNotes": "Notas de habilidad",
+        "SkillPer": "Percepción",
+        "SkillPil": "Pilotaje",
+        "SkillPro": "Profesión",
+        "SkillProfessionName": "Nombre de profesión",
+        "SkillProficiencyLevelClassSkill": "Habilidad de Clase",
+        "SkillPsc": "Ciencia Física",
+        "SkillSen": "Sospecha",
+        "SkillSle": "Juego de Manos",
+        "SkillSte": "Sigilo",
+        "SkillSur": "Supervivencia",
+        "SkillTooltipAbilityMod": "Modificador de habilidad: {abilityMod} ({abilityAbbr})",
+        "SkillTooltipMiscMod": "Modificadores varios: {mod}",
+        "SkillTooltipSkillRanks": "Rangos en habilidad: {ranks}",
+        "SkillTooltipThemeMod": "Modificador de tema: {mod}",
+        "SkillTooltipTrainedClassSkill": "Modificador por habilidad entrenada de clase: {mod}",
+        "SkillTrained": "Entrenado",
+        "SkillTrainedOnly": "Solo entrenado",
+        "SkillTrainedOnlyDialog": {
+            "Content": "{skill} es una habilidad solo para entrenados, pero {name} no está entrenado en esa habilidad. ¿Quieres tirar de todos modos?",
+            "Title": "{skill} solo entrenada"
+        },
+        "SkillUntrained": "No entrenado",
+        "SkillsHeaderAbility": "Hab",
+        "SkillsHeaderModifier": "Mod",
+        "SkillsHeaderName": "Nombre",
+        "SkillsHeaderRanks": "Rangos",
+        "SkillsToggleHeader": "Habilidades",
+        "SortByFilterLevel": "Nivel",
+        "SortByFilterName": "Nombre",
+        "Space": "Espacio",
+        "Special": "Especial",
+        "SpecialAbilityTypes": {
+            "Extraordinary": "Extraordinaria (Ex)",
+            "SpellLike": "Habilidad tipo hechizo (Sp)",
+            "Supernatural": "Sobrenatural (Su)"
+        },
+        "SpecialMaterials": {
+            "Abysium": "Abisium",
+            "Adamantine": "Aleación de Adamantina",
+            "ColdIron": "Hierro Frío",
+            "Diatha": "Diatha",
+            "Djezet": "Djezet",
+            "Horacalcum": "Horacalcum",
+            "Inubrix": "Inubrix",
+            "Khefak": "Armadura Khefak",
+            "Noqual": "Noqual",
+            "Nyblantine": "Nyblantina",
+            "PurpleCores": "Núcleos Morados",
+            "Siccatite": "Siccatite",
+            "Silver": "Plata",
+            "Voidglass": "Vidrio del Vacío"
+        },
+        "SpecialTraits": "Rasgos Especiales",
+        "SpeciesGraft": "Injerto de Especie",
+        "Speed": "Velocidad",
+        "SpeedSpecial": "Movimiento Especial",
+        "SpellAreaEffects": {
+            "Burst": "Explosión",
+            "Emanation": "Emanación",
+            "Spread": "Extensión"
+        },
+        "SpellAreaShapesCone": "Cono",
+        "SpellAreaShapesCube": "Cubo",
+        "SpellAreaShapesCylinder": "Cilindro",
+        "SpellAreaShapesLine": "Línea",
+        "SpellAreaShapesOther": "Otro",
+        "SpellAreaShapesShapable": "Modificable",
+        "SpellAreaShapesSphere": "Esfera",
+        "SpellBook": {
+            "Add": "Agregar",
+            "AddSpells": "Agregar Hechizo",
+            "AttributesNone": "Ninguno",
+            "Browse": "Explorar libro de hechizos",
+            "CreateFromCompendium": "Agregar hechizo desde compendio",
+            "CreateSpell": "Crear hechizo",
+            "DeleteItem": "Eliminar objeto",
+            "EditItem": "Editar objeto",
+            "NoSpells": "No se encontraron hechizos con este filtro.",
+            "SearchSpell": "Buscar hechizo",
+            "SpellCastingAbility": "Habilidad de lanzamiento",
+            "SpellSchool": "Escuela de magia",
+            "SpellUsage": "Uso de hechizo",
+            "Spellbook": "Libro de hechizos",
+            "Uses": "Usos"
         },
         "SpellBrowserSearchHint": "",
-"SpellCantripLabel": "Truco",
-"SpellCasting": {
-    "AllowedClasses": "Clases Permitidas",
-    "ButtonCast": "Lanzar",
-    "ConsumeSlot": "¿Consumir ranura de conjuro?",
-    "ConsumeSlotYes": "Sí",
-    "ErrorNoSlot": "No puedes lanzar este conjuro usando ranuras de conjuro, ya que no tienes ranuras disponibles. Puedes optar por lanzarlo sin consumir ninguna ranura.",
-    "Header": "Configura cómo quieres lanzar {spellName}.",
-    "SelectSpellSlot": "Lanzar con ranura de conjuro",
-    "SpellLabelClass": "{className} - {spellSlot} ({remainingSlots} Ranuras)",
-    "SpellLabelGeneral": "{spellSlot} ({remainingSlots} Ranuras)",
-    "Title": "{spellName}: Configuración del conjuro"
-},
-"SpellPreparationModesAlways": "Siempre Disponible",
-"SpellPreparationModesInnate": "Conjuración Innata",
-"SpellResistance": "Resistencia a conjuros",
-"Stamina": "Aguante",
-"StarshipSheet": {
-    "Actions": {
-        "Header": {
-            "Phase": "Fase",
-            "ResolvePoints": "Puntos de Resolución"
+        "SpellCantripLabel": "Truco",
+        "SpellCasting": {
+            "AllowedClasses": "Clases Permitidas",
+            "ButtonCast": "Lanzar",
+            "ConsumeSlot": "¿Consumir ranura de conjuro?",
+            "ConsumeSlotYes": "Sí",
+            "ErrorNoSlot": "No puedes lanzar este conjuro usando ranuras de conjuro, ya que no tienes ranuras disponibles. Puedes optar por lanzarlo sin consumir ninguna ranura.",
+            "Header": "Configura cómo quieres lanzar {spellName}.",
+            "SelectSpellSlot": "Lanzar con ranura de conjuro",
+            "SpellLabelClass": "{className} - {spellSlot} ({remainingSlots} Ranuras)",
+            "SpellLabelGeneral": "{spellSlot} ({remainingSlots} Ranuras)",
+            "Title": "{spellName}: Configuración del conjuro"
         },
-        "Tooltips": {
-            "CriticalEffect": "Efecto Crítico",
-            "NormalEffect": "Efecto normal",
-            "Push": "Impulso",
-            "PushTooltip": "Las acciones de impulso (indicadas en el encabezado de la acción) son difíciles de realizar pero pueden producir mejores resultados. No puedes realizar una acción de impulso si el sistema necesario está averiado o destruido (como se indica en las Condiciones de Daño Crítico en la página 321)."
-        }
-    },
-    "Attributes": {
-        "BuildPoints": "Puntos de Construcción",
-        "BuildPointsUsage": "Uso",
-        "Complement": "Tripulación",
-        "ComplementMax": "Número máximo de tripulantes que pueden asignarse a un rol en la nave (no es el máximo de criaturas a bordo).",
-        "ComplementMin": "Tripulación mínima necesaria para operar la nave.",
-        "Computer": "Computadora",
-        "DriftNotAvailable": "No disponible",
-        "DriftRating": "Clasificación de Deriva",
-        "Power": "Núcleo de Energía",
-        "PowerConsumption": "Consumo",
-        "PowerMissing": "Falta Núcleo de Energía"
-    },
-    "Crew": {
-        "ActionsPerRound": "Acciones por ronda",
-        "AddSkill": "Agregar habilidad",
-        "AssignedCount": "({current} / {max})",
-        "Captain": "Capitán",
-        "ChiefMates": "Primeros Oficiales",
-        "CrewLimitReached": "Has alcanzado la cantidad máxima de tripulantes permitidos para el rol '{targetRole}'.",
-        "CrewSetting": "Configuración de tripulación",
-        "Engineers": "Ingenieros",
-        "Gunners": "Artilleros",
-        "Header": "Tripulación de la Nave",
-        "IsNPCCrew": "Es tripulación NPC",
-        "MagicOfficers": "Oficiales Mágicos",
-        "NPCGunnerRanksMessage": "Aunque los rangos no afectan el modificador de artillería de un NPC, algunas fichas incluyen el nivel del artillero, que puedes almacenar aquí. De lo contrario, puedes dejar esta casilla en blanco.",
-        "Passengers": "Pasajeros",
-        "Pilot": "Piloto",
-        "RemoveCrewMember": "Eliminar miembro de la tripulación",
-        "ScienceOfficers": "Oficiales Científicos",
-        "SkillModifier": "Modificador",
-        "SkillRanks": "Rangos",
-        "UnlimitedMax": "Sin límite"
-    },
-    "Critical": {
-        "Edit": "Editar roles afectados.",
-        "EditMessage": "Selecciona qué roles se ven afectados por el daño en este sistema.",
-        "EditTitle": "Seleccionar roles afectados",
-        "Header": "Daño Crítico",
-        "Status": {
-            "Glitching": "Fallas",
-            "Malfunctioning": "Mal funcionamiento",
-            "Nominal": "Nominal",
-            "Wrecked": "Destruido"
-        },
-        "Systems": {
-            "Engines": "Motores",
-            "LifeSupport": "Soporte Vital",
-            "PowerCore": "Núcleo de Energía",
-            "Sensors": "Sensores",
-            "WeaponsArrayAft": "Armas (Popa)",
-            "WeaponsArrayForward": "Armas (Proa)",
-            "WeaponsArrayPort": "Armas (Babor)",
-            "WeaponsArrayStarboard": "Armas (Estribor)"
-        }
-    },
-    "Damage": {
-        "CrossedCriticalThreshold": "¡{name} cruzó {crossedThresholds} umbrales críticos!",
-        "Message": "El daño a una nave siempre proviene de una dirección específica, por favor selecciona el cuadrante al que debe aplicarse el daño entrante.",
-        "Nat20": "¡Daño crítico! {name} sufre un efecto de daño crítico.",
-        "Nat20WithThreshold": "¡Daño crítico! {name} sufre un efecto de daño crítico adicional.",
-        "Quadrant": {
-            "Aft": "Popa",
-            "Forward": "Proa",
-            "Port": "Babor",
-            "Quadrant": "Cuadrante",
-            "Starboard": "Estribor"
-        },
-        "Title": "{name} - Selecciona el cuadrante dañado."
-    },
-    "Details": {
-        "Ablative": {
-            "Aft": "Armadura Ablativa (Popa)",
-            "Forward": "Armadura Ablativa (Proa)",
-            "Header": "Ablativa",
-            "Port": "Armadura Ablativa (Babor)",
-            "Starboard": "Armadura Ablativa (Estribor)"
-        },
-        "AblativeExceedsHull": "¡El total de ablativa excede el doble de los puntos de casco!",
-        "AblativeExceedsHullTooltip": "Una nave no puede soportar armadura ablativa si sus Puntos de Casco temporales exceden el doble del total estándar de Puntos de Casco. (Para más información, consulta el Manual de Operaciones de Nave, pág. 20)",
-        "AblativeTooHigh": "¡Demasiada ablativa asignada!",
-        "AblativeTooHighTooltip": "O el total de ablativa instalada es demasiado alto, o la suma actual de ablativa es demasiado alta.",
-        "ShieldHighestTooHigh": "¡Uno o más cuadrantes exceden los límites!",
-        "ShieldHighestTooHighTooltip": "Un cuadrante de escudo no puede exceder el 70% de la asignación total de escudos, ya que el mínimo disponible para cada escudo debe ser del 10%. (Para más información, consulta el Libro Básico, pág. 302)",
-        "ShieldTotalTooHigh": "¡El total de escudos excede el máximo!",
-        "ShieldTotalTooHighTooltip": "La suma total de escudos excede la salida máxima del escudo.",
-        "Shields": {
-            "Aft": "Escudos (Popa)",
-            "Conventional": "Escudos",
-            "Deflector": "DV de Escudo",
-            "Forward": "Escudos (Proa)",
-            "Header": "Escudos",
-            "Port": "Escudos (Babor)",
-            "Starboard": "Escudos (Estribor)"
-        }
-    },
-    "Features": {
-        "ExpansionBays": "Bahías de Expansión ({current} / {max})",
-        "Frame": "Armazón ({current} / 1)",
-        "OtherSystems": "Otros Sistemas",
-        "PowerCores": "Núcleos de Energía",
-        "Prefixes": {
-            "StarshipAblativeArmors": "Armadura Ablativa",
-            "StarshipArmors": "Armadura",
-            "StarshipComputers": "Computadora",
-            "StarshipCrewQuarters": "Cuartos de Tripulación",
-            "StarshipDefensiveCountermeasures": "Contramedida Defensiva",
-            "StarshipDriftEngine": "Motor de Deriva",
-            "StarshipExpansionBays": "Bahía de Expansión",
-            "StarshipFortifiedHulls": "Casco Fortificado",
-            "StarshipFrames": "Armazón",
-            "StarshipOtherSystems": "Otro Sistema",
-            "StarshipPowerCores": "Núcleo de Energía",
-            "StarshipReinforcedBulkheads": "Mamparos Reforzados",
-            "StarshipSecuritySystems": "Sistema de Seguridad",
-            "StarshipSensors": "Sensor",
-            "StarshipShields": "Escudo",
-            "StarshipThrusters": "Propulsores",
-            "StarshipWeapons": "Arma"
-        },
-        "PrimarySystems": "Sistemas Primarios",
-        "SecuritySystems": "Sistemas de Seguridad",
-        "SpecialAbilities": "Habilidades Especiales",
-        "Thrusters": "Propulsores"
-            },
-           "Header": {
-    "BP": "BP",
-    "CT": "CT",
-    "CriticalThreshold": "Umbral Crítico",
-    "DT": "DT",
-    "DamageThreshold": "Umbral de Daño",
-    "FrameMissing": "Armazón Ausente",
-    "HullPointIncrementTooltip": "Este es el número de puntos de casco que se añaden cuando la nave alcanza el nivel 4 (y cada 4 niveles después)",
-    "Max": "Máx",
-    "Misc": "Misceláneo",
-    "Movement": {
-        "Maneuverability": "Maniobrabilidad",
-        "ManeuverabilityTooltip": "Maniobrabilidad: {maneuverability}",
-        "Speed": "Velocidad",
-        "ThrustersMissing": "Propulsores Ausentes",
-        "Title": "Movimiento",
-        "Turn": "Giro"
-    },
-    "PCU": "PCU",
-    "Size": "Tamaño: {size}",
-    "Statistics": "Estadísticas",
-    "Thresholds": "Umbrales",
-    "Value": "Valor"
-},
-"Inventory": {
-    "Inventory": "Inventario"
-},
-"Modifiers": {
-    "AblativeOverload": "Sobrecarga ablativa: {mod}",
-    "Base": "Base: 10",
-    "ComputerBonus": "Bono de Computadora: {mod} ({source})",
-    "MiscModifier": "Modificador misceláneo: {value}",
-    "PilotSkillBonus": "Bono de habilidad de piloto: {value}",
-    "PilotingBonus": "Bono de pilotaje: {value}",
-    "SizeModifier": "Modificador de tamaño: {value}",
-    "UnevenAblative": "Ablativo irregular: {mod}"
-},
-"Quadrants": {
-    "AblativeHeader": "Armadura Ablativa",
-    "ArmorClass": "Clase de Armadura",
-    "EvenDistribution": "Distribución uniforme",
-    "Header": "Defensas del Cuadrante",
-    "NotAvailable": "No disponible",
-    "QuadrantLimit": "Límite del cuadrante",
-    "ShieldHeader": "Escudos",
-    "TargetLock": "Bloqueo de objetivo"
-},
-"RandomQuadrantMacro": {
-    "NoToken": "Selecciona el receptor del efecto crítico antes de continuar.",
-    "NotStarship": "El token seleccionado debe ser una nave estelar."
-},
-"Role": {
-    "Captain": "Capitán",
-    "ChiefMate": "Primer Oficial",
-    "Engineer": "Ingeniero",
-    "Gunner": "Artillero",
-    "MagicOfficer": "Oficial Mágico",
-    "MinorCrew": "Tripulación menor",
-    "OpenCrew": "Tripulación abierta",
-    "Passenger": "Pasajero",
-    "Pilot": "Piloto",
-    "ScienceOfficer": "Oficial Científico"
-},
-"Sides": {
-    "Aft": "Popa",
-    "Forward": "Proa",
-    "Port": "Babor",
-    "Starboard": "Estribor"
-},
-"Tabs": {
-    "Actions": "Acciones",
-    "Crew": "Tripulación",
-    "Weapons": "Armas"
-},
-"Weapons": {
-    "AftArc": "Arco de Popa ({slots})",
-    "CapitalSlots": "Capital: {current} / {max}",
-    "ForwardArc": "Arco de Proa ({slots})",
-    "HeavySlots": "Pesadas: {current} / {max}",
-    "LightSlots": "Ligeras: {current} / {max}",
-    "NoCapacity": "Esta arma no tiene cargas disponibles para atacar.",
-    "NotAvailable": "No disponible",
-    "NotMounted": "Armas desmontadas",
-    "PortArc": "Arco de Babor ({slots})",
-    "SpinalSlots": "Espinal: {current} / {max}",
-    "StarboardArc": "Arco de Estribor ({slots})",
-    "Turret": "Torreta ({slots})"
-            }
-        },
-"SubmitButtonLabel": "Enviar",
-"SystemWide": "A nivel del sistema",
-"TempHPMaxPlaceHolderText": "+Máx",
-"TempHPPlaceHolderText": "+Temp",
-"Text": "Texto",
-"ThemePlaceHolderText": "Tema",
-"Tippy": {
-    "Attributes": "Atributos:",
-    "ErrorNoTitle": "Debes definir un título para la descripción emergente."
-},
-"ToggleSkillsButtonLabel": "Alternar habilidades",
-"Touch": "Toque",
-"TraitArmorProf": "Competencias en armadura",
-"TraitWeaponProf": "Competencias en armas",
-"TurnEvent": {
-    "AddTurnEvent": "Agregar evento de turno",
-    "DeleteTurnEvent": "Eliminar evento de turno",
-    "Formula": "Fórmula",
-    "FormulaTooltip": "Una fórmula que se lanzará cuando se cumpla el disparador.",
-    "Name": "Nombre",
-    "NoteContent": "Contenido de la nota",
-    "NoteTooltip": "Texto que se enviará al chat como mensaje cuando se cumpla el disparador.",
-    "Trigger": "Disparador",
-    "TriggerTooltip": "Cuándo durante el turno del combatiente activar el evento.",
-    "TurnEventI": "Evento de turno {number}",
-    "Type": "Tipo",
-    "TypeTooltip": "El tipo de comportamiento para activar en este evento de turno.",
-    "Types": {
-        "Note": "Nota",
-        "Roll": "Tirada"
-    }
-},
-"UPBs": "UPB's",
-"Units": {
-    "Speed": "ft."
-},
-"Unlimited": "Ilimitado",
-"VehicleAttackSheet": {
-    "Details": {
-        "IgnoresHardness": "Ignora dureza"
-    },
-    "Errors": {
-        "NoDamage": "No puedes realizar una tirada de daño con este objeto."
-    },
-    "Header": {
-        "Save": "DC de salvación",
-        "SaveTooltip": "<strong>DC de salvación</strong><br/>Este es el modificador de la tirada de salvación para este ataque."
-    }
-},
-"VehicleSheet": {
-    "Attacks": {
-        "Attacks": "Ataques",
-        "Title": "Ataques",
-        "ToDo": "Esto todavía está en construcción."
-    },
-    "Details": {
-        "Dimensions": {
-            "Height": "Altura",
-            "Length": "Longitud",
-            "Title": "Dimensiones",
-            "Unit": "Pies",
-            "Width": "Ancho"
-
-
+        "SpellPreparationModesAlways": "Siempre Disponible",
+        "SpellPreparationModesInnate": "Conjuración Innata",
+        "SpellResistance": "Resistencia a conjuros",
+        "Stamina": "Aguante",
+        "StarshipSheet": {
+            "Actions": {
+                "Header": {
+                    "Phase": "Fase",
+                    "ResolvePoints": "Puntos de Resolución"
                 },
-               "Hardness": "Dureza",
-"HealthTooltip": "Si el vehículo se reduce a o por debajo del umbral, queda averiado. Mientras esté averiado, el vehículo recibe una penalización de –2 a su CA y a la DC de colisión, su modificador de pilotaje disminuye en 2, y su velocidad máxima y velocidad en mph se reducen a la mitad. Si el vehículo se reduce a 0 PS, queda destruido. Un vehículo destruido no puede ser pilotado, y puede ser difícil o imposible repararlo. Si el vehículo está en el agua cuando se destruye, se hunde; si está volando, cae.",
-"Modifiers": {
-    "AttackFullSpeed": "Ataque (a máxima velocidad)",
-    "AttackMoving": "Ataque (en movimiento)",
-    "AttackStopped": "Ataque (detenido)",
-    "AttackTooltip": "Los modificadores de ataque se aplican a los ataques del personaje realizados mientras está en el vehículo o con las armas montadas en el vehículo",
-    "Title": "Modificadores"
-},
-"Movement": {
-    "Drive": "Conducción",
-    "DrivePlaceholder": "p.ej., 20 pies",
-    "DriveTooltip": "Movimiento en combate táctico al usar una acción de movimiento.",
-    "Full": "Completo",
-    "FullPlaceholder": "p.ej., 500 pies",
-    "FullTooltip": "Movimiento en combate táctico al usar una acción completa.",
-    "Speed": "Velocidad",
-    "SpeedPlaceholder": "p.ej., 55 mph",
-    "SpeedTooltip": "Velocidad general sobre terreno.",
-    "Title": "Velocidad"
-},
-"OtherAttributes": {
-    "Complement": "Tripulación",
-    "Cover": "Cobertura",
-    "ExpansionBays": "Bahías de expansión",
-    "HangarBays": "Bahías de hangar",
-    "Passengers": "Pasajeros",
-    "Size": "Tamaño",
-    "Title": "Otros atributos",
-    "Type": "Tipo"
-},
-"Threshold": "Umbral"
-},
-"Hangar": {
-    "AssignedCount": "({current} / {max})",
-    "ExpansionBays": "Bahías de expansión",
-    "PrimarySystems": "Sistemas principales",
-    "UnlimitedMax": "Sin límite",
-    "Vehicles": "Vehículos",
-    "VehiclesLimitReached": "Has alcanzado la cantidad máxima de vehículos permitidos en las bahías de hangar de este vehículo."
-},
+                "Tooltips": {
+                    "CriticalEffect": "Efecto Crítico",
+                    "NormalEffect": "Efecto normal",
+                    "Push": "Impulso",
+                    "PushTooltip": "Las acciones de impulso (indicadas en el encabezado de la acción) son difíciles de realizar pero pueden producir mejores resultados. No puedes realizar una acción de impulso si el sistema necesario está averiado o destruido (como se indica en las Condiciones de Daño Crítico en la página 321)."
+                }
+            },
+            "Attributes": {
+                "BuildPoints": "Puntos de Construcción",
+                "BuildPointsUsage": "Uso",
+                "Complement": "Tripulación",
+                "ComplementMax": "Número máximo de tripulantes que pueden asignarse a un rol en la nave (no es el máximo de criaturas a bordo).",
+                "ComplementMin": "Tripulación mínima necesaria para operar la nave.",
+                "Computer": "Computadora",
+                "DriftNotAvailable": "No disponible",
+                "DriftRating": "Clasificación de Deriva",
+                "Power": "Núcleo de Energía",
+                "PowerConsumption": "Consumo",
+                "PowerMissing": "Falta Núcleo de Energía"
+            },
+            "Crew": {
+                "ActionsPerRound": "Acciones por ronda",
+                "AddSkill": "Agregar habilidad",
+                "AssignedCount": "({current} / {max})",
+                "Captain": "Capitán",
+                "ChiefMates": "Primeros Oficiales",
+                "CrewLimitReached": "Has alcanzado la cantidad máxima de tripulantes permitidos para el rol '{targetRole}'.",
+                "CrewSetting": "Configuración de tripulación",
+                "Engineers": "Ingenieros",
+                "Gunners": "Artilleros",
+                "Header": "Tripulación de la Nave",
+                "IsNPCCrew": "Es tripulación NPC",
+                "MagicOfficers": "Oficiales Mágicos",
+                "NPCGunnerRanksMessage": "Aunque los rangos no afectan el modificador de artillería de un NPC, algunas fichas incluyen el nivel del artillero, que puedes almacenar aquí. De lo contrario, puedes dejar esta casilla en blanco.",
+                "Passengers": "Pasajeros",
+                "Pilot": "Piloto",
+                "RemoveCrewMember": "Eliminar miembro de la tripulación",
+                "ScienceOfficers": "Oficiales Científicos",
+                "SkillModifier": "Modificador",
+                "SkillRanks": "Rangos",
+                "UnlimitedMax": "Sin límite"
+            },
+            "Critical": {
+                "Edit": "Editar roles afectados.",
+                "EditMessage": "Selecciona qué roles se ven afectados por el daño en este sistema.",
+                "EditTitle": "Seleccionar roles afectados",
+                "Header": "Daño Crítico",
+                "Status": {
+                    "Glitching": "Fallas",
+                    "Malfunctioning": "Mal funcionamiento",
+                    "Nominal": "Nominal",
+                    "Wrecked": "Destruido"
+                },
+                "Systems": {
+                    "Engines": "Motores",
+                    "LifeSupport": "Soporte Vital",
+                    "PowerCore": "Núcleo de Energía",
+                    "Sensors": "Sensores",
+                    "WeaponsArrayAft": "Armas (Popa)",
+                    "WeaponsArrayForward": "Armas (Proa)",
+                    "WeaponsArrayPort": "Armas (Babor)",
+                    "WeaponsArrayStarboard": "Armas (Estribor)"
+                }
+            },
+            "Damage": {
+                "CrossedCriticalThreshold": "¡{name} cruzó {crossedThresholds} umbrales críticos!",
+                "Message": "El daño a una nave siempre proviene de una dirección específica, por favor selecciona el cuadrante al que debe aplicarse el daño entrante.",
+                "Nat20": "¡Daño crítico! {name} sufre un efecto de daño crítico.",
+                "Nat20WithThreshold": "¡Daño crítico! {name} sufre un efecto de daño crítico adicional.",
+                "Quadrant": {
+                    "Aft": "Popa",
+                    "Forward": "Proa",
+                    "Port": "Babor",
+                    "Quadrant": "Cuadrante",
+                    "Starboard": "Estribor"
+                },
+                "Title": "{name} - Selecciona el cuadrante dañado."
+            },
+            "Details": {
+                "Ablative": {
+                    "Aft": "Armadura Ablativa (Popa)",
+                    "Forward": "Armadura Ablativa (Proa)",
+                    "Header": "Ablativa",
+                    "Port": "Armadura Ablativa (Babor)",
+                    "Starboard": "Armadura Ablativa (Estribor)"
+                },
+                "AblativeExceedsHull": "¡El total de ablativa excede el doble de los puntos de casco!",
+                "AblativeExceedsHullTooltip": "Una nave no puede soportar armadura ablativa si sus Puntos de Casco temporales exceden el doble del total estándar de Puntos de Casco. (Para más información, consulta el Manual de Operaciones de Nave, pág. 20)",
+                "AblativeTooHigh": "¡Demasiada ablativa asignada!",
+                "AblativeTooHighTooltip": "O el total de ablativa instalada es demasiado alto, o la suma actual de ablativa es demasiado alta.",
+                "ShieldHighestTooHigh": "¡Uno o más cuadrantes exceden los límites!",
+                "ShieldHighestTooHighTooltip": "Un cuadrante de escudo no puede exceder el 70% de la asignación total de escudos, ya que el mínimo disponible para cada escudo debe ser del 10%. (Para más información, consulta el Libro Básico, pág. 302)",
+                "ShieldTotalTooHigh": "¡El total de escudos excede el máximo!",
+                "ShieldTotalTooHighTooltip": "La suma total de escudos excede la salida máxima del escudo.",
+                "Shields": {
+                    "Aft": "Escudos (Popa)",
+                    "Conventional": "Escudos",
+                    "Deflector": "DV de Escudo",
+                    "Forward": "Escudos (Proa)",
+                    "Header": "Escudos",
+                    "Port": "Escudos (Babor)",
+                    "Starboard": "Escudos (Estribor)"
+                }
+            },
+            "Features": {
+                "ExpansionBays": "Bahías de Expansión ({current} / {max})",
+                "Frame": "Armazón ({current} / 1)",
+                "OtherSystems": "Otros Sistemas",
+                "PowerCores": "Núcleos de Energía",
+                "Prefixes": {
+                    "StarshipAblativeArmors": "Armadura Ablativa",
+                    "StarshipArmors": "Armadura",
+                    "StarshipComputers": "Computadora",
+                    "StarshipCrewQuarters": "Cuartos de Tripulación",
+                    "StarshipDefensiveCountermeasures": "Contramedida Defensiva",
+                    "StarshipDriftEngine": "Motor de Deriva",
+                    "StarshipExpansionBays": "Bahía de Expansión",
+                    "StarshipFortifiedHulls": "Casco Fortificado",
+                    "StarshipFrames": "Armazón",
+                    "StarshipOtherSystems": "Otro Sistema",
+                    "StarshipPowerCores": "Núcleo de Energía",
+                    "StarshipReinforcedBulkheads": "Mamparos Reforzados",
+                    "StarshipSecuritySystems": "Sistema de Seguridad",
+                    "StarshipSensors": "Sensor",
+                    "StarshipShields": "Escudo",
+                    "StarshipThrusters": "Propulsores",
+                    "StarshipWeapons": "Arma"
+                },
+                "PrimarySystems": "Sistemas Primarios",
+                "SecuritySystems": "Sistemas de Seguridad",
+                "SpecialAbilities": "Habilidades Especiales",
+                "Thrusters": "Propulsores"
+            },
+            "Header": {
+                "BP": "BP",
+                "CT": "CT",
+                "CriticalThreshold": "Umbral Crítico",
+                "DT": "DT",
+                "DamageThreshold": "Umbral de Daño",
+                "FrameMissing": "Armazón Ausente",
+                "HullPointIncrementTooltip": "Este es el número de puntos de casco que se añaden cuando la nave alcanza el nivel 4 (y cada 4 niveles después)",
+                "Max": "Máx",
+                "Misc": "Misceláneo",
+                "Movement": {
+                    "Maneuverability": "Maniobrabilidad",
+                    "ManeuverabilityTooltip": "Maniobrabilidad: {maneuverability}",
+                    "Speed": "Velocidad",
+                    "ThrustersMissing": "Propulsores Ausentes",
+                    "Title": "Movimiento",
+                    "Turn": "Giro"
+                },
+                "PCU": "PCU",
+                "Size": "Tamaño: {size}",
+                "Statistics": "Estadísticas",
+                "Thresholds": "Umbrales",
+                "Value": "Valor"
+            },
+            "Inventory": {
+                "Inventory": "Inventario"
+            },
+            "Modifiers": {
+                "AblativeOverload": "Sobrecarga ablativa: {mod}",
+                "Base": "Base: 10",
+                "ComputerBonus": "Bono de Computadora: {mod} ({source})",
+                "MiscModifier": "Modificador misceláneo: {value}",
+                "PilotSkillBonus": "Bono de habilidad de piloto: {value}",
+                "PilotingBonus": "Bono de pilotaje: {value}",
+                "SizeModifier": "Modificador de tamaño: {value}",
+                "UnevenAblative": "Ablativo irregular: {mod}"
+            },
+            "Quadrants": {
+                "AblativeHeader": "Armadura Ablativa",
+                "ArmorClass": "Clase de Armadura",
+                "EvenDistribution": "Distribución uniforme",
+                "Header": "Defensas del Cuadrante",
+                "NotAvailable": "No disponible",
+                "QuadrantLimit": "Límite del cuadrante",
+                "ShieldHeader": "Escudos",
+                "TargetLock": "Bloqueo de objetivo"
+            },
+            "RandomQuadrantMacro": {
+                "NoToken": "Selecciona el receptor del efecto crítico antes de continuar.",
+                "NotStarship": "El token seleccionado debe ser una nave estelar."
+            },
+            "Role": {
+                "Captain": "Capitán",
+                "ChiefMate": "Primer Oficial",
+                "Engineer": "Ingeniero",
+                "Gunner": "Artillero",
+                "MagicOfficer": "Oficial Mágico",
+                "MinorCrew": "Tripulación menor",
+                "OpenCrew": "Tripulación abierta",
+                "Passenger": "Pasajero",
+                "Pilot": "Piloto",
+                "ScienceOfficer": "Oficial Científico"
+            },
+            "Sides": {
+                "Aft": "Popa",
+                "Forward": "Proa",
+                "Port": "Babor",
+                "Starboard": "Estribor"
+            },
+            "Tabs": {
+                "Actions": "Acciones",
+                "Crew": "Tripulación",
+                "Weapons": "Armas"
+            },
+            "Weapons": {
+                "AftArc": "Arco de Popa ({slots})",
+                "CapitalSlots": "Capital: {current} / {max}",
+                "ForwardArc": "Arco de Proa ({slots})",
+                "HeavySlots": "Pesadas: {current} / {max}",
+                "LightSlots": "Ligeras: {current} / {max}",
+                "NoCapacity": "Esta arma no tiene cargas disponibles para atacar.",
+                "NotAvailable": "No disponible",
+                "NotMounted": "Armas desmontadas",
+                "PortArc": "Arco de Babor ({slots})",
+                "SpinalSlots": "Espinal: {current} / {max}",
+                "StarboardArc": "Arco de Estribor ({slots})",
+                "Turret": "Torreta ({slots})"
+            }
+        },
+        "SubmitButtonLabel": "Enviar",
+        "SystemWide": "A nivel del sistema",
+        "TempHPMaxPlaceHolderText": "+Máx",
+        "TempHPPlaceHolderText": "+Temp",
+        "Text": "Texto",
+        "ThemePlaceHolderText": "Tema",
+        "Tippy": {
+            "Attributes": "Atributos:",
+            "ErrorNoTitle": "Debes definir un título para la descripción emergente."
+        },
+        "ToggleSkillsButtonLabel": "Alternar habilidades",
+        "Touch": "Toque",
+        "TraitArmorProf": "Competencias en armadura",
+        "TraitWeaponProf": "Competencias en armas",
+        "TurnEvent": {
+            "AddTurnEvent": "Agregar evento de turno",
+            "DeleteTurnEvent": "Eliminar evento de turno",
+            "Formula": "Fórmula",
+            "FormulaTooltip": "Una fórmula que se lanzará cuando se cumpla el disparador.",
+            "Name": "Nombre",
+            "NoteContent": "Contenido de la nota",
+            "NoteTooltip": "Texto que se enviará al chat como mensaje cuando se cumpla el disparador.",
+            "Trigger": "Disparador",
+            "TriggerTooltip": "Cuándo durante el turno del combatiente activar el evento.",
+            "TurnEventI": "Evento de turno {number}",
+            "Type": "Tipo",
+            "TypeTooltip": "El tipo de comportamiento para activar en este evento de turno.",
+            "Types": {
+                "Note": "Nota",
+                "Roll": "Tirada"
+            }
+        },
+        "UPBs": "UPB's",
+        "Units": {
+            "Speed": "ft."
+        },
+        "Unlimited": "Ilimitado",
+        "VehicleAttackSheet": {
+            "Details": {
+                "IgnoresHardness": "Ignora dureza"
+            },
+            "Errors": {
+                "NoDamage": "No puedes realizar una tirada de daño con este objeto."
+            },
+            "Header": {
+                "Save": "DC de salvación",
+                "SaveTooltip": "<strong>DC de salvación</strong><br/>Este es el modificador de la tirada de salvación para este ataque."
+            }
+        },
+        "VehicleSheet": {
+            "Attacks": {
+                "Attacks": "Ataques",
+                "Title": "Ataques",
+                "ToDo": "Esto todavía está en construcción."
+            },
+            "Details": {
+                "Dimensions": {
+                    "Height": "Altura",
+                    "Length": "Longitud",
+                    "Title": "Dimensiones",
+                    "Unit": "Pies",
+                    "Width": "Ancho"
+                },
+                "Hardness": "Dureza",
+                "HealthTooltip": "Si el vehículo se reduce a o por debajo del umbral, queda averiado. Mientras esté averiado, el vehículo recibe una penalización de –2 a su CA y a la DC de colisión, su modificador de pilotaje disminuye en 2, y su velocidad máxima y velocidad en mph se reducen a la mitad. Si el vehículo se reduce a 0 PS, queda destruido. Un vehículo destruido no puede ser pilotado, y puede ser difícil o imposible repararlo. Si el vehículo está en el agua cuando se destruye, se hunde; si está volando, cae.",
+                "Modifiers": {
+                    "AttackFullSpeed": "Ataque (a máxima velocidad)",
+                    "AttackMoving": "Ataque (en movimiento)",
+                    "AttackStopped": "Ataque (detenido)",
+                    "AttackTooltip": "Los modificadores de ataque se aplican a los ataques del personaje realizados mientras está en el vehículo o con las armas montadas en el vehículo",
+                    "Title": "Modificadores"
+                },
+                "Movement": {
+                    "Drive": "Conducción",
+                    "DrivePlaceholder": "p.ej., 20 pies",
+                    "DriveTooltip": "Movimiento en combate táctico al usar una acción de movimiento.",
+                    "Full": "Completo",
+                    "FullPlaceholder": "p.ej., 500 pies",
+                    "FullTooltip": "Movimiento en combate táctico al usar una acción completa.",
+                    "Speed": "Velocidad",
+                    "SpeedPlaceholder": "p.ej., 55 mph",
+                    "SpeedTooltip": "Velocidad general sobre terreno.",
+                    "Title": "Velocidad"
+                },
+                "OtherAttributes": {
+                    "Complement": "Tripulación",
+                    "Cover": "Cobertura",
+                    "ExpansionBays": "Bahías de expansión",
+                    "HangarBays": "Bahías de hangar",
+                    "Passengers": "Pasajeros",
+                    "Size": "Tamaño",
+                    "Title": "Otros atributos",
+                    "Type": "Tipo"
+                },
+                "Threshold": "Umbral"
+            },
+            "Hangar": {
+                "AssignedCount": "({current} / {max})",
+                "ExpansionBays": "Bahías de expansión",
+                "PrimarySystems": "Sistemas principales",
+                "UnlimitedMax": "Sin límite",
+                "Vehicles": "Vehículos",
+                "VehiclesLimitReached": "Has alcanzado la cantidad máxima de vehículos permitidos en las bahías de hangar de este vehículo."
+            },
 
-"Header": {
-    "Level": "Nivel",
-    "LevelPlaceholder": "1",
-    "NamePlaceholder": "Nombre del vehículo",
-    "NameTooltip": "Introduce aquí el nombre del vehículo.",
-    "Price": "Precio",
-    "PricePlaceholder": "Precio en créditos",
-    "PriceTooltip": "La cantidad de créditos que vale este vehículo."
-},
+            "Header": {
+                "Level": "Nivel",
+                "LevelPlaceholder": "1",
+                "NamePlaceholder": "Nombre del vehículo",
+                "NameTooltip": "Introduce aquí el nombre del vehículo.",
+                "Price": "Precio",
+                "PricePlaceholder": "Precio en créditos",
+                "PriceTooltip": "La cantidad de créditos que vale este vehículo."
+            },
 
-"Passengers": {
-    "AssignedCount": "({current} / {max})",
-    "Complement": "Tripulación",
-    "Header": "Pasajeros del vehículo",
-    "IsNPCPassengers": "Son pasajeros PNJ",
-    "NPCPilotingHint": "Puedes hacer una tirada de Pilotaje para el piloto PNJ desde la pestaña Detalles",
-    "Passengers": "Pasajeros",
-    "PassengersLimitReached": "Has alcanzado la cantidad máxima de pasajeros permitidos para el rol de '{targetRole}'.",
-    "PassengersSetting": "Pasajeros PNJ",
-    "Pilot": "Piloto",
-    "Piloting": "Tirada de pilotaje",
-    "Title": "Pasajeros",
-    "UnlimitedMax": "Sin límite"
-},
+            "Passengers": {
+                "AssignedCount": "({current} / {max})",
+                "Complement": "Tripulación",
+                "Header": "Pasajeros del vehículo",
+                "IsNPCPassengers": "Son pasajeros PNJ",
+                "NPCPilotingHint": "Puedes hacer una tirada de Pilotaje para el piloto PNJ desde la pestaña Detalles",
+                "Passengers": "Pasajeros",
+                "PassengersLimitReached": "Has alcanzado la cantidad máxima de pasajeros permitidos para el rol de '{targetRole}'.",
+                "PassengersSetting": "Pasajeros PNJ",
+                "Pilot": "Piloto",
+                "Piloting": "Tirada de pilotaje",
+                "Title": "Pasajeros",
+                "UnlimitedMax": "Sin límite"
+            },
 
-"Systems": {
-    "Piloting": "Pilotaje",
-    "RollPiloting": "Tirada de pilotaje"
-},
+            "Systems": {
+                "Piloting": "Pilotaje",
+                "RollPiloting": "Tirada de pilotaje"
+            },
 
-"Tabs": {
-    "Attacks": "Ataques",
-    "Hangar": "Hangar",
-    "Passengers": "Pasajeros",
-    "Systems": "Sistemas"
+            "Tabs": {
+                "Attacks": "Ataques",
+                "Hangar": "Hangar",
+                "Passengers": "Pasajeros",
+                "Systems": "Sistemas"
             }
         },
 
-"VehicleSystemSheet": {
-    "Activated": "Activado",
-    "CanBeActivated": "Puede ser activado",
-    "CanBeActivatedTooltip": "Este sistema tiene un estado activado.",
-    "NotActivated": "No activado",
-    "Piloting": "Pilotaje",
-    "PilotingTooltip": "Modificador de pilotaje para aplicar al usar este sistema para pilotar.",
-    "Senses": "Sentidos",
-    "SensesTooltip": "Una criatura en este vehículo puede intentar chequeos de Percepción usando el sentido listado en el rango indicado.",
-    "UseForSenses": "Usar para sentidos",
-    "UseForSensesTooltip": "Este sistema puede usarse para hacer chequeos de percepción.",
-    "UseToPilot": "Usar para pilotar",
-    "UseToPilotTooltip": "Este sistema puede usarse para hacer chequeos de pilotaje cuando está activado.",
-    "isActivated": "Está activado",
-    "isActivatedTooltip": "Está activado actualmente"
-},
-
-"Vehicles": {
-    "VehicleCoverTypes": {
-        "Cover": "Cobertura",
-        "Improved": "Cobertura mejorada",
-        "None": "Ninguna",
-        "Partial": "Cobertura parcial",
-        "Soft": "Cobertura ligera",
-        "Total": "Cobertura total"
-    },
-    "VehicleTypes": {
-        "Air": "Aéreo",
-        "Hover": "Flotante",
-        "Land": "Terrestre",
-        "Landa": "Tierra y aire",
-        "Landatw": "Tierra, aire, túneles y agua",
-        "Landaw": "Tierra, aire y agua",
-        "Landt": "Tierra y túneles",
-        "Landtw": "Tierra, túneles y agua",
-        "Landw": "Tierra y agua",
-        "Water": "Acuático"
-    }
-},
-
-"WeaponCategoriesCryo": "Armas criogénicas",
-"WeaponCategoriesDisintegrator": "Armas desintegradoras",
-"WeaponCategoriesDisruption": "Armas disruptoras",
-"WeaponCategoriesFlame": "Armas de llama",
-"WeaponCategoriesLaser": "Armas láser",
-"WeaponCategoriesPlasma": "Armas de plasma",
-"WeaponCategoriesProjectile": "Armas de proyectiles",
-"WeaponCategoriesShock": "Armas de choque",
-"WeaponCategoriesSonic": "Armas sónicas",
-"WeaponCategoriesUncategorized": "Armas sin categoría",
-
-"WeaponCriticalHitEffects": {
-    "Arc": "Arco",
-    "Bleed": "Sangrado",
-    "Burn": "Quemadura",
-    "Corrode": "Corrosión",
-    "Deafen": "Ensordecer",
-    "Injection": "DC de Inyección + 2",
-    "Knockdown": "Derribo",
-    "SevereWound": "Herida grave",
-    "Staggered": "Aturdido",
-    "Stunned": "Atontado",
-    "Wound": "Herida"
+        "VehicleSystemSheet": {
+            "Activated": "Activado",
+            "CanBeActivated": "Puede ser activado",
+            "CanBeActivatedTooltip": "Este sistema tiene un estado activado.",
+            "NotActivated": "No activado",
+            "Piloting": "Pilotaje",
+            "PilotingTooltip": "Modificador de pilotaje para aplicar al usar este sistema para pilotar.",
+            "Senses": "Sentidos",
+            "SensesTooltip": "Una criatura en este vehículo puede intentar chequeos de Percepción usando el sentido listado en el rango indicado.",
+            "UseForSenses": "Usar para sentidos",
+            "UseForSensesTooltip": "Este sistema puede usarse para hacer chequeos de percepción.",
+            "UseToPilot": "Usar para pilotar",
+            "UseToPilotTooltip": "Este sistema puede usarse para hacer chequeos de pilotaje cuando está activado.",
+            "isActivated": "Está activado",
+            "isActivatedTooltip": "Está activado actualmente"
+        },
+        "Vehicles": {
+            "VehicleCoverTypes": {
+                "Cover": "Cobertura",
+                "Improved": "Cobertura mejorada",
+                "None": "Ninguna",
+                "Partial": "Cobertura parcial",
+                "Soft": "Cobertura ligera",
+                "Total": "Cobertura total"
+            },
+            "VehicleTypes": {
+                "Air": "Aéreo",
+                "Hover": "Flotante",
+                "Land": "Terrestre",
+                "Landa": "Tierra y aire",
+                "Landatw": "Tierra, aire, túneles y agua",
+                "Landaw": "Tierra, aire y agua",
+                "Landt": "Tierra y túneles",
+                "Landtw": "Tierra, túneles y agua",
+                "Landw": "Tierra y agua",
+                "Water": "Acuático"
+            }
+        },
+        "WeaponCategoriesCryo": "Armas criogénicas",
+        "WeaponCategoriesDisintegrator": "Armas desintegradoras",
+        "WeaponCategoriesDisruption": "Armas disruptoras",
+        "WeaponCategoriesFlame": "Armas de llama",
+        "WeaponCategoriesLaser": "Armas láser",
+        "WeaponCategoriesPlasma": "Armas de plasma",
+        "WeaponCategoriesProjectile": "Armas de proyectiles",
+        "WeaponCategoriesShock": "Armas de choque",
+        "WeaponCategoriesSonic": "Armas sónicas",
+        "WeaponCategoriesUncategorized": "Armas sin categoría",
+        "WeaponCriticalHitEffects": {
+            "Arc": "Arco",
+            "Bleed": "Sangrado",
+            "Burn": "Quemadura",
+            "Corrode": "Corrosión",
+            "Deafen": "Ensordecer",
+            "Injection": "DC de Inyección + 2",
+            "Knockdown": "Derribo",
+            "SevereWound": "Herida grave",
+            "Staggered": "Aturdido",
+            "Stunned": "Atontado",
+            "Wound": "Herida"
         },
         "WeaponProficiencyAdvMelee": "Combate Cuerpo a Cuerpo Avanzado",
-    "WeaponProficiencyBasicMelee": "Combate Cuerpo a Cuerpo Básico",
-    "WeaponProficiencyGrenades": "Granadas",
-    "WeaponProficiencyHeavy": "Armas Pesadas",
-    "WeaponProficiencyLongArms": "Armas Largas",
-    "WeaponProficiencySmallArms": "Armas Cortas",
-    "WeaponProficiencySniper": "Armas de Francotirador",
-    "WeaponProficiencySpecial": "Armas Especiales",
-    "WeaponPropertiesAeon": "Aeón",
-    "WeaponPropertiesAeonTooltip": "Un arma que tiene la propiedad especial aeón incluye una ranura que puede alojar una piedra aeón. Como acción estándar, puedes insertar una piedra aeón en la ranura o retirarla. Solo puedes insertar una piedra aeón en un arma si el nivel del objeto del arma es igual o mayor que el nivel del objeto de la piedra aeón. No obtienes los beneficios normales de la piedra mientras está insertada en el arma. En cambio, un arma aeón con una piedra aeón insertada obtiene la propiedad especial de arma potenciadora (boost), siempre que no tenga las propiedades de explosión (blast) o engorroso (unwieldy). El aumento del daño por el potenciador depende del nivel del objeto de la piedra aeón insertada, como sigue: niveles 1–5, 1d4; niveles 6–10, 1d6; niveles 11–15, 1d8; niveles 16–20, 1d10.<br><br>Una piedra aeón insertada tiene un número de cargas por día igual al nivel del objeto de la piedra. Usar la propiedad especial de potenciador consume cargas de la piedra igual al valor de uso del arma. Si la piedra no tiene suficientes cargas, el intento de potenciación no tiene efecto. Una piedra aeón que haya gastado cargas diarias de esta manera cambia a un color apagado y no confiere sus beneficios habituales si se retira del arma aeón.",
-    "WeaponPropertiesAmmunition": "Munición",
-    "WeaponPropertiesAnalog": "Análogo",
-    "WeaponPropertiesAnalogTooltip": "Esta arma no usa electrónica avanzada, sistemas computarizados ni fuentes de energía eléctrica. Es inmune a habilidades que atacan tecnología. Aunque el uso del término “análogo” no es técnicamente correcto para tecnología, este uso se ha vuelto común en los Mundos del Pacto.",
-    "WeaponPropertiesAntibiological": "Antibiológico",
-    "WeaponPropertiesAntibiologicalTooltip": "Un arma antibiológica solo daña objetivos vivos. Objetos y criaturas con la cualidad especial no vivos, como robots y no muertos, son inmunes a sus efectos.",
-    "WeaponPropertiesArchaic": "Arcaico",
-    "WeaponPropertiesArchaicTooltip": "Esta arma inflige 5 puntos de daño menos a menos que el objetivo no lleve armadura o lleve armadura arcaica. Las armas arcaicas están hechas de materiales primitivos como madera o acero común.",
-    "WeaponPropertiesAurora": "Aurora",
-    "WeaponPropertiesAuroraTooltip": "Cuando un arma aurora golpea un objetivo, la criatura brilla con una luminiscencia suave durante 1 minuto. Esto anula efectos de invisibilidad e impide que el objetivo obtenga ocultamiento o se esconda en sombras o áreas oscuras.",
-    "WeaponPropertiesAutomatic": "Automática",
-    "WeaponPropertiesAutomaticTooltip": "Además de hacer ataques a distancia normalmente, un arma con esta propiedad especial puede disparar en modo automático completo. No se requiere acción para cambiar entre ataques normales y modo automático.<br><br>Al hacer un ataque completo en modo automático, puedes atacar en un cono con rango de la mitad del incremento de alcance del arma. Esto usa toda la munición restante del arma. Haz una tirada de ataque contra cada objetivo en el cono, empezando por los más cercanos. Los ataques en modo automático no pueden lograr golpes críticos. Lanza daño solo una vez y aplícalo a todos los objetivos alcanzados. Cada ataque contra una criatura usa la munición equivalente a dos disparos, y cuando ya no tengas munición suficiente para atacar otro objetivo, dejas de atacar.<br><br>Por ejemplo, con un arma X-gen táctica con 27 balas restantes, atacarías a las 6 criaturas más cercanas en el cono usando las 27 balas.<br><br>Si hay varias criaturas a la misma distancia y no tienes munición para atacar a todas, decide al azar cuál atacar. No puedes evitar atacar aliados en el cono ni atacar dos veces al mismo objetivo. Los ataques en modo automático tienen las mismas penalizaciones que otros ataques completos.",
-    "WeaponPropertiesBlast": "Explosión",
-    "WeaponPropertiesBlastTooltip": "Esta arma dispara en un cono que se extiende solo hasta su primer incremento de alcance. No puedes atacar objetivos más allá de ese rango.\nPor cada ataque con un arma con la propiedad especial de explosión, haz una tirada de ataque contra cada objetivo en el cono, empezando por los más cercanos. Cada ataque tiene una penalización de –2 además de otras penalizaciones, como la penalización por ataques múltiples. Lanza daño solo una vez para todos los objetivos. Si logras uno o más golpes críticos, lanza el daño crítico extra solo una vez (o cualquier otro efecto especial de golpe crítico que requiera tirada) y aplícalo a cada criatura alcanzada con crítico. No puedes evitar atacar aliados ni atacar dos veces al mismo objetivo.<br><br>Los ataques con armas de explosión ignoran ocultamiento. Un arma de explosión no se beneficia de dotes o habilidades que aumentan el daño de un solo ataque (como el ataque trucado del operativo). La munición de armas de explosión está diseñada para ataques en cono, por lo que se gasta el valor de uso solo una vez por cada cono de ataques.",
-    "WeaponPropertiesBlock": "Bloqueo",
-    "WeaponPropertiesBlockTooltip": "Solo armas cuerpo a cuerpo pueden tener la propiedad especial bloqueo, que representa algún tipo de guarda o barra que protege de ataques del enemigo al que golpeas en cuerpo a cuerpo. Al impactar con éxito a un objetivo con un ataque cuerpo a cuerpo usando esta arma, obtienes un bono de mejora +1 a tu CA por 1 ronda contra ataques cuerpo a cuerpo de ese objetivo.",
-    "WeaponPropertiesBoost": "Potenciador",
-    "WeaponPropertiesBoostTooltip": "Puedes cargar un arma con esta propiedad especial como acción de movimiento. Al hacerlo, aumentas el daño del arma en la cantidad listada en el siguiente ataque que hagas con ella. Potenciar consume cargas del arma igual a su valor de uso. Esto aumenta el daño y se multiplica en un golpe crítico. Potenciar más de una vez antes de disparar no tiene efecto adicional y la carga extra se pierde si no disparas antes del fin de tu siguiente turno.",
-    "WeaponPropertiesBreach": "Apertura",
-    "WeaponPropertiesBreachTooltip": "Un arma de apertura está diseñada para aplicar fuerza súbita a puertas y muros para romperlos. Si estás entrenado en Ingeniería, como acción completa puedes usarla contra una puerta o muro estacionario adyacente o, a discreción del DJ, contra un objeto similar. El ataque consume munición como normal, pero en lugar de tirada de ataque, haces una prueba de Fuerza contra la DC de rotura del objeto (Reglas Básicas 408) y añades el nivel del objeto del arma.",
-    "WeaponPropertiesBreakdown": "Desmontable",
-    "WeaponPropertiesBreakdownTooltip": "Un arma desmontable puede dividirse en múltiples piezas pequeñas. Mientras está desmontada, el arma se considera especialmente pequeña o fácil de ocultar para la tarea de ocultar objetos con Juego de Manos y puede caber en espacios que normalmente solo sostienen objetos de peso ligero (como las bolsas de las mejillas de un ysoki). Tomar o armar el arma desmontable toma 1 minuto.",
-    "WeaponPropertiesBright": "Brillante",
-    "WeaponPropertiesBrightTooltip": "Los ataques con armas brillantes iluminan el área dentro de 6 metros (20 pies) alrededor del objetivo por 1 ronda después del ataque, aumentando el nivel de iluminación en un paso, hasta un máximo de luz normal.",
-    "WeaponPropertiesButtressing": "Refuerzo",
-    "WeaponPropertiesButtressingTooltip": "Al activarse, esta arma emite cargas estáticas sutiles que unen firmemente objetos cercanos entre sí, otorgándoles mayor resistencia a ataques entrantes. Después de atacar con esta arma: aumentas el bono de CA que obtienes por cobertura en 1, aumentas la dureza de objetos a 1.5 metros (5 pies) por una cantidad igual a 1/4 x el nivel del objeto del arma y obtienes +1 a tu CA contra maniobras de combate. Estos beneficios duran hasta que te mueves o hasta el comienzo de tu siguiente turno, lo que ocurra primero. Objetos movidos de su lugar pierden el beneficio inmediatamente. Los efectos de múltiples ataques con armas de refuerzo no se acumulan.",
-    "WeaponPropertiesCluster": "Agrupado",
-    "WeaponPropertiesClusterTooltip": "Un arma agrupada es un tipo de lanzagranadas que puede disparar una sola granada o, si está cargada con granadas apropiadas, puede gastar dos granadas idénticas en un solo ataque. En este caso, las granadas actúan como una sola del mismo tipo (una tirada de ataque, daño una sola vez, etc.), excepto que su radio se incrementa por la cantidad listada y la DC de salvación de los efectos de la granada se calcula usando el nivel del objeto del arma agrupada si es mayor que el de la granada. Intentar disparar dos granadas diferentes genera un error y el arma no dispara.",
-    "WeaponPropertiesDeconstruct": "Descomponer",
-    "WeaponPropertiesDeconstructTooltip": "El objetivo de un arma con la propiedad especial descomponer recibe la cantidad listada de daño ácido cada ronda hasta que el objetivo tenga éxito en una salvación de Reflejos para terminar el daño. Esto funciona como la condición de quemadura, excepto lo señalado, y el daño continuo también termina si el objetivo recibe daño eléctrico.",
-    "WeaponPropertiesDeflect": "Desviar",
-    "WeaponPropertiesDeflectTooltip": "Un arma con la propiedad especial desviar genera un efecto tanto energético como cinético, lo que permite usarla con la dote Desviar Proyectiles (si la tienes) para contrarrestar ataques a distancia tanto cinéticos como energéticos.",
-    "WeaponPropertiesDisarm": "Desarmar",
-    "WeaponPropertiesDisarmTooltip": "Al intentar una maniobra de desarme mientras empuñas un arma con la propiedad desarmar, obtienes un bono +2 a tu tirada de ataque.",
-    "WeaponPropertiesDouble": "Doble",
-       "WeaponPropertiesDoubleTooltip": "Un arma doble tiene dos armas diferentes colocadas una al final de la otra, para que puedas atacar con cualquiera de ellas fácilmente sin cambiar tu agarre. Para el propósito de la dote Combate Multi-Arma, un arma doble se trata como dos o más armas cuerpo a cuerpo operativas. Un arma doble no se considera un arma operativa para ningún otro propósito a menos que tenga la propiedad especial de arma operativa.<br><br>Algunas armas dobles tienen extremos que infligen diferentes tipos de daño. Al realizar un solo ataque con tal arma, puedes elegir qué tipo de daño causar, pero si haces más de un ataque en el mismo turno, al menos uno de esos ataques debe realizarse con el segundo tipo de daño. La categoría del arma de un arma doble que inflige más de un tipo de daño se basa en el primer tipo de daño listado. Si su segundo tipo de daño hace que se considere una categoría de arma diferente al causar ese daño, esa categoría se indica entre paréntesis. Por ejemplo, un arma doble en la categoría de fuego que inflige 1d6 de daño por fuego o 1d6 de daño por frío se lista como “doble (crio)” para indicar que cuando se usa para causar daño por frío, se trata como un arma de la categoría crio.",
-"WeaponPropertiesDrainCharge": "Carga de Drenaje",
-"WeaponPropertiesDrainChargeTooltip": "Cuando un arma con la propiedad especial de carga de drenaje golpea a un enemigo que tiene un ataque natural que inflige daño eléctrico (un ataque que no depende de mejoras de armadura, conjuros, habilidades parecidas a conjuros, o armas o equipo que lleve), absorbe parte de esa electricidad inherente del objetivo y recupera el número de cargas indicadas en la entrada de uso del arma.",
-"WeaponPropertiesEcho": "Eco",
-"WeaponPropertiesEchoTooltip": "Un arma eco establece una resonancia sónica persistente dentro de un objetivo. Una criatura con sentido ciego o vista ciega (vibración o sonido) puede detectar un objetivo golpeado por un arma eco a una distancia de hasta 10 × su rango normal. Esto no concede sentido ciego ni vista ciega a criaturas que no tengan ya esta habilidad.",
-"WeaponPropertiesEntangle": "Enredar",
-"WeaponPropertiesEntangleTooltip": "Una criatura golpeada por un arma enredadora queda enredada hasta que escape con una prueba de Acrobacias (CD = 10 + nivel del objeto del arma + modificador de Destreza del atacante) o una prueba de Fuerza (CD = 15 + nivel del objeto del arma + modificador de Destreza del atacante). Una criatura enredada puede intentar esta prueba como acción de movimiento. Algunas armas (como las granadas adhesivas) tienen una duración máxima para este efecto. Consulta la página 275 para información sobre la condición enredada.",
-"WeaponPropertiesExplode": "Explosión",
-"WeaponPropertiesExplodeTooltip": "Los explosivos tienen la propiedad especial de explosión, que lista la cantidad de daño que inflige la explosión, el tipo de daño, efectos especiales (con duración, si es necesario) y el radio de la explosión. Cuando atacas con este tipo de arma o munición, apunta a la intersección de una cuadrícula. Cada criatura dentro del radio de la explosión recibe el daño listado, pero puede intentar una tirada de salvación de Reflejos para recibir la mitad del daño. Si la propiedad especial de explosión tiene efectos especiales además del daño, estos se anulan con una salvación exitosa. Si logras un golpe crítico, solo se aplica al objetivo más cercano a la intersección apuntada (eliges la criatura si hay varias igual de cerca). Algunas armas explosivas, como las granadas de humo, no infligen daño, por lo que no incluyen los apartados de daño y tipo de daño.",
-"WeaponPropertiesExtinguish": "Apagar",
-"WeaponPropertiesExtinguishTooltip": "Puedes gastar todas las cargas restantes de esta arma (incluso si solo tiene una carga o uso) como acción rápida para eliminar la condición de quemadura de ti mismo o de una criatura adyacente, o para apagar las llamas en un cuadrado. Si el arma afecta un área, apaga todas las llamas en esa área (incluyendo el fin de la condición de quemadura para todos los objetivos completamente dentro del área). Apagar las llamas no impide que el área vuelva a prenderse, especialmente si quedan llamas cerca.",
-"WeaponPropertiesFeint": "Finta",
-"WeaponPropertiesFeintTooltip": "Cuando usas esta arma para fintar (Manual Básico 247), obtienes un bono circunstancial de +2 a tu prueba de Engaño.",
-"WeaponPropertiesFiery": "Ígneo",
-"WeaponPropertiesFieryTooltip": "La munición ígnea estalla en brasas incandescentes al dispararse. Aunque esto no cambia el daño normal a daño por fuego, cualquier daño adicional por un golpe crítico se considera daño por fuego y el arma inflige la mitad de daño a objetivos que reciben la mitad de daño de ataques de energía pero ningún daño de ataques cinéticos (como criaturas incorpóreas) y cuenta como un arma con la propiedad especial de explosión contra criaturas con defensas de enjambre. Si la munición ígnea se usa en un arma que ya inflige mitad de daño por fuego (como un arma con la fusión de arma llameante), en un golpe crítico todo el daño infligido es daño por fuego. A discreción del GM, la munición ígnea puede prender materiales extremadamente inflamables, como trapos empapados en aceite o yesca seca.",
-"WeaponPropertiesFirstArc": "Arco Inicial",
-"WeaponPropertiesFirstArcTooltip": "Un arma con la propiedad especial de arco inicial siempre genera un arco eléctrico, según el efecto de golpe crítico, cada vez que golpea a un objetivo.",
-"WeaponPropertiesFlexibleLine": "Línea Flexible",
-"WeaponPropertiesFlexibleLineTooltip": "Un arma flexible genera líneas de efecto a distancia del usuario. Elige dos puntos, ambos deben estar dentro del primer incremento de rango del arma. El efecto del arma se extiende de un punto a otro. Aparte de esta colocación, resuelve el ataque según la propiedad especial de arma de línea.",
-"WeaponPropertiesForce": "Fuerza",
-"WeaponPropertiesForceTooltip": "Un arma de fuerza se considera que tiene el descriptor de fuerza, lo que puede hacer que interactúe diferente con ciertos objetivos (según las reglas especiales de dichos objetivos). Las armas de fuerza infligen daño cinético pero aún apuntan a CAE.",
-"WeaponPropertiesFreeHands": "Manos Libres",
-"WeaponPropertiesFreeHandsTooltip": "Un arma de manos libres está desequilibrada o es difícil de usar. Esta dificultad puede ser contrarrestada moviendo el número indicado de manos que no estén sosteniendo nada ni usadas para otro propósito como contrapesos. Usas el número normal de manos para manejar el arma, pero si tienes el número indicado de manos libres mientras la manejas, el arma no se considera difícil de manejar. Por ejemplo, una kasatha que maneja un lanzallamas con dos de sus manos mientras las otras dos manos quedan libres trata el arma como si no tuviera la propiedad especial de arma difícil de manejar.",
-"WeaponPropertiesFueled": "Combustible",
-"WeaponPropertiesFueledTooltip": "Un arma con combustible tiene un tanque integrado de gasolina y debe activarse para funcionar correctamente. Esto funciona como la propiedad especial de arma con energía, excepto que usa gasolina en vez de batería. A diferencia de una batería, la gasolina se consume permanentemente al usarse y debe comprarse en lugar de recargarse.",
-"WeaponPropertiesGearArray": "Matriz de Equipo",
-"WeaponPropertiesGearArrayTooltip": "Tus nanites se moldean en una sola pieza de equipo, como un arma, herramienta o mejora cibernética.",
-"WeaponPropertiesGrapple": "Agarre",
-"WeaponPropertiesGrappleTooltip": "Cuando manejas un arma de agarre, puedes usarla para realizar una maniobra de combate de agarre sin tener las manos libres. Al hacerlo, obtienes un bono de +2 a la tirada de ataque, y si sacas un 20 natural en la tirada de ataque, aplicas el efecto de golpe crítico del arma (si tiene) al objetivo.",
-"WeaponPropertiesGravitation": "Gravitacional",
-"WeaponPropertiesGravitationTooltip": "Cuando golpeas un objetivo con un arma gravitacional, puedes mover a ese objetivo la distancia indicada hacia ti o alejándolo, a menos que supere una salvación de Reflejos (CD = 10 + 1/2 nivel del objeto del arma + tu bono de Destreza). Si este movimiento causaría que el objetivo atraviese una pared, objeto u otra barrera, el objetivo se detiene pero no cae ni recibe daño. Si el movimiento empuja al objetivo por un precipicio, trampa o lo mueve a un área de peligro obvio, el objetivo debe superar una segunda salvación de Reflejos para detenerse o ser movido al espacio peligroso. El movimiento causado por un arma gravitacional no provoca ataques de oportunidad.",
-"WeaponPropertiesGuided": "Guiado",
-"WeaponPropertiesGuidedTooltip": "Un arma guiada usa una señal junto con telemetría inalámbrica, guía magnética u otro medio para guiar su carga después de haber sido disparada. Cuando realizas una acción de movimiento para apuntar el arma y luego disparas en el mismo turno (incluyendo un arma francotiradora), tu objetivo no obtiene el bono a CA proporcionado por cobertura, cobertura parcial o cobertura suave. La cobertura mejorada y la cobertura total siguen otorgando sus bonos normalmente.",
-"WeaponPropertiesHarrying": "Hostigador",
-"WeaponPropertiesHarryingTooltip": "Un arma hostigadora produce ráfagas de fuego excepcionalmente distractoras. Cuando usas la acción de fuego hostigador con esta arma, obtienes un bono de +2 de percepción a la tirada de ataque.",
-"WeaponPropertiesHealing": "Curativo",
-"WeaponPropertiesHealingTooltip": "Un arma curativa, que debe ser un arma de energía, puede entregar energía restauradora. Puedes poner el arma en modo curativo (o devolverla a modo normal) como acción de movimiento. Mientras está en modo curativo, si el arma golpea a una criatura, tira dados igual al daño del arma; Especialización de Arma, ataque trucado del operativo y otros efectos que aumentan daño no aplican. La criatura recupera Puntos de Golpe igual a la cantidad obtenida, mínimo 1. La curación se reduce a la mitad para constructos y no muertos; los objetos no se ven afectados. Un golpe crítico con un arma curativa no aumenta la curación ni tiene efecto de golpe crítico. Un arma curativa en modo curativo gasta el doble de cargas usuales, y una batería usada en un arma curativa no puede recargarse.",
-"WeaponPropertiesHolyWater": "Agua Bendita",
-"WeaponPropertiesHolyWaterTooltip": "Un arma de agua bendita está impregnada con las bendiciones de una o más deidades alineadas con el bien (más comúnmente Hylax, Iomedae o Sarenrae en los Mundos del Pacto, aunque seguidores devotos de cualquier deidad buena podrían crear tales armas). Solo daña a no muertos (sin importar alineamiento) y a externos con el subtipo malvado, y esas criaturas no sufren efecto alguno (ni muestran signos de su naturaleza si no es obvia) con una salvación exitosa. Fabricar una granada de agua bendita requiere la bendición de sacerdotes formalmente entrenados de una deidad buena, aunque un personaje de cualquier alineamiento puede hacer la fabricación.",
-"WeaponPropertiesHybrid": "Híbrido",
-"WeaponPropertiesHybridTooltip": "Un arma con esta propiedad especial es un objeto híbrido, que incorpora tanto magia como tecnología en su diseño. Cuenta como un arma mágica y gana la propiedad especial de arma análoga. Consume munición y cargas de batería normalmente.",
-"WeaponPropertiesHydrodynamic": "Hidrodinámico",
-"WeaponPropertiesHydrodynamicTooltip": "Este arma puede lanzarse eficazmente bajo el agua, sin penalización a tiradas de ataque ni daño por combate subacuático.",
-"WeaponPropertiesIgnite": "Ignición",
-"WeaponPropertiesIgniteTooltip": "Las armas con la propiedad especial de ignición usan un acelerante para iniciar pequeños fuegos intensos en sus objetivos. Un objetivo golpeado por un arma con esta propiedad debe superar una salvación de Reflejos (CD = 20 + 1/2 nivel del objeto + bono de Destreza) o gana la condición de quemadura con el daño listado. Obtener la condición de quemadura varias veces por la propiedad de ignición no aumenta el daño por quemadura—solo se recibe el daño de ignición más alto cada turno. Un personaje que gane la condición de quemadura por otros medios (como el efecto de golpe crítico de quemadura, incluso con un arma con ignición) suma ese daño a su daño por quemadura cada turno. Terminar la condición de quemadura termina la quemadura de todas las fuentes.",
-"WeaponPropertiesIndirect": "Indirecto",
-"WeaponPropertiesIndirectTooltip": "Un arma indirecta usa una señal inalámbrica junto con un sistema de disparo multietapa, telemetría interna, fluctuación bimetálica, guía magnética u otro sistema para que parezca que el disparo fue hecho desde una ubicación diferente. Esto reduce la penalización a las pruebas de Sigilo para francotiradores en 10.",
-"WeaponPropertiesInjection": "Inyección",
-"WeaponPropertiesInjectionTooltip": "Este arma o su munición pueden llenarse con una droga; un veneno de contacto, ingerido, inhalado o por herida; o un compuesto medicinal. Con un ataque exitoso con el arma (ya sea el primer ataque si es cuerpo a cuerpo o un ataque con la munición relevante si es a distancia), el arma inyecta automáticamente la sustancia al objetivo. Recargar el arma con una nueva sustancia equivale a recargarla y es una acción de movimiento. Cada material inyectable diferente debe comprarse por separado y puede usarse en cualquier arma con la propiedad especial de inyección. Consulta la página 231 para reglas y precios de drogas, medicinas y venenos.",
-"WeaponPropertiesInstrumental": "Instrumental",
-"WeaponPropertiesInstrumentalTooltip": "Un arma con esta propiedad también puede usarse como un instrumento musical básico (Armería 105). El tamaño de la batería del instrumento es igual al del arma, y puede usarse como arma (con el uso de cargas indicado) o como instrumento (donde usa 1 carga cada 10 minutos). Si el arma es de nivel 8 o superior, también funciona como un instrumento musical eufónico (Armería 106).",
-"WeaponPropertiesIntegrated": "Integrado",
-"WeaponPropertiesIntegratedTooltip": "Un arma integrada puede manejarse normalmente o instalarse en una ranura de mejora de armadura. Cuando está correctamente instalada, se considera que se maneja sin necesidad de asignar manos para usarla. Un arma integrada requiere el número indicado de ranuras de armadura para su instalación adecuada. Un androide u otra criatura con la habilidad de ranura de mejora de especie no puede combinar su ranura de mejora de especie con ranuras de armadura para instalar un arma integrada. Instalar, remover o reemplazar un arma integrada en una armadura toma 10 minutos, como si fuera una mejora de armadura.",
-"WeaponPropertiesLine": "Línea",
-"WeaponPropertiesLineTooltip": "Esta arma dispara un proyectil en línea recta que atraviesa múltiples criaturas u obstáculos. Al atacar con tal arma, realiza una sola tirada de ataque y compárala con la CA relevante de todas las criaturas y objetos en una línea que se extiende hasta el incremento de rango listado del arma. Tira daño solo una vez. El arma golpea a todos los objetivos con CA igual o menor a la tirada de ataque. Sin embargo, si un ataque no daña a una criatura u obstáculo golpeado en la línea (generalmente por reducción de daño o dureza), la trayectoria se detiene y el ataque no daña a criaturas más alejadas. Un arma de línea no puede dañar objetivos más allá de su rango listado. Si sacas un golpe crítico, ese efecto se aplica solo al primer objetivo golpeado en la línea, y tiras el daño crítico por separado. Si varias criaturas están igual de cerca, eliges cuál recibe el efecto del golpe crítico. Un arma de línea no se beneficia de dotes o habilidades que aumenten el daño de un solo ataque (como el ataque trucado del operativo).",
-"WeaponPropertiesLiving": "Viviente"
-,
+        "WeaponProficiencyBasicMelee": "Combate Cuerpo a Cuerpo Básico",
+        "WeaponProficiencyGrenades": "Granadas",
+        "WeaponProficiencyHeavy": "Armas Pesadas",
+        "WeaponProficiencyLongArms": "Armas Largas",
+        "WeaponProficiencySmallArms": "Armas Cortas",
+        "WeaponProficiencySniper": "Armas de Francotirador",
+        "WeaponProficiencySpecial": "Armas Especiales",
+        "WeaponPropertiesAeon": "Aeón",
+        "WeaponPropertiesAeonTooltip": "Un arma que tiene la propiedad especial aeón incluye una ranura que puede alojar una piedra aeón. Como acción estándar, puedes insertar una piedra aeón en la ranura o retirarla. Solo puedes insertar una piedra aeón en un arma si el nivel del objeto del arma es igual o mayor que el nivel del objeto de la piedra aeón. No obtienes los beneficios normales de la piedra mientras está insertada en el arma. En cambio, un arma aeón con una piedra aeón insertada obtiene la propiedad especial de arma potenciadora (boost), siempre que no tenga las propiedades de explosión (blast) o engorroso (unwieldy). El aumento del daño por el potenciador depende del nivel del objeto de la piedra aeón insertada, como sigue: niveles 1–5, 1d4; niveles 6–10, 1d6; niveles 11–15, 1d8; niveles 16–20, 1d10.<br><br>Una piedra aeón insertada tiene un número de cargas por día igual al nivel del objeto de la piedra. Usar la propiedad especial de potenciador consume cargas de la piedra igual al valor de uso del arma. Si la piedra no tiene suficientes cargas, el intento de potenciación no tiene efecto. Una piedra aeón que haya gastado cargas diarias de esta manera cambia a un color apagado y no confiere sus beneficios habituales si se retira del arma aeón.",
+        "WeaponPropertiesAmmunition": "Munición",
+        "WeaponPropertiesAnalog": "Análogo",
+        "WeaponPropertiesAnalogTooltip": "Esta arma no usa electrónica avanzada, sistemas computarizados ni fuentes de energía eléctrica. Es inmune a habilidades que atacan tecnología. Aunque el uso del término “análogo” no es técnicamente correcto para tecnología, este uso se ha vuelto común en los Mundos del Pacto.",
+        "WeaponPropertiesAntibiological": "Antibiológico",
+        "WeaponPropertiesAntibiologicalTooltip": "Un arma antibiológica solo daña objetivos vivos. Objetos y criaturas con la cualidad especial no vivos, como robots y no muertos, son inmunes a sus efectos.",
+        "WeaponPropertiesArchaic": "Arcaico",
+        "WeaponPropertiesArchaicTooltip": "Esta arma inflige 5 puntos de daño menos a menos que el objetivo no lleve armadura o lleve armadura arcaica. Las armas arcaicas están hechas de materiales primitivos como madera o acero común.",
+        "WeaponPropertiesAurora": "Aurora",
+        "WeaponPropertiesAuroraTooltip": "Cuando un arma aurora golpea un objetivo, la criatura brilla con una luminiscencia suave durante 1 minuto. Esto anula efectos de invisibilidad e impide que el objetivo obtenga ocultamiento o se esconda en sombras o áreas oscuras.",
+        "WeaponPropertiesAutomatic": "Automática",
+        "WeaponPropertiesAutomaticTooltip": "Además de hacer ataques a distancia normalmente, un arma con esta propiedad especial puede disparar en modo automático completo. No se requiere acción para cambiar entre ataques normales y modo automático.<br><br>Al hacer un ataque completo en modo automático, puedes atacar en un cono con rango de la mitad del incremento de alcance del arma. Esto usa toda la munición restante del arma. Haz una tirada de ataque contra cada objetivo en el cono, empezando por los más cercanos. Los ataques en modo automático no pueden lograr golpes críticos. Lanza daño solo una vez y aplícalo a todos los objetivos alcanzados. Cada ataque contra una criatura usa la munición equivalente a dos disparos, y cuando ya no tengas munición suficiente para atacar otro objetivo, dejas de atacar.<br><br>Por ejemplo, con un arma X-gen táctica con 27 balas restantes, atacarías a las 6 criaturas más cercanas en el cono usando las 27 balas.<br><br>Si hay varias criaturas a la misma distancia y no tienes munición para atacar a todas, decide al azar cuál atacar. No puedes evitar atacar aliados en el cono ni atacar dos veces al mismo objetivo. Los ataques en modo automático tienen las mismas penalizaciones que otros ataques completos.",
+        "WeaponPropertiesBlast": "Explosión",
+        "WeaponPropertiesBlastTooltip": "Esta arma dispara en un cono que se extiende solo hasta su primer incremento de alcance. No puedes atacar objetivos más allá de ese rango.\nPor cada ataque con un arma con la propiedad especial de explosión, haz una tirada de ataque contra cada objetivo en el cono, empezando por los más cercanos. Cada ataque tiene una penalización de –2 además de otras penalizaciones, como la penalización por ataques múltiples. Lanza daño solo una vez para todos los objetivos. Si logras uno o más golpes críticos, lanza el daño crítico extra solo una vez (o cualquier otro efecto especial de golpe crítico que requiera tirada) y aplícalo a cada criatura alcanzada con crítico. No puedes evitar atacar aliados ni atacar dos veces al mismo objetivo.<br><br>Los ataques con armas de explosión ignoran ocultamiento. Un arma de explosión no se beneficia de dotes o habilidades que aumentan el daño de un solo ataque (como el ataque trucado del operativo). La munición de armas de explosión está diseñada para ataques en cono, por lo que se gasta el valor de uso solo una vez por cada cono de ataques.",
+        "WeaponPropertiesBlock": "Bloqueo",
+        "WeaponPropertiesBlockTooltip": "Solo armas cuerpo a cuerpo pueden tener la propiedad especial bloqueo, que representa algún tipo de guarda o barra que protege de ataques del enemigo al que golpeas en cuerpo a cuerpo. Al impactar con éxito a un objetivo con un ataque cuerpo a cuerpo usando esta arma, obtienes un bono de mejora +1 a tu CA por 1 ronda contra ataques cuerpo a cuerpo de ese objetivo.",
+        "WeaponPropertiesBoost": "Potenciador",
+        "WeaponPropertiesBoostTooltip": "Puedes cargar un arma con esta propiedad especial como acción de movimiento. Al hacerlo, aumentas el daño del arma en la cantidad listada en el siguiente ataque que hagas con ella. Potenciar consume cargas del arma igual a su valor de uso. Esto aumenta el daño y se multiplica en un golpe crítico. Potenciar más de una vez antes de disparar no tiene efecto adicional y la carga extra se pierde si no disparas antes del fin de tu siguiente turno.",
+        "WeaponPropertiesBreach": "Apertura",
+        "WeaponPropertiesBreachTooltip": "Un arma de apertura está diseñada para aplicar fuerza súbita a puertas y muros para romperlos. Si estás entrenado en Ingeniería, como acción completa puedes usarla contra una puerta o muro estacionario adyacente o, a discreción del DJ, contra un objeto similar. El ataque consume munición como normal, pero en lugar de tirada de ataque, haces una prueba de Fuerza contra la DC de rotura del objeto (Reglas Básicas 408) y añades el nivel del objeto del arma.",
+        "WeaponPropertiesBreakdown": "Desmontable",
+        "WeaponPropertiesBreakdownTooltip": "Un arma desmontable puede dividirse en múltiples piezas pequeñas. Mientras está desmontada, el arma se considera especialmente pequeña o fácil de ocultar para la tarea de ocultar objetos con Juego de Manos y puede caber en espacios que normalmente solo sostienen objetos de peso ligero (como las bolsas de las mejillas de un ysoki). Tomar o armar el arma desmontable toma 1 minuto.",
+        "WeaponPropertiesBright": "Brillante",
+        "WeaponPropertiesBrightTooltip": "Los ataques con armas brillantes iluminan el área dentro de 6 metros (20 pies) alrededor del objetivo por 1 ronda después del ataque, aumentando el nivel de iluminación en un paso, hasta un máximo de luz normal.",
+        "WeaponPropertiesButtressing": "Refuerzo",
+        "WeaponPropertiesButtressingTooltip": "Al activarse, esta arma emite cargas estáticas sutiles que unen firmemente objetos cercanos entre sí, otorgándoles mayor resistencia a ataques entrantes. Después de atacar con esta arma: aumentas el bono de CA que obtienes por cobertura en 1, aumentas la dureza de objetos a 1.5 metros (5 pies) por una cantidad igual a 1/4 x el nivel del objeto del arma y obtienes +1 a tu CA contra maniobras de combate. Estos beneficios duran hasta que te mueves o hasta el comienzo de tu siguiente turno, lo que ocurra primero. Objetos movidos de su lugar pierden el beneficio inmediatamente. Los efectos de múltiples ataques con armas de refuerzo no se acumulan.",
+        "WeaponPropertiesCluster": "Agrupado",
+        "WeaponPropertiesClusterTooltip": "Un arma agrupada es un tipo de lanzagranadas que puede disparar una sola granada o, si está cargada con granadas apropiadas, puede gastar dos granadas idénticas en un solo ataque. En este caso, las granadas actúan como una sola del mismo tipo (una tirada de ataque, daño una sola vez, etc.), excepto que su radio se incrementa por la cantidad listada y la DC de salvación de los efectos de la granada se calcula usando el nivel del objeto del arma agrupada si es mayor que el de la granada. Intentar disparar dos granadas diferentes genera un error y el arma no dispara.",
+        "WeaponPropertiesDeconstruct": "Descomponer",
+        "WeaponPropertiesDeconstructTooltip": "El objetivo de un arma con la propiedad especial descomponer recibe la cantidad listada de daño ácido cada ronda hasta que el objetivo tenga éxito en una salvación de Reflejos para terminar el daño. Esto funciona como la condición de quemadura, excepto lo señalado, y el daño continuo también termina si el objetivo recibe daño eléctrico.",
+        "WeaponPropertiesDeflect": "Desviar",
+        "WeaponPropertiesDeflectTooltip": "Un arma con la propiedad especial desviar genera un efecto tanto energético como cinético, lo que permite usarla con la dote Desviar Proyectiles (si la tienes) para contrarrestar ataques a distancia tanto cinéticos como energéticos.",
+        "WeaponPropertiesDisarm": "Desarmar",
+        "WeaponPropertiesDisarmTooltip": "Al intentar una maniobra de desarme mientras empuñas un arma con la propiedad desarmar, obtienes un bono +2 a tu tirada de ataque.",
+        "WeaponPropertiesDouble": "Doble",
+        "WeaponPropertiesDoubleTooltip": "Un arma doble tiene dos armas diferentes colocadas una al final de la otra, para que puedas atacar con cualquiera de ellas fácilmente sin cambiar tu agarre. Para el propósito de la dote Combate Multi-Arma, un arma doble se trata como dos o más armas cuerpo a cuerpo operativas. Un arma doble no se considera un arma operativa para ningún otro propósito a menos que tenga la propiedad especial de arma operativa.<br><br>Algunas armas dobles tienen extremos que infligen diferentes tipos de daño. Al realizar un solo ataque con tal arma, puedes elegir qué tipo de daño causar, pero si haces más de un ataque en el mismo turno, al menos uno de esos ataques debe realizarse con el segundo tipo de daño. La categoría del arma de un arma doble que inflige más de un tipo de daño se basa en el primer tipo de daño listado. Si su segundo tipo de daño hace que se considere una categoría de arma diferente al causar ese daño, esa categoría se indica entre paréntesis. Por ejemplo, un arma doble en la categoría de fuego que inflige 1d6 de daño por fuego o 1d6 de daño por frío se lista como “doble (crio)” para indicar que cuando se usa para causar daño por frío, se trata como un arma de la categoría crio.",
+        "WeaponPropertiesDrainCharge": "Carga de Drenaje",
+        "WeaponPropertiesDrainChargeTooltip": "Cuando un arma con la propiedad especial de carga de drenaje golpea a un enemigo que tiene un ataque natural que inflige daño eléctrico (un ataque que no depende de mejoras de armadura, conjuros, habilidades parecidas a conjuros, o armas o equipo que lleve), absorbe parte de esa electricidad inherente del objetivo y recupera el número de cargas indicadas en la entrada de uso del arma.",
+        "WeaponPropertiesEcho": "Eco",
+        "WeaponPropertiesEchoTooltip": "Un arma eco establece una resonancia sónica persistente dentro de un objetivo. Una criatura con sentido ciego o vista ciega (vibración o sonido) puede detectar un objetivo golpeado por un arma eco a una distancia de hasta 10 × su rango normal. Esto no concede sentido ciego ni vista ciega a criaturas que no tengan ya esta habilidad.",
+        "WeaponPropertiesEntangle": "Enredar",
+        "WeaponPropertiesEntangleTooltip": "Una criatura golpeada por un arma enredadora queda enredada hasta que escape con una prueba de Acrobacias (CD = 10 + nivel del objeto del arma + modificador de Destreza del atacante) o una prueba de Fuerza (CD = 15 + nivel del objeto del arma + modificador de Destreza del atacante). Una criatura enredada puede intentar esta prueba como acción de movimiento. Algunas armas (como las granadas adhesivas) tienen una duración máxima para este efecto. Consulta la página 275 para información sobre la condición enredada.",
+        "WeaponPropertiesExplode": "Explosión",
+        "WeaponPropertiesExplodeTooltip": "Los explosivos tienen la propiedad especial de explosión, que lista la cantidad de daño que inflige la explosión, el tipo de daño, efectos especiales (con duración, si es necesario) y el radio de la explosión. Cuando atacas con este tipo de arma o munición, apunta a la intersección de una cuadrícula. Cada criatura dentro del radio de la explosión recibe el daño listado, pero puede intentar una tirada de salvación de Reflejos para recibir la mitad del daño. Si la propiedad especial de explosión tiene efectos especiales además del daño, estos se anulan con una salvación exitosa. Si logras un golpe crítico, solo se aplica al objetivo más cercano a la intersección apuntada (eliges la criatura si hay varias igual de cerca). Algunas armas explosivas, como las granadas de humo, no infligen daño, por lo que no incluyen los apartados de daño y tipo de daño.",
+        "WeaponPropertiesExtinguish": "Apagar",
+        "WeaponPropertiesExtinguishTooltip": "Puedes gastar todas las cargas restantes de esta arma (incluso si solo tiene una carga o uso) como acción rápida para eliminar la condición de quemadura de ti mismo o de una criatura adyacente, o para apagar las llamas en un cuadrado. Si el arma afecta un área, apaga todas las llamas en esa área (incluyendo el fin de la condición de quemadura para todos los objetivos completamente dentro del área). Apagar las llamas no impide que el área vuelva a prenderse, especialmente si quedan llamas cerca.",
+        "WeaponPropertiesFeint": "Finta",
+        "WeaponPropertiesFeintTooltip": "Cuando usas esta arma para fintar (Manual Básico 247), obtienes un bono circunstancial de +2 a tu prueba de Engaño.",
+        "WeaponPropertiesFiery": "Ígneo",
+        "WeaponPropertiesFieryTooltip": "La munición ígnea estalla en brasas incandescentes al dispararse. Aunque esto no cambia el daño normal a daño por fuego, cualquier daño adicional por un golpe crítico se considera daño por fuego y el arma inflige la mitad de daño a objetivos que reciben la mitad de daño de ataques de energía pero ningún daño de ataques cinéticos (como criaturas incorpóreas) y cuenta como un arma con la propiedad especial de explosión contra criaturas con defensas de enjambre. Si la munición ígnea se usa en un arma que ya inflige mitad de daño por fuego (como un arma con la fusión de arma llameante), en un golpe crítico todo el daño infligido es daño por fuego. A discreción del GM, la munición ígnea puede prender materiales extremadamente inflamables, como trapos empapados en aceite o yesca seca.",
+        "WeaponPropertiesFirstArc": "Arco Inicial",
+        "WeaponPropertiesFirstArcTooltip": "Un arma con la propiedad especial de arco inicial siempre genera un arco eléctrico, según el efecto de golpe crítico, cada vez que golpea a un objetivo.",
+        "WeaponPropertiesFlexibleLine": "Línea Flexible",
+        "WeaponPropertiesFlexibleLineTooltip": "Un arma flexible genera líneas de efecto a distancia del usuario. Elige dos puntos, ambos deben estar dentro del primer incremento de rango del arma. El efecto del arma se extiende de un punto a otro. Aparte de esta colocación, resuelve el ataque según la propiedad especial de arma de línea.",
+        "WeaponPropertiesForce": "Fuerza",
+        "WeaponPropertiesForceTooltip": "Un arma de fuerza se considera que tiene el descriptor de fuerza, lo que puede hacer que interactúe diferente con ciertos objetivos (según las reglas especiales de dichos objetivos). Las armas de fuerza infligen daño cinético pero aún apuntan a CAE.",
+        "WeaponPropertiesFreeHands": "Manos Libres",
+        "WeaponPropertiesFreeHandsTooltip": "Un arma de manos libres está desequilibrada o es difícil de usar. Esta dificultad puede ser contrarrestada moviendo el número indicado de manos que no estén sosteniendo nada ni usadas para otro propósito como contrapesos. Usas el número normal de manos para manejar el arma, pero si tienes el número indicado de manos libres mientras la manejas, el arma no se considera difícil de manejar. Por ejemplo, una kasatha que maneja un lanzallamas con dos de sus manos mientras las otras dos manos quedan libres trata el arma como si no tuviera la propiedad especial de arma difícil de manejar.",
+        "WeaponPropertiesFueled": "Combustible",
+        "WeaponPropertiesFueledTooltip": "Un arma con combustible tiene un tanque integrado de gasolina y debe activarse para funcionar correctamente. Esto funciona como la propiedad especial de arma con energía, excepto que usa gasolina en vez de batería. A diferencia de una batería, la gasolina se consume permanentemente al usarse y debe comprarse en lugar de recargarse.",
+        "WeaponPropertiesGearArray": "Matriz de Equipo",
+        "WeaponPropertiesGearArrayTooltip": "Tus nanites se moldean en una sola pieza de equipo, como un arma, herramienta o mejora cibernética.",
+        "WeaponPropertiesGrapple": "Agarre",
+        "WeaponPropertiesGrappleTooltip": "Cuando manejas un arma de agarre, puedes usarla para realizar una maniobra de combate de agarre sin tener las manos libres. Al hacerlo, obtienes un bono de +2 a la tirada de ataque, y si sacas un 20 natural en la tirada de ataque, aplicas el efecto de golpe crítico del arma (si tiene) al objetivo.",
+        "WeaponPropertiesGravitation": "Gravitacional",
+        "WeaponPropertiesGravitationTooltip": "Cuando golpeas un objetivo con un arma gravitacional, puedes mover a ese objetivo la distancia indicada hacia ti o alejándolo, a menos que supere una salvación de Reflejos (CD = 10 + 1/2 nivel del objeto del arma + tu bono de Destreza). Si este movimiento causaría que el objetivo atraviese una pared, objeto u otra barrera, el objetivo se detiene pero no cae ni recibe daño. Si el movimiento empuja al objetivo por un precipicio, trampa o lo mueve a un área de peligro obvio, el objetivo debe superar una segunda salvación de Reflejos para detenerse o ser movido al espacio peligroso. El movimiento causado por un arma gravitacional no provoca ataques de oportunidad.",
+        "WeaponPropertiesGuided": "Guiado",
+        "WeaponPropertiesGuidedTooltip": "Un arma guiada usa una señal junto con telemetría inalámbrica, guía magnética u otro medio para guiar su carga después de haber sido disparada. Cuando realizas una acción de movimiento para apuntar el arma y luego disparas en el mismo turno (incluyendo un arma francotiradora), tu objetivo no obtiene el bono a CA proporcionado por cobertura, cobertura parcial o cobertura suave. La cobertura mejorada y la cobertura total siguen otorgando sus bonos normalmente.",
+        "WeaponPropertiesHarrying": "Hostigador",
+        "WeaponPropertiesHarryingTooltip": "Un arma hostigadora produce ráfagas de fuego excepcionalmente distractoras. Cuando usas la acción de fuego hostigador con esta arma, obtienes un bono de +2 de percepción a la tirada de ataque.",
+        "WeaponPropertiesHealing": "Curativo",
+        "WeaponPropertiesHealingTooltip": "Un arma curativa, que debe ser un arma de energía, puede entregar energía restauradora. Puedes poner el arma en modo curativo (o devolverla a modo normal) como acción de movimiento. Mientras está en modo curativo, si el arma golpea a una criatura, tira dados igual al daño del arma; Especialización de Arma, ataque trucado del operativo y otros efectos que aumentan daño no aplican. La criatura recupera Puntos de Golpe igual a la cantidad obtenida, mínimo 1. La curación se reduce a la mitad para constructos y no muertos; los objetos no se ven afectados. Un golpe crítico con un arma curativa no aumenta la curación ni tiene efecto de golpe crítico. Un arma curativa en modo curativo gasta el doble de cargas usuales, y una batería usada en un arma curativa no puede recargarse.",
+        "WeaponPropertiesHolyWater": "Agua Bendita",
+        "WeaponPropertiesHolyWaterTooltip": "Un arma de agua bendita está impregnada con las bendiciones de una o más deidades alineadas con el bien (más comúnmente Hylax, Iomedae o Sarenrae en los Mundos del Pacto, aunque seguidores devotos de cualquier deidad buena podrían crear tales armas). Solo daña a no muertos (sin importar alineamiento) y a externos con el subtipo malvado, y esas criaturas no sufren efecto alguno (ni muestran signos de su naturaleza si no es obvia) con una salvación exitosa. Fabricar una granada de agua bendita requiere la bendición de sacerdotes formalmente entrenados de una deidad buena, aunque un personaje de cualquier alineamiento puede hacer la fabricación.",
+        "WeaponPropertiesHybrid": "Híbrido",
+        "WeaponPropertiesHybridTooltip": "Un arma con esta propiedad especial es un objeto híbrido, que incorpora tanto magia como tecnología en su diseño. Cuenta como un arma mágica y gana la propiedad especial de arma análoga. Consume munición y cargas de batería normalmente.",
+        "WeaponPropertiesHydrodynamic": "Hidrodinámico",
+        "WeaponPropertiesHydrodynamicTooltip": "Este arma puede lanzarse eficazmente bajo el agua, sin penalización a tiradas de ataque ni daño por combate subacuático.",
+        "WeaponPropertiesIgnite": "Ignición",
+        "WeaponPropertiesIgniteTooltip": "Las armas con la propiedad especial de ignición usan un acelerante para iniciar pequeños fuegos intensos en sus objetivos. Un objetivo golpeado por un arma con esta propiedad debe superar una salvación de Reflejos (CD = 20 + 1/2 nivel del objeto + bono de Destreza) o gana la condición de quemadura con el daño listado. Obtener la condición de quemadura varias veces por la propiedad de ignición no aumenta el daño por quemadura—solo se recibe el daño de ignición más alto cada turno. Un personaje que gane la condición de quemadura por otros medios (como el efecto de golpe crítico de quemadura, incluso con un arma con ignición) suma ese daño a su daño por quemadura cada turno. Terminar la condición de quemadura termina la quemadura de todas las fuentes.",
+        "WeaponPropertiesIndirect": "Indirecto",
+        "WeaponPropertiesIndirectTooltip": "Un arma indirecta usa una señal inalámbrica junto con un sistema de disparo multietapa, telemetría interna, fluctuación bimetálica, guía magnética u otro sistema para que parezca que el disparo fue hecho desde una ubicación diferente. Esto reduce la penalización a las pruebas de Sigilo para francotiradores en 10.",
+        "WeaponPropertiesInjection": "Inyección",
+        "WeaponPropertiesInjectionTooltip": "Este arma o su munición pueden llenarse con una droga; un veneno de contacto, ingerido, inhalado o por herida; o un compuesto medicinal. Con un ataque exitoso con el arma (ya sea el primer ataque si es cuerpo a cuerpo o un ataque con la munición relevante si es a distancia), el arma inyecta automáticamente la sustancia al objetivo. Recargar el arma con una nueva sustancia equivale a recargarla y es una acción de movimiento. Cada material inyectable diferente debe comprarse por separado y puede usarse en cualquier arma con la propiedad especial de inyección. Consulta la página 231 para reglas y precios de drogas, medicinas y venenos.",
+        "WeaponPropertiesInstrumental": "Instrumental",
+        "WeaponPropertiesInstrumentalTooltip": "Un arma con esta propiedad también puede usarse como un instrumento musical básico (Armería 105). El tamaño de la batería del instrumento es igual al del arma, y puede usarse como arma (con el uso de cargas indicado) o como instrumento (donde usa 1 carga cada 10 minutos). Si el arma es de nivel 8 o superior, también funciona como un instrumento musical eufónico (Armería 106).",
+        "WeaponPropertiesIntegrated": "Integrado",
+        "WeaponPropertiesIntegratedTooltip": "Un arma integrada puede manejarse normalmente o instalarse en una ranura de mejora de armadura. Cuando está correctamente instalada, se considera que se maneja sin necesidad de asignar manos para usarla. Un arma integrada requiere el número indicado de ranuras de armadura para su instalación adecuada. Un androide u otra criatura con la habilidad de ranura de mejora de especie no puede combinar su ranura de mejora de especie con ranuras de armadura para instalar un arma integrada. Instalar, remover o reemplazar un arma integrada en una armadura toma 10 minutos, como si fuera una mejora de armadura.",
+        "WeaponPropertiesLine": "Línea",
+        "WeaponPropertiesLineTooltip": "Esta arma dispara un proyectil en línea recta que atraviesa múltiples criaturas u obstáculos. Al atacar con tal arma, realiza una sola tirada de ataque y compárala con la CA relevante de todas las criaturas y objetos en una línea que se extiende hasta el incremento de rango listado del arma. Tira daño solo una vez. El arma golpea a todos los objetivos con CA igual o menor a la tirada de ataque. Sin embargo, si un ataque no daña a una criatura u obstáculo golpeado en la línea (generalmente por reducción de daño o dureza), la trayectoria se detiene y el ataque no daña a criaturas más alejadas. Un arma de línea no puede dañar objetivos más allá de su rango listado. Si sacas un golpe crítico, ese efecto se aplica solo al primer objetivo golpeado en la línea, y tiras el daño crítico por separado. Si varias criaturas están igual de cerca, eliges cuál recibe el efecto del golpe crítico. Un arma de línea no se beneficia de dotes o habilidades que aumenten el daño de un solo ataque (como el ataque trucado del operativo).",
+        "WeaponPropertiesLiving": "Viviente",
         "WeaponPropertiesLivingTooltip": "A diferencia de formas más simples de biotecnología, un arma viviente no es solo material orgánico: es en realidad un organismo vivo simple. La función principal de un arma viviente se basa en los mismos principios científicos que las armas manufacturadas, pero surge como parte de su desarrollo natural y función corporal.<br><br>Un arma viviente puede ser afectada por hechizos que apuntan a criaturas, aunque es inconsciente, incapaz de acción independiente, y no tiene puntuaciones de habilidad excepto Constitución (que siempre es igual a su nivel de objeto). Está sujeta a venenos y enfermedades, aunque no necesita respirar y siempre está protegida tan bien como una criatura con protección ambiental activa por armadura. Si se ve forzada a hacer una tirada de salvación, su bono de salvación es siempre igual a su nivel de objeto. Si sufre una condición que normalmente le causaría una penalización a ataques, daño o DCs de salvación, esas penalizaciones se aplican a cualquier ataque o efecto creado con ella. Las armas vivientes “comen” absorbiendo parte de las cargas o combustible (o energía de alguna otra forma de munición) cuando se disparan. No duermen ni respiran, no pueden comunicarse de ninguna forma, son inmunes a efectos de dolor debido a sus sistemas nerviosos increíblemente simples, y son inconscientes.<br><br>Si resultan dañadas, un arma viviente puede recuperar Puntos de Golpe por efectos que restauran Puntos de Golpe a criaturas vivas, como un hechizo de cura mística, y recupera un número de Puntos de Golpe igual a su nivel de objeto cada día. Puedes usar la habilidad de Ciencias de la Vida o Medicina en lugar de Ingeniería para reparar un arma viviente.",
-"WeaponPropertiesLockdown": "Bloqueo",
-"WeaponPropertiesLockdownTooltip": "Un constructo reducido a 0 Puntos de Golpe por un arma de bloqueo no es destruido sino simplemente inmovilizado hasta que recupere 1 o más Puntos de Golpe.",
-"WeaponPropertiesMindAffecting": "Afecta Mentes",
-"WeaponPropertiesMindAffectingTooltip": "Un arma que afecta mentes solo afecta criaturas con mente; los objetivos inmunes a efectos que afectan la mente son inmunes a esta arma. El daño de armas que afectan la mente es normalmente sin tipo, en cuyo caso se ve afectado por las mismas cosas que afectan el daño del hechizo empuje mental. Por ejemplo, si una criatura fuera inmune a empuje mental, también sería inmune al daño sin tipo de un arma que afecta mentes.",
-"WeaponPropertiesMine": "Mina",
-"WeaponPropertiesMineTooltip": "Un arma con la propiedad especial mina puede modificar la munición que dispara para retrasar la detonación de su armamento. La munición disparada por esta arma (típicamente una granada o mini-cohete) cae intacta en la intersección del cuadrante objetivo, detonando solo cuando una criatura se mueve a una casilla adyacente, o detona automáticamente después de 1d6+1 rondas.",
-"WeaponPropertiesMire": "Pantano",
-"WeaponPropertiesMireTooltip": "Un arma pantano tiene un área definida (generalmente un radio) que temporalmente convierte en terreno difícil. Solo una superficie puede convertirse en terreno difícil (por ejemplo, no se puede usar un arma pantano para crear terreno difícil en el aire), y el terreno difícil afecta solo la velocidad de escalada y la velocidad de tierra de las criaturas en el área.",
-"WeaponPropertiesModal": "Modal",
-"WeaponPropertiesModalTooltip": "Un arma modal puede cambiarse para infligir diferentes tipos de daño, con las opciones listadas en la entrada de daño del arma. El arma solo puede infligir un tipo de daño a la vez; cambiar el modo del arma para infligir otro tipo de daño requiere una acción de movimiento. La categoría del arma modal se basa en el primer tipo de daño listado. Si su segundo tipo de daño hace que se considere una categoría diferente cuando inflige ese daño, esa categoría se indica entre paréntesis. Por ejemplo, un arma modal en la categoría fuego que inflige 1d6 de daño por fuego o 1d6 de daño por frío indica “modal (crio)” para mostrar que al infligir daño por frío, se trata como un arma de la categoría crio.",
-"WeaponPropertiesNecrotic": "Necrótico",
-"WeaponPropertiesNecroticTooltip": "Un arma necrótica inflige daño por frío infundido con energía negativa. Las criaturas inmunes a la energía negativa (como los objetivos de un hechizo guardián de la muerte) son inmunes al daño por frío de un arma necrótica, y el daño por frío de armas necróticas solo afecta a criaturas vivas. Las criaturas no-muertas objetivo de un arma con esta propiedad no solo no reciben daño por frío sino que también ganan Puntos de Golpe temporales iguales al nivel del arma. Estos Puntos de Golpe temporales duran 10 minutos, hasta que se agotan o hasta que el no-muerto gane un número mayor de Puntos de Golpe temporales de un arma necrótica. Una criatura solo puede beneficiarse de una fuente de Puntos de Golpe temporales de un arma necrótica a la vez.",
-"WeaponPropertiesNonlethal": "No Letal",
-"WeaponPropertiesNonlethalTooltip": "Esta arma inflige daño no letal. Consulta la página 252 para más información sobre cómo funciona el daño no letal.",
-"WeaponPropertiesOneHanded": "De una mano",
-"WeaponPropertiesOneHandedTooltip": "Solo puedes atacar con un arma (o amenazar un área con ella, para todas las armas cuerpo a cuerpo excepto golpes sin armas) si la empuñas con el número correcto de manos. Cuando las reglas se refieren a empuñar un arma, significa que estás sosteniendo un arma con el número correcto de manos y por tanto puedes atacar con ella. Por ejemplo, si sostienes un arma corta en tu mano, se considera que la estás empuñando. Si llevas un arma larga en una mano o un arma enfundada, no la estás empuñando. Puedes llevar un arma de dos manos en una mano, pero no puedes atacar con ella mientras lo haces.",
-"WeaponPropertiesOperative": "Operativo",
-"WeaponPropertiesOperativeTooltip": "Ligero y versátil, las armas operativas adoptan muchas formas, y son particularmente efectivas en manos de un combatiente entrenado. Un operativo puede usar la característica de clase ataque tramposo con un arma que tenga la propiedad especial operativo, y cualquier personaje puede añadir su modificador de Destreza en lugar del de Fuerza a las tiradas de ataque cuerpo a cuerpo con estas armas.",
-"WeaponPropertiesPenetrating": "Penetrante",
-"WeaponPropertiesPenetratingTooltip": "Un arma penetrante está diseñada para atravesar las capas externas de grandes objetos, facilitando dañarlos. Un arma penetrante ignora una cantidad de dureza igual al nivel del arma.",
-"WeaponPropertiesPolarize": "Polarizar",
-"WeaponPropertiesPolarizeTooltip": "Un arma con la propiedad especial polarizar acumula brevemente una carga polarizada en un objetivo. Cuando se golpea un objetivo varias veces con un arma con esta propiedad en la misma ronda, el daño de cada golpe después del primero aumenta en la cantidad listada. Esto se reinicia al comienzo de tu siguiente turno.",
-"WeaponPropertiesPolymorphic": "Polimórfico",
-"WeaponPropertiesPolymorphicTooltip": "Las armas cuerpo a cuerpo con la propiedad especial polimórfica están hechas de múltiples escamas enlazadas que pueden reconfigurarse con un gesto. El portador puede hacer que las escamas se aplanen, formen varios bordes afilados contiguos o se levanten como una serie de puntos. Como acción rápida o una vez como parte de una acción completa, una criatura que empuña un arma polimórfica puede cambiar su tipo de daño de contundente, cortante o perforante a otro de esos tipos.",
-"WeaponPropertiesPowered": "Motorizada",
-"WeaponPropertiesPoweredTooltip": "Un arma cuerpo a cuerpo con una batería interna que debe cargarse para funcionar tiene la propiedad especial motorizada, que lista su capacidad y uso. A diferencia de un arma a distancia, el uso es para 1 minuto de operación en lugar de por ataque, aunque usar un arma motorizada por menos de 1 minuto consume 1 uso completo. La cantidad de cargas gastadas es igual al uso × número de minutos que se usa el arma, redondeado hacia arriba al minuto más cercano. Puedes activar la energía del arma como parte de la acción para hacer un ataque con ella, y se desactiva automáticamente después de 1 minuto.<br><br>Como con armas a distancia, puedes recargar la batería de un arma motorizada cuerpo a cuerpo usando un generador o estación de recarga, o puedes comprar baterías nuevas. Si intentas atacar con un arma motorizada sin cargas, funciona como un arma improvisada (consulta página 169).",
-"WeaponPropertiesProfessional": "Profesional",
-"WeaponPropertiesProfessionalTooltip": "Un arma profesional es una herramienta usada en un oficio especializado que sin embargo tiene un gran potencial de daño. Al usar un arma profesional, ganas un bono de +2 de perspicacia a las pruebas con la habilidad Profesión listada (o a pruebas con habilidades similares que razonablemente podrían usar ese arma como parte de la profesión, sujeto a discreción del GM). Si tienes un número de rangos en la habilidad Profesión listada igual al nivel del objeto, se considera que eres competente con ese arma, incluso si normalmente no lo serías. Esta competencia nunca cuenta para prerrequisitos de ningún tipo.",
-"WeaponPropertiesPropel": "Impulsar",
-"WeaponPropertiesPropelTooltip": "Estas armas mueven a los objetivos afectados la distancia listada desde el punto de origen del efecto. Un objetivo que tenga éxito en una tirada de salvación de Reflejos (DC = 10 + 1/2 nivel del arma + modificador de Destreza del portador) no se mueve. Si el movimiento hace que el objetivo atraviese una pared, objeto u otra barrera, el objetivo se detiene y cae prone.",
-"WeaponPropertiesPunchGun": "Pistola de Puñetazo",
-"WeaponPropertiesPunchGunTooltip": "Un arma pistola de puñetazo es un pequeño arma a distancia equipada con un mecanismo de disparo sensible a presión, fijado a un guante o artículo similar. A diferencia de la mayoría de armas a distancia, que disparan al presionar un gatillo, una pistola de puñetazo dispara cuando se aplica suficiente presión en su cañón. Todas las armas proyectiles pistola de puñetazo tienen un alcance igual al alcance natural del portador. Aunque son ataques a distancia, no provocan ataques de oportunidad.",
-"WeaponPropertiesQuickReload": "Recarga Rápida",
-"WeaponPropertiesQuickReloadTooltip": "Puedes recargar este arma como parte de la misma acción para dispararla, en lugar de tomar una acción de movimiento para recargar.",
-"WeaponPropertiesRadioactive": "Radiactiva",
-"WeaponPropertiesRadioactiveTooltip": "Un arma radiactiva contiene componentes radiactivos inestables. Cuando el portador obtiene un 1 natural en una tirada de ataque, queda expuesto a radiación peligrosa y debe tener éxito en una salvación de Fortaleza o sufrir enfermedad por radiación. (Para armas explosivas radiactivas, el usuario debe intentar una salvación de Fortaleza si alguno de los ataques es un 1 natural). Esto se considera un nivel bajo de radiación. Las DC para esta salvación y la enfermedad son iguales a la DC de golpe crítico del arma.",
-"WeaponPropertiesReach": "Alcance",
-"WeaponPropertiesReachTooltip": "Solo las armas cuerpo a cuerpo pueden tener la propiedad alcance. Empuñar un arma con alcance te da 10 pies de alcance para ataques con ese arma. Consulta Alcance y Casillas Amenazadas en página 255 para más información.",
-"WeaponPropertiesRecall": "Recuperar",
-"WeaponPropertiesRecallTooltip": "Un arma recuperar está vinculada a una pulsera o dispositivo pequeño usado por el portador (que no cuenta contra el máximo de dos objetos mágicos o híbridos). Si lanzas un arma recuperar y fallas el ataque, el arma regresa a ti al final de tu turno.",
-"WeaponPropertiesRegrowth": "Recrecimiento",
-"WeaponPropertiesRegrowthTooltip": "Este arma regenera su propia munición, generalmente con ayuda de la luz solar y nutrientes extraídos del aire o suelo. El arma tarda 8 horas en reponer toda su munición; esta munición siempre es munición estándar única para el arma y no puede venderse.",
-"WeaponPropertiesRelic": "Reliquia",
-"WeaponPropertiesRelicTooltip": "Estos objetos raros son fragmentos de tecnología perdida o ítems únicos menos poderosos que artefactos. Una reliquia tiene nivel de objeto pero puede venderse por el 100% de su precio (como bienes comerciales). Una reliquia no puede fabricarse sin los medios de una fórmula específica, que casi siempre está perdida y a menudo requiere materiales especiales. Una reliquia comprendida lo suficiente para ser reproducida, estandarizada y producida en masa podría perder su estatus de reliquia. A diferencia de armas normales, las armas reliquia no vienen completamente cargadas salvo que se indique.",
-"WeaponPropertiesReposition": "Reposicionar",
-"WeaponPropertiesRepositionTooltip": "Cuando intentas una maniobra de combate reposicionar con esta arma, ganas un bono de +2 a la tirada de ataque.",
-"WeaponPropertiesScramble": "Desordenar",
-"WeaponPropertiesScrambleTooltip": "Un arma con la propiedad desordenar interrumpe brevemente las habilidades telepáticas o mente colmena de una criatura. Cuando una criatura recibe daño de un arma con esta propiedad, debe tener éxito en una salvación de Fortaleza (DC = 10 + mitad del nivel del arma + modificador de Int del portador) o pierde su habilidad para comunicarse telepáticamente hasta el final de tu siguiente turno. Las habilidades que dependen de comunicación telepática, como la habilidad mente de enjambre, tampoco funcionan durante este tiempo."
-,
-       "WeaponPropertiesShape": "Forma",
-"WeaponPropertiesShapeTooltip": "Un arma con la propiedad especial forma tiene una matriz compleja de puntería que le permite atacar áreas específicas. Si haces un solo ataque como acción completa con tal arma, puedes excluir la cantidad listada de casillas dentro del área de efecto del arma. Esto significa que puedes evitar disparar a un aliado dentro del área de efecto de un arma explosiva, por ejemplo.",
-"WeaponPropertiesShatter": "Destrozar",
-"WeaponPropertiesShatterTooltip": "La primera vez que se usa un arma con esta propiedad en un objetivo, el arma tiene la propiedad especial penetrante. Sin embargo, si el daño del arma se inflige continuamente al mismo objetivo en rondas sucesivas, la cantidad de Dureza que el arma ignora = 3 × el nivel del objeto del arma. Si el arma con esta propiedad es modal, el tipo de daño que inflige el arma debe cambiar cada ronda, o el arma solo funciona como un arma penetrante.",
-"WeaponPropertiesShells": "Cartuchos",
-"WeaponPropertiesShellsTooltip": "Algunas armas cuerpo a cuerpo pueden cargarse con cartuchos de escopeta para crear un ataque potente de corto alcance y un solo disparo. Un arma con la propiedad especial cartucho lista su capacidad y valor de uso. A diferencia de las cargas para armas cuerpo a cuerpo potenciadas, este uso es por ataque.",
-"WeaponPropertiesShield": "Escudo",
-"WeaponPropertiesShieldTooltip": "Un arma escudo encapsula al objetivo en un campo de fuerza de corta duración. Este campo dura hasta el inicio de tu siguiente turno o hasta que haya absorbido la cantidad listada de daño, lo que ocurra primero. Un campo de fuerza originado por un arma escudo bloquea solo el daño entrante; no interfiere en modo alguno con las armas o ataques del objetivo. No puedes usar un proyector de escudo para dirigirte a ti mismo.",
-"WeaponPropertiesSniper": "Francotirador",
-"WeaponPropertiesSniperTooltip": "Las armas con la propiedad especial francotirador pueden dispararse con precisión a muy largas distancias si se apuntan correctamente. Si apuntas el arma como acción de movimiento y luego disparas en el mismo turno, usa el valor listado con la propiedad especial francotirador como el incremento de alcance del arma. Aún puedes disparar un arma francotirador normalmente, pero solo tiene el alcance listado en su entrada normal de alcance cuando lo haces.",
-"WeaponPropertiesStun": "Aturdir",
-"WeaponPropertiesStunTooltip": "Puedes poner un arma con la propiedad especial aturdir en modo aturdimiento (o resetearla a modo normal) como acción de movimiento. Mientras está en modo aturdimiento, todos los ataques del arma son no letales. Consulta la página 252 para más información sobre cómo funciona el daño no letal.",
-"WeaponPropertiesSubtle": "Sutil",
-"WeaponPropertiesSubtleTooltip": "Puedes poner un arma con la propiedad especial aturdir en modo aturdimiento (o resetearla a modo normal) como acción de movimiento. Mientras está en modo aturdimiento, todos los ataques del arma son no letales. Consulta la página 252 para más información sobre cómo funciona el daño no letal.",
-"WeaponPropertiesSunder": "Desarmar",
-"WeaponPropertiesSunderTooltip": "Cuando intentas una maniobra de combate desarmar mientras empuñas un arma con la propiedad especial desarmar, ganas un bono de +2 a tu tirada de ataque.",
-"WeaponPropertiesSwarm": "Enjambre",
-"WeaponPropertiesSwarmTooltip": "Un arma con esta propiedad especial es prácticamente indistinguible de la tecnología Enjambre y requiere una batería especial de Enjambre para usarse eficientemente. El arma puede usar otras baterías, pero el uso se duplica al hacerlo.<br><br>Además del inconveniente energético, un arma Enjambre atrae la atención de criaturas Enjambre cercanas. Estas pueden detectar tal arma como si usaran sentidos ciegos con un rango de 30 pies. Se ha observado que componentes Enjambre se fijan en los portadores de esta tecnología durante la batalla, sin otra explicación para tal concentración violenta. Si el Enjambre gana el conflicto, los componentes sobrevivientes destruyen estas armas.",
-"WeaponPropertiesTail": "Cola",
-"WeaponPropertiesTailTooltip": "Si tienes una cola (o un apéndice similar a una cola), puedes llevar un arma con la propiedad especial cola en tu cola, en lugar de empuñarla con la mano. Colocar o quitar un arma cola es una acción completa, y una vez instalada, empuñas el arma sin usar las manos.",
-"WeaponPropertiesTeleportive": "Teletransportiva",
-"WeaponPropertiesTeleportiveTooltip": "La munición disparada por este arma se teletransporta una corta distancia tras ser disparada. Recibes solo una penalización acumulativa de –1 al atacar fuera del rango de este arma.",
-"WeaponPropertiesThought": "Mental",
-"WeaponPropertiesThoughtTooltip": "Un arma mental puede ser controlada total o parcialmente por telepatía. Si tienes el rasgo de especie telepatía o telepatía limitada, te beneficias de un hechizo de telepatía, llevas una diadema de enlace mental, o tienes una habilidad similar, ignoras la propiedad especial torpe del arma.",
-"WeaponPropertiesThrottle": "Estranguladora",
-"WeaponPropertiesThrottleTooltip": "Un arma estranguladora inflige daño solo cuando se usa para agarrar a un enemigo, infligiendo daño automáticamente con cada maniobra de combate de agarre exitosa. Todas las armas estranguladoras también son armas de agarre. Mientras un objetivo esté siendo agarrado exitosamente con un arma estranguladora, no puede usar sus vías respiratorias para hablar o hacer vocalizaciones de ningún tipo (aunque otras formas de hacer ruido funcionan normalmente).",
-"WeaponPropertiesThrown": "Arrojadiza",
-"WeaponPropertiesThrownTooltip": "Las armas a distancia que deben ser arrojadas y las armas cuerpo a cuerpo que pueden ser arrojadas como ataque a distancia tienen la propiedad especial arrojadiza y un incremento de alcance listado. Aplicas tu modificador de Fuerza a las tiradas de daño para ataques arrojadizos. Después de arrojar un arma, esta cae cerca del objetivo y debes recuperarla si quieres atacar con ella de nuevo.",
-"WeaponPropertiesThruster": "Propulsor",
-"WeaponPropertiesThrusterTooltip": "Esta arma produce ráfagas controladas de energía poderosa, que puedes dirigir para potenciar tus hazañas atléticas. Como parte de la acción que usas para volar, saltar o realizar la maniobra de empuje, puedes gastar munición o cargas igual al uso del arma para aumentar esa acción. Al volar, esta ráfaga te otorga un bono de mejora +2 a una prueba de Acrobacias para volar en esa ronda. Al saltar, esta ráfaga te otorga un bono de mejora igual al nivel del objeto del arma para esa prueba de Atletismo. Al realizar un empuje, esta ráfaga te otorga un bono +2 a tu tirada de ataque.",
-"WeaponPropertiesTrip": "Derribar",
-"WeaponPropertiesTripTooltip": "Cuando intentas una maniobra de combate derribar mientras empuñas un arma con esta propiedad, ganas un bono de +2 a tu tirada de ataque.",
-"WeaponPropertiesTwoHanded": "A dos manos",
-"WeaponPropertiesTwoHandedTooltip": "Solo puedes atacar con un arma (o amenazar un área con ella, para todas las armas cuerpo a cuerpo excepto ataques sin armas) si la empuñas con el número correcto de manos. Cuando las reglas se refieren a empuñar un arma, significa que sostienes un arma con el número correcto de manos y por tanto puedes hacer ataques con ella. Por ejemplo, si sostienes un arma corta en tu mano, se considera que empuñas el arma. Si llevas un arma larga en una mano o tienes un arma enfundada, no la estás empuñando. Puedes llevar un arma a dos manos en una mano, pero no puedes atacar con ella mientras haces eso.",
-"WeaponPropertiesUnbalancing": "Desequilibrante",
-"WeaponPropertiesUnbalancingTooltip": "Esta arma desequilibra a los enemigos. Cuando infliges daño con esta arma, el objetivo queda desprevenido contra el siguiente ataque que lo apunte antes del inicio de tu siguiente turno. Cualquier cosa que haga que un golpe crítico se trate como un golpe normal, como la fortificación, concede inmunidad a esta propiedad especial.",
-"WeaponPropertiesUnderwater": "Subacuática",
-"WeaponPropertiesUnderwaterTooltip": "Como los habitantes de la mayoría de los mundos acuáticos, los kalos crean sus propias versiones de armas comunes, rediseñadas para funcionar mejor bajo el agua. Estas armas tienen la siguiente propiedad especial y generalmente cuestan un 10% más.<br><br>Subacuática: Un arma con esta propiedad especial que se usa bajo el agua ignora la penalización de –2 a las tiradas de ataque y causa daño completo.",
-"WeaponPropertiesUnwieldy": "Torpe",
-"WeaponPropertiesUnwieldyTooltip": "Las armas con la propiedad especial torpe son grandes y torpes, no pueden dispararse sin antes enfriarse, o son difíciles de usar en ataques repetidos. No puedes usar un arma torpe como parte de un ataque completo (o cualquier otra acción que permita múltiples ataques), no puedes atacar más de una vez por ronda con ella, y no puedes usarla para realizar ataques de oportunidad.",
-"WeaponPropertiesVariantBoost": "Impulso variante",
-"WeaponPropertiesVariantBoostTooltip": "Un arma con la propiedad especial impulso variante actúa como un arma con la propiedad impulso, excepto que impulsarla no consume cargas adicionales y el arma solo puede impulsarse el número listado de veces por día.",
-"WeaponPropertiesWideLine": "Línea ancha",
-"WeaponPropertiesWideLineTooltip": "Un arma línea ancha funciona como un arma con la propiedad línea, excepto que la línea mide 10 pies de ancho. Al determinar las casillas que están en la trayectoria de una línea, anota las casillas por las que normalmente pasaría la línea y extiende el área a un lado de la línea (a tu elección) para que la línea tenga 2 casillas de ancho. Para que un obstáculo bloquee la trayectoria de una línea, debe bloquear el ancho total de la línea; de lo contrario, la línea continúa (con su ancho completo) más allá del obstáculo.",
-"WeaponTypesAdvMelee": "Cuerpo a cuerpo avanzado",
-"WeaponTypesBasicMelee": "Cuerpo a cuerpo básico",
-"WeaponTypesGrenades": "Granadas",
-"WeaponTypesHeavy": "Armas pesadas",
-"WeaponTypesLongArms": "Armas largas",
-"WeaponTypesSmallArms": "Armas cortas",
-"WeaponTypesSniper": "Armas francotirador",
-"WeaponTypesSolarian": "Cristales solares",
-"WeaponTypesSpecial": "Armas especiales",
-"WeaponsPropertiesConceal": "Oculto",
-"WeaponsPropertiesConcealTooltip": "Un arma con la propiedad especial oculto se considera especialmente pequeña o fácil de esconder para los propósitos de la tarea de ocultar objeto de la habilidad Juego de Manos, otorgándote un bono circunstancial +4 a las pruebas para ocultar objeto.",
-"WillSave": "Voluntad"
-
+        "WeaponPropertiesLockdown": "Bloqueo",
+        "WeaponPropertiesLockdownTooltip": "Un constructo reducido a 0 Puntos de Golpe por un arma de bloqueo no es destruido sino simplemente inmovilizado hasta que recupere 1 o más Puntos de Golpe.",
+        "WeaponPropertiesMindAffecting": "Afecta Mentes",
+        "WeaponPropertiesMindAffectingTooltip": "Un arma que afecta mentes solo afecta criaturas con mente; los objetivos inmunes a efectos que afectan la mente son inmunes a esta arma. El daño de armas que afectan la mente es normalmente sin tipo, en cuyo caso se ve afectado por las mismas cosas que afectan el daño del hechizo empuje mental. Por ejemplo, si una criatura fuera inmune a empuje mental, también sería inmune al daño sin tipo de un arma que afecta mentes.",
+        "WeaponPropertiesMine": "Mina",
+        "WeaponPropertiesMineTooltip": "Un arma con la propiedad especial mina puede modificar la munición que dispara para retrasar la detonación de su armamento. La munición disparada por esta arma (típicamente una granada o mini-cohete) cae intacta en la intersección del cuadrante objetivo, detonando solo cuando una criatura se mueve a una casilla adyacente, o detona automáticamente después de 1d6+1 rondas.",
+        "WeaponPropertiesMire": "Pantano",
+        "WeaponPropertiesMireTooltip": "Un arma pantano tiene un área definida (generalmente un radio) que temporalmente convierte en terreno difícil. Solo una superficie puede convertirse en terreno difícil (por ejemplo, no se puede usar un arma pantano para crear terreno difícil en el aire), y el terreno difícil afecta solo la velocidad de escalada y la velocidad de tierra de las criaturas en el área.",
+        "WeaponPropertiesModal": "Modal",
+        "WeaponPropertiesModalTooltip": "Un arma modal puede cambiarse para infligir diferentes tipos de daño, con las opciones listadas en la entrada de daño del arma. El arma solo puede infligir un tipo de daño a la vez; cambiar el modo del arma para infligir otro tipo de daño requiere una acción de movimiento. La categoría del arma modal se basa en el primer tipo de daño listado. Si su segundo tipo de daño hace que se considere una categoría diferente cuando inflige ese daño, esa categoría se indica entre paréntesis. Por ejemplo, un arma modal en la categoría fuego que inflige 1d6 de daño por fuego o 1d6 de daño por frío indica “modal (crio)” para mostrar que al infligir daño por frío, se trata como un arma de la categoría crio.",
+        "WeaponPropertiesNecrotic": "Necrótico",
+        "WeaponPropertiesNecroticTooltip": "Un arma necrótica inflige daño por frío infundido con energía negativa. Las criaturas inmunes a la energía negativa (como los objetivos de un hechizo guardián de la muerte) son inmunes al daño por frío de un arma necrótica, y el daño por frío de armas necróticas solo afecta a criaturas vivas. Las criaturas no-muertas objetivo de un arma con esta propiedad no solo no reciben daño por frío sino que también ganan Puntos de Golpe temporales iguales al nivel del arma. Estos Puntos de Golpe temporales duran 10 minutos, hasta que se agotan o hasta que el no-muerto gane un número mayor de Puntos de Golpe temporales de un arma necrótica. Una criatura solo puede beneficiarse de una fuente de Puntos de Golpe temporales de un arma necrótica a la vez.",
+        "WeaponPropertiesNonlethal": "No Letal",
+        "WeaponPropertiesNonlethalTooltip": "Esta arma inflige daño no letal. Consulta la página 252 para más información sobre cómo funciona el daño no letal.",
+        "WeaponPropertiesOneHanded": "De una mano",
+        "WeaponPropertiesOneHandedTooltip": "Solo puedes atacar con un arma (o amenazar un área con ella, para todas las armas cuerpo a cuerpo excepto golpes sin armas) si la empuñas con el número correcto de manos. Cuando las reglas se refieren a empuñar un arma, significa que estás sosteniendo un arma con el número correcto de manos y por tanto puedes atacar con ella. Por ejemplo, si sostienes un arma corta en tu mano, se considera que la estás empuñando. Si llevas un arma larga en una mano o un arma enfundada, no la estás empuñando. Puedes llevar un arma de dos manos en una mano, pero no puedes atacar con ella mientras lo haces.",
+        "WeaponPropertiesOperative": "Operativo",
+        "WeaponPropertiesOperativeTooltip": "Ligero y versátil, las armas operativas adoptan muchas formas, y son particularmente efectivas en manos de un combatiente entrenado. Un operativo puede usar la característica de clase ataque tramposo con un arma que tenga la propiedad especial operativo, y cualquier personaje puede añadir su modificador de Destreza en lugar del de Fuerza a las tiradas de ataque cuerpo a cuerpo con estas armas.",
+        "WeaponPropertiesPenetrating": "Penetrante",
+        "WeaponPropertiesPenetratingTooltip": "Un arma penetrante está diseñada para atravesar las capas externas de grandes objetos, facilitando dañarlos. Un arma penetrante ignora una cantidad de dureza igual al nivel del arma.",
+        "WeaponPropertiesPolarize": "Polarizar",
+        "WeaponPropertiesPolarizeTooltip": "Un arma con la propiedad especial polarizar acumula brevemente una carga polarizada en un objetivo. Cuando se golpea un objetivo varias veces con un arma con esta propiedad en la misma ronda, el daño de cada golpe después del primero aumenta en la cantidad listada. Esto se reinicia al comienzo de tu siguiente turno.",
+        "WeaponPropertiesPolymorphic": "Polimórfico",
+        "WeaponPropertiesPolymorphicTooltip": "Las armas cuerpo a cuerpo con la propiedad especial polimórfica están hechas de múltiples escamas enlazadas que pueden reconfigurarse con un gesto. El portador puede hacer que las escamas se aplanen, formen varios bordes afilados contiguos o se levanten como una serie de puntos. Como acción rápida o una vez como parte de una acción completa, una criatura que empuña un arma polimórfica puede cambiar su tipo de daño de contundente, cortante o perforante a otro de esos tipos.",
+        "WeaponPropertiesPowered": "Motorizada",
+        "WeaponPropertiesPoweredTooltip": "Un arma cuerpo a cuerpo con una batería interna que debe cargarse para funcionar tiene la propiedad especial motorizada, que lista su capacidad y uso. A diferencia de un arma a distancia, el uso es para 1 minuto de operación en lugar de por ataque, aunque usar un arma motorizada por menos de 1 minuto consume 1 uso completo. La cantidad de cargas gastadas es igual al uso × número de minutos que se usa el arma, redondeado hacia arriba al minuto más cercano. Puedes activar la energía del arma como parte de la acción para hacer un ataque con ella, y se desactiva automáticamente después de 1 minuto.<br><br>Como con armas a distancia, puedes recargar la batería de un arma motorizada cuerpo a cuerpo usando un generador o estación de recarga, o puedes comprar baterías nuevas. Si intentas atacar con un arma motorizada sin cargas, funciona como un arma improvisada (consulta página 169).",
+        "WeaponPropertiesProfessional": "Profesional",
+        "WeaponPropertiesProfessionalTooltip": "Un arma profesional es una herramienta usada en un oficio especializado que sin embargo tiene un gran potencial de daño. Al usar un arma profesional, ganas un bono de +2 de perspicacia a las pruebas con la habilidad Profesión listada (o a pruebas con habilidades similares que razonablemente podrían usar ese arma como parte de la profesión, sujeto a discreción del GM). Si tienes un número de rangos en la habilidad Profesión listada igual al nivel del objeto, se considera que eres competente con ese arma, incluso si normalmente no lo serías. Esta competencia nunca cuenta para prerrequisitos de ningún tipo.",
+        "WeaponPropertiesPropel": "Impulsar",
+        "WeaponPropertiesPropelTooltip": "Estas armas mueven a los objetivos afectados la distancia listada desde el punto de origen del efecto. Un objetivo que tenga éxito en una tirada de salvación de Reflejos (DC = 10 + 1/2 nivel del arma + modificador de Destreza del portador) no se mueve. Si el movimiento hace que el objetivo atraviese una pared, objeto u otra barrera, el objetivo se detiene y cae prone.",
+        "WeaponPropertiesPunchGun": "Pistola de Puñetazo",
+        "WeaponPropertiesPunchGunTooltip": "Un arma pistola de puñetazo es un pequeño arma a distancia equipada con un mecanismo de disparo sensible a presión, fijado a un guante o artículo similar. A diferencia de la mayoría de armas a distancia, que disparan al presionar un gatillo, una pistola de puñetazo dispara cuando se aplica suficiente presión en su cañón. Todas las armas proyectiles pistola de puñetazo tienen un alcance igual al alcance natural del portador. Aunque son ataques a distancia, no provocan ataques de oportunidad.",
+        "WeaponPropertiesQuickReload": "Recarga Rápida",
+        "WeaponPropertiesQuickReloadTooltip": "Puedes recargar este arma como parte de la misma acción para dispararla, en lugar de tomar una acción de movimiento para recargar.",
+        "WeaponPropertiesRadioactive": "Radiactiva",
+        "WeaponPropertiesRadioactiveTooltip": "Un arma radiactiva contiene componentes radiactivos inestables. Cuando el portador obtiene un 1 natural en una tirada de ataque, queda expuesto a radiación peligrosa y debe tener éxito en una salvación de Fortaleza o sufrir enfermedad por radiación. (Para armas explosivas radiactivas, el usuario debe intentar una salvación de Fortaleza si alguno de los ataques es un 1 natural). Esto se considera un nivel bajo de radiación. Las DC para esta salvación y la enfermedad son iguales a la DC de golpe crítico del arma.",
+        "WeaponPropertiesReach": "Alcance",
+        "WeaponPropertiesReachTooltip": "Solo las armas cuerpo a cuerpo pueden tener la propiedad alcance. Empuñar un arma con alcance te da 10 pies de alcance para ataques con ese arma. Consulta Alcance y Casillas Amenazadas en página 255 para más información.",
+        "WeaponPropertiesRecall": "Recuperar",
+        "WeaponPropertiesRecallTooltip": "Un arma recuperar está vinculada a una pulsera o dispositivo pequeño usado por el portador (que no cuenta contra el máximo de dos objetos mágicos o híbridos). Si lanzas un arma recuperar y fallas el ataque, el arma regresa a ti al final de tu turno.",
+        "WeaponPropertiesRegrowth": "Recrecimiento",
+        "WeaponPropertiesRegrowthTooltip": "Este arma regenera su propia munición, generalmente con ayuda de la luz solar y nutrientes extraídos del aire o suelo. El arma tarda 8 horas en reponer toda su munición; esta munición siempre es munición estándar única para el arma y no puede venderse.",
+        "WeaponPropertiesRelic": "Reliquia",
+        "WeaponPropertiesRelicTooltip": "Estos objetos raros son fragmentos de tecnología perdida o ítems únicos menos poderosos que artefactos. Una reliquia tiene nivel de objeto pero puede venderse por el 100% de su precio (como bienes comerciales). Una reliquia no puede fabricarse sin los medios de una fórmula específica, que casi siempre está perdida y a menudo requiere materiales especiales. Una reliquia comprendida lo suficiente para ser reproducida, estandarizada y producida en masa podría perder su estatus de reliquia. A diferencia de armas normales, las armas reliquia no vienen completamente cargadas salvo que se indique.",
+        "WeaponPropertiesReposition": "Reposicionar",
+        "WeaponPropertiesRepositionTooltip": "Cuando intentas una maniobra de combate reposicionar con esta arma, ganas un bono de +2 a la tirada de ataque.",
+        "WeaponPropertiesScramble": "Desordenar",
+        "WeaponPropertiesScrambleTooltip": "Un arma con la propiedad desordenar interrumpe brevemente las habilidades telepáticas o mente colmena de una criatura. Cuando una criatura recibe daño de un arma con esta propiedad, debe tener éxito en una salvación de Fortaleza (DC = 10 + mitad del nivel del arma + modificador de Int del portador) o pierde su habilidad para comunicarse telepáticamente hasta el final de tu siguiente turno. Las habilidades que dependen de comunicación telepática, como la habilidad mente de enjambre, tampoco funcionan durante este tiempo.",
+        "WeaponPropertiesShape": "Forma",
+        "WeaponPropertiesShapeTooltip": "Un arma con la propiedad especial forma tiene una matriz compleja de puntería que le permite atacar áreas específicas. Si haces un solo ataque como acción completa con tal arma, puedes excluir la cantidad listada de casillas dentro del área de efecto del arma. Esto significa que puedes evitar disparar a un aliado dentro del área de efecto de un arma explosiva, por ejemplo.",
+        "WeaponPropertiesShatter": "Destrozar",
+        "WeaponPropertiesShatterTooltip": "La primera vez que se usa un arma con esta propiedad en un objetivo, el arma tiene la propiedad especial penetrante. Sin embargo, si el daño del arma se inflige continuamente al mismo objetivo en rondas sucesivas, la cantidad de Dureza que el arma ignora = 3 × el nivel del objeto del arma. Si el arma con esta propiedad es modal, el tipo de daño que inflige el arma debe cambiar cada ronda, o el arma solo funciona como un arma penetrante.",
+        "WeaponPropertiesShells": "Cartuchos",
+        "WeaponPropertiesShellsTooltip": "Algunas armas cuerpo a cuerpo pueden cargarse con cartuchos de escopeta para crear un ataque potente de corto alcance y un solo disparo. Un arma con la propiedad especial cartucho lista su capacidad y valor de uso. A diferencia de las cargas para armas cuerpo a cuerpo potenciadas, este uso es por ataque.",
+        "WeaponPropertiesShield": "Escudo",
+        "WeaponPropertiesShieldTooltip": "Un arma escudo encapsula al objetivo en un campo de fuerza de corta duración. Este campo dura hasta el inicio de tu siguiente turno o hasta que haya absorbido la cantidad listada de daño, lo que ocurra primero. Un campo de fuerza originado por un arma escudo bloquea solo el daño entrante; no interfiere en modo alguno con las armas o ataques del objetivo. No puedes usar un proyector de escudo para dirigirte a ti mismo.",
+        "WeaponPropertiesSniper": "Francotirador",
+        "WeaponPropertiesSniperTooltip": "Las armas con la propiedad especial francotirador pueden dispararse con precisión a muy largas distancias si se apuntan correctamente. Si apuntas el arma como acción de movimiento y luego disparas en el mismo turno, usa el valor listado con la propiedad especial francotirador como el incremento de alcance del arma. Aún puedes disparar un arma francotirador normalmente, pero solo tiene el alcance listado en su entrada normal de alcance cuando lo haces.",
+        "WeaponPropertiesStun": "Aturdir",
+        "WeaponPropertiesStunTooltip": "Puedes poner un arma con la propiedad especial aturdir en modo aturdimiento (o resetearla a modo normal) como acción de movimiento. Mientras está en modo aturdimiento, todos los ataques del arma son no letales. Consulta la página 252 para más información sobre cómo funciona el daño no letal.",
+        "WeaponPropertiesSubtle": "Sutil",
+        "WeaponPropertiesSubtleTooltip": "Puedes poner un arma con la propiedad especial aturdir en modo aturdimiento (o resetearla a modo normal) como acción de movimiento. Mientras está en modo aturdimiento, todos los ataques del arma son no letales. Consulta la página 252 para más información sobre cómo funciona el daño no letal.",
+        "WeaponPropertiesSunder": "Desarmar",
+        "WeaponPropertiesSunderTooltip": "Cuando intentas una maniobra de combate desarmar mientras empuñas un arma con la propiedad especial desarmar, ganas un bono de +2 a tu tirada de ataque.",
+        "WeaponPropertiesSwarm": "Enjambre",
+        "WeaponPropertiesSwarmTooltip": "Un arma con esta propiedad especial es prácticamente indistinguible de la tecnología Enjambre y requiere una batería especial de Enjambre para usarse eficientemente. El arma puede usar otras baterías, pero el uso se duplica al hacerlo.<br><br>Además del inconveniente energético, un arma Enjambre atrae la atención de criaturas Enjambre cercanas. Estas pueden detectar tal arma como si usaran sentidos ciegos con un rango de 30 pies. Se ha observado que componentes Enjambre se fijan en los portadores de esta tecnología durante la batalla, sin otra explicación para tal concentración violenta. Si el Enjambre gana el conflicto, los componentes sobrevivientes destruyen estas armas.",
+        "WeaponPropertiesTail": "Cola",
+        "WeaponPropertiesTailTooltip": "Si tienes una cola (o un apéndice similar a una cola), puedes llevar un arma con la propiedad especial cola en tu cola, en lugar de empuñarla con la mano. Colocar o quitar un arma cola es una acción completa, y una vez instalada, empuñas el arma sin usar las manos.",
+        "WeaponPropertiesTeleportive": "Teletransportiva",
+        "WeaponPropertiesTeleportiveTooltip": "La munición disparada por este arma se teletransporta una corta distancia tras ser disparada. Recibes solo una penalización acumulativa de –1 al atacar fuera del rango de este arma.",
+        "WeaponPropertiesThought": "Mental",
+        "WeaponPropertiesThoughtTooltip": "Un arma mental puede ser controlada total o parcialmente por telepatía. Si tienes el rasgo de especie telepatía o telepatía limitada, te beneficias de un hechizo de telepatía, llevas una diadema de enlace mental, o tienes una habilidad similar, ignoras la propiedad especial torpe del arma.",
+        "WeaponPropertiesThrottle": "Estranguladora",
+        "WeaponPropertiesThrottleTooltip": "Un arma estranguladora inflige daño solo cuando se usa para agarrar a un enemigo, infligiendo daño automáticamente con cada maniobra de combate de agarre exitosa. Todas las armas estranguladoras también son armas de agarre. Mientras un objetivo esté siendo agarrado exitosamente con un arma estranguladora, no puede usar sus vías respiratorias para hablar o hacer vocalizaciones de ningún tipo (aunque otras formas de hacer ruido funcionan normalmente).",
+        "WeaponPropertiesThrown": "Arrojadiza",
+        "WeaponPropertiesThrownTooltip": "Las armas a distancia que deben ser arrojadas y las armas cuerpo a cuerpo que pueden ser arrojadas como ataque a distancia tienen la propiedad especial arrojadiza y un incremento de alcance listado. Aplicas tu modificador de Fuerza a las tiradas de daño para ataques arrojadizos. Después de arrojar un arma, esta cae cerca del objetivo y debes recuperarla si quieres atacar con ella de nuevo.",
+        "WeaponPropertiesThruster": "Propulsor",
+        "WeaponPropertiesThrusterTooltip": "Esta arma produce ráfagas controladas de energía poderosa, que puedes dirigir para potenciar tus hazañas atléticas. Como parte de la acción que usas para volar, saltar o realizar la maniobra de empuje, puedes gastar munición o cargas igual al uso del arma para aumentar esa acción. Al volar, esta ráfaga te otorga un bono de mejora +2 a una prueba de Acrobacias para volar en esa ronda. Al saltar, esta ráfaga te otorga un bono de mejora igual al nivel del objeto del arma para esa prueba de Atletismo. Al realizar un empuje, esta ráfaga te otorga un bono +2 a tu tirada de ataque.",
+        "WeaponPropertiesTrip": "Derribar",
+        "WeaponPropertiesTripTooltip": "Cuando intentas una maniobra de combate derribar mientras empuñas un arma con esta propiedad, ganas un bono de +2 a tu tirada de ataque.",
+        "WeaponPropertiesTwoHanded": "A dos manos",
+        "WeaponPropertiesTwoHandedTooltip": "Solo puedes atacar con un arma (o amenazar un área con ella, para todas las armas cuerpo a cuerpo excepto ataques sin armas) si la empuñas con el número correcto de manos. Cuando las reglas se refieren a empuñar un arma, significa que sostienes un arma con el número correcto de manos y por tanto puedes hacer ataques con ella. Por ejemplo, si sostienes un arma corta en tu mano, se considera que empuñas el arma. Si llevas un arma larga en una mano o tienes un arma enfundada, no la estás empuñando. Puedes llevar un arma a dos manos en una mano, pero no puedes atacar con ella mientras haces eso.",
+        "WeaponPropertiesUnbalancing": "Desequilibrante",
+        "WeaponPropertiesUnbalancingTooltip": "Esta arma desequilibra a los enemigos. Cuando infliges daño con esta arma, el objetivo queda desprevenido contra el siguiente ataque que lo apunte antes del inicio de tu siguiente turno. Cualquier cosa que haga que un golpe crítico se trate como un golpe normal, como la fortificación, concede inmunidad a esta propiedad especial.",
+        "WeaponPropertiesUnderwater": "Subacuática",
+        "WeaponPropertiesUnderwaterTooltip": "Como los habitantes de la mayoría de los mundos acuáticos, los kalos crean sus propias versiones de armas comunes, rediseñadas para funcionar mejor bajo el agua. Estas armas tienen la siguiente propiedad especial y generalmente cuestan un 10% más.<br><br>Subacuática: Un arma con esta propiedad especial que se usa bajo el agua ignora la penalización de –2 a las tiradas de ataque y causa daño completo.",
+        "WeaponPropertiesUnwieldy": "Torpe",
+        "WeaponPropertiesUnwieldyTooltip": "Las armas con la propiedad especial torpe son grandes y torpes, no pueden dispararse sin antes enfriarse, o son difíciles de usar en ataques repetidos. No puedes usar un arma torpe como parte de un ataque completo (o cualquier otra acción que permita múltiples ataques), no puedes atacar más de una vez por ronda con ella, y no puedes usarla para realizar ataques de oportunidad.",
+        "WeaponPropertiesVariantBoost": "Impulso variante",
+        "WeaponPropertiesVariantBoostTooltip": "Un arma con la propiedad especial impulso variante actúa como un arma con la propiedad impulso, excepto que impulsarla no consume cargas adicionales y el arma solo puede impulsarse el número listado de veces por día.",
+        "WeaponPropertiesWideLine": "Línea ancha",
+        "WeaponPropertiesWideLineTooltip": "Un arma línea ancha funciona como un arma con la propiedad línea, excepto que la línea mide 10 pies de ancho. Al determinar las casillas que están en la trayectoria de una línea, anota las casillas por las que normalmente pasaría la línea y extiende el área a un lado de la línea (a tu elección) para que la línea tenga 2 casillas de ancho. Para que un obstáculo bloquee la trayectoria de una línea, debe bloquear el ancho total de la línea; de lo contrario, la línea continúa (con su ancho completo) más allá del obstáculo.",
+        "WeaponTypesAdvMelee": "Cuerpo a cuerpo avanzado",
+        "WeaponTypesBasicMelee": "Cuerpo a cuerpo básico",
+        "WeaponTypesGrenades": "Granadas",
+        "WeaponTypesHeavy": "Armas pesadas",
+        "WeaponTypesLongArms": "Armas largas",
+        "WeaponTypesSmallArms": "Armas cortas",
+        "WeaponTypesSniper": "Armas francotirador",
+        "WeaponTypesSolarian": "Cristales solares",
+        "WeaponTypesSpecial": "Armas especiales",
+        "WeaponsPropertiesConceal": "Oculto",
+        "WeaponsPropertiesConcealTooltip": "Un arma con la propiedad especial oculto se considera especialmente pequeña o fácil de esconder para los propósitos de la tarea de ocultar objeto de la habilidad Juego de Manos, otorgándote un bono circunstancial +4 a las pruebas para ocultar objeto.",
+        "WillSave": "Voluntad"
     },
-   "TYPES": {
-    "Actor": {
-        "character": "Personaje Jugador",
-        "drone": "Dron",
-        "hazard": "Peligro",
-        "npc": "PNJ Estilo Antiguo",
-        "npc2": "Personaje No Jugador",
-        "starship": "Nave Estelar",
-        "vehicle": "Vehículo"
-    },
-    "Item": {
-        "actorResource": "Recurso de Actor",
-        "ammunition": "Munición",
-        "archetypes": "Arquetipo",
-        "asi": "Aumento de Característica",
-        "augmentation": "Aumento",
-        "chassis": "Chasis de Dron",
-        "class": "Clase",
-        "consumable": "Consumible",
-        "container": "Contenedor",
-        "effect": "Efecto",
-        "equipment": "Armadura",
-        "feat": "Hazaña",
-        "fusion": "Fusión de Arma",
-        "goods": "Bienes",
-        "hybrid": "Híbrido",
-        "magic": "Mágico",
-        "mod": "Mod de Dron",
-        "race": "Especie",
-        "shield": "Escudo",
-        "spell": "Hechizo",
-        "starshipAblativeArmor": "Armadura Ablativa de Nave Estelar",
-        "starshipAction": "Acción de Nave Estelar",
-        "starshipArmor": "Armadura de Nave Estelar",
-        "starshipComputer": "Computadora de Nave Estelar",
-        "starshipCrewQuarter": "Alojamiento de Tripulación de Nave Estelar",
-        "starshipDefensiveCountermeasure": "Contramedida Defensiva de Nave Estelar",
-        "starshipDriftEngine": "Motor de Deriva de Nave Estelar",
-        "starshipExpansionBay": "Bahía de Expansión de Nave Estelar",
-        "starshipFortifiedHull": "Casco Fortificado de Nave Estelar",
-        "starshipFrame": "Estructura de Nave Estelar",
-        "starshipOtherSystem": "Otro Sistema de Nave Estelar",
-        "starshipPowerCore": "Núcleo de Energía de Nave Estelar",
-        "starshipReinforcedBulkhead": "Mamparo Reforzado de Nave Estelar",
-        "starshipSecuritySystem": "Sistema de Seguridad de Nave Estelar",
-        "starshipSensor": "Sensor de Nave Estelar",
-        "starshipShield": "Escudo de Nave Estelar",
-        "starshipSpecialAbility": "Habilidad Especial de Nave Estelar",
-        "starshipThruster": "Propulsor de Nave Estelar",
-        "starshipWeapon": "Arma de Nave Estelar",
-        "technological": "Tecnológico",
-        "theme": "Tema",
-        "upgrade": "Mejora de Armadura",
-        "vehicleAttack": "Ataque de Vehículo",
-        "vehicleSystem": "Sistema de Vehículo",
-        "weapon": "Arma",
-        "weaponAccessory": "Accesorio de Arma"
+    "TYPES": {
+        "Actor": {
+            "character": "Personaje Jugador",
+            "drone": "Dron",
+            "hazard": "Peligro",
+            "npc": "PNJ Estilo Antiguo",
+            "npc2": "Personaje No Jugador",
+            "starship": "Nave Estelar",
+            "vehicle": "Vehículo"
+        },
+        "Item": {
+            "actorResource": "Recurso de Actor",
+            "ammunition": "Munición",
+            "archetypes": "Arquetipo",
+            "asi": "Aumento de Característica",
+            "augmentation": "Aumento",
+            "chassis": "Chasis de Dron",
+            "class": "Clase",
+            "consumable": "Consumible",
+            "container": "Contenedor",
+            "effect": "Efecto",
+            "equipment": "Armadura",
+            "feat": "Hazaña",
+            "fusion": "Fusión de Arma",
+            "goods": "Bienes",
+            "hybrid": "Híbrido",
+            "magic": "Mágico",
+            "mod": "Mod de Dron",
+            "race": "Especie",
+            "shield": "Escudo",
+            "spell": "Hechizo",
+            "starshipAblativeArmor": "Armadura Ablativa de Nave Estelar",
+            "starshipAction": "Acción de Nave Estelar",
+            "starshipArmor": "Armadura de Nave Estelar",
+            "starshipComputer": "Computadora de Nave Estelar",
+            "starshipCrewQuarter": "Alojamiento de Tripulación de Nave Estelar",
+            "starshipDefensiveCountermeasure": "Contramedida Defensiva de Nave Estelar",
+            "starshipDriftEngine": "Motor de Deriva de Nave Estelar",
+            "starshipExpansionBay": "Bahía de Expansión de Nave Estelar",
+            "starshipFortifiedHull": "Casco Fortificado de Nave Estelar",
+            "starshipFrame": "Estructura de Nave Estelar",
+            "starshipOtherSystem": "Otro Sistema de Nave Estelar",
+            "starshipPowerCore": "Núcleo de Energía de Nave Estelar",
+            "starshipReinforcedBulkhead": "Mamparo Reforzado de Nave Estelar",
+            "starshipSecuritySystem": "Sistema de Seguridad de Nave Estelar",
+            "starshipSensor": "Sensor de Nave Estelar",
+            "starshipShield": "Escudo de Nave Estelar",
+            "starshipSpecialAbility": "Habilidad Especial de Nave Estelar",
+            "starshipThruster": "Propulsor de Nave Estelar",
+            "starshipWeapon": "Arma de Nave Estelar",
+            "technological": "Tecnológico",
+            "theme": "Tema",
+            "upgrade": "Mejora de Armadura",
+            "vehicleAttack": "Ataque de Vehículo",
+            "vehicleSystem": "Sistema de Vehículo",
+            "weapon": "Arma",
+            "weaponAccessory": "Accesorio de Arma"
         }
     }
 }

--- a/static/lang/fr.json
+++ b/static/lang/fr.json
@@ -2426,6 +2426,10 @@
                 "Hint": "When posting notifications about starship criticals or thresholds, only post to GM if the ship is a Hostile Token.",
                 "Name": "Hide Hostile Starship Critical Message"
             },
+            "LockArtworkRotationDefault": {
+                "Hint": "When enabled, enables Lock Artwork Rotation on character scale actors by default (Characters/NPC/Drones/Hazards). This can be overridden by the actor's prototype token settings.",
+                "Name": "Lock Artwork Rotation by Default"
+            },
             "SFRPGTheme": {
                 "Hint": "Lorsqu'il est activé, quelques ajustements mineurs aux couleurs de Foundry seront apportés pour correspondre au schéma de couleurs de Starfinder.",
                 "Name": "Thème SFRPG personnalisé"

--- a/static/lang/it.json
+++ b/static/lang/it.json
@@ -2434,6 +2434,10 @@
                 "Hint": "When posting notifications about starship criticals or thresholds, only post to GM if the ship is a Hostile Token.",
                 "Name": "Hide Hostile Starship Critical Message"
             },
+            "LockArtworkRotationDefault": {
+                "Hint": "When enabled, enables Lock Artwork Rotation on character scale actors by default (Characters/NPC/Drones/Hazards). This can be overridden by the actor's prototype token settings.",
+                "Name": "Lock Artwork Rotation by Default"
+            },
             "SFRPGTheme": {
                 "Hint": "When enabled, a few minor tweaks to Foundry's colours will be made to match Starfinder's colour scheme.",
                 "Name": "Custom SFRPG theme"

--- a/static/lang/ja.json
+++ b/static/lang/ja.json
@@ -2434,6 +2434,10 @@
                 "Hint": "When posting notifications about starship criticals or thresholds, only post to GM if the ship is a Hostile Token.",
                 "Name": "Hide Hostile Starship Critical Message"
             },
+            "LockArtworkRotationDefault": {
+                "Hint": "When enabled, enables Lock Artwork Rotation on character scale actors by default (Characters/NPC/Drones/Hazards). This can be overridden by the actor's prototype token settings.",
+                "Name": "Lock Artwork Rotation by Default"
+            },
             "SFRPGTheme": {
                 "Hint": "When enabled, a few minor tweaks to Foundry's colours will be made to match Starfinder's colour scheme.",
                 "Name": "Custom SFRPG theme"

--- a/static/lang/pt-BR.json
+++ b/static/lang/pt-BR.json
@@ -2434,6 +2434,10 @@
                 "Hint": "When posting notifications about starship criticals or thresholds, only post to GM if the ship is a Hostile Token.",
                 "Name": "Hide Hostile Starship Critical Message"
             },
+            "LockArtworkRotationDefault": {
+                "Hint": "When enabled, enables Lock Artwork Rotation on character scale actors by default (Characters/NPC/Drones/Hazards). This can be overridden by the actor's prototype token settings.",
+                "Name": "Lock Artwork Rotation by Default"
+            },
             "SFRPGTheme": {
                 "Hint": "When enabled, a few minor tweaks to Foundry's colours will be made to match Starfinder's colour scheme.",
                 "Name": "Custom SFRPG theme"


### PR DESCRIPTION
Creates a new setting for default lock artwork rotation on Character scale actors.

Prompts user to apply to all game actors when changed otherwise just sets property when creating new actors.

Also fixes null error bug creating hazards.