### PR TITLE
Test to build system on PR submission

### DIFF
--- a/.github/workflows/pr_test.yml
+++ b/.github/workflows/pr_test.yml
@@ -1,0 +1,51 @@
+# Much of this code yoinked and modified from https://github.com/SR5-FoundryVTT/SR5-FoundryVTT
+name: Build Test
+
+on:
+    pull_request:
+        branches: [ development ]
+
+jobs:
+    build:
+        runs-on: ubuntu-latest
+        steps:
+            # Checkout
+            - uses: actions/checkout@v4
+            # install deps
+            - run: npm ci
+
+            # Substitute the Manifest and Download URLs in system.json
+            - name: Update system.json url
+              uses: jossef/action-set-json-field@v2.1
+              with:
+                  file: static/system.json
+                  field: url
+                  value: https://github.com/${{github.repository}}
+
+            - name: Update system.json manifest link
+              uses: jossef/action-set-json-field@v2.1
+              with:
+                  file: static/system.json
+                  field: manifest
+                  value: https://github.com/${{github.repository}}/releases/download/${{github.event.release.tag_name}}/system.json
+
+            - name: Update system.json version number
+              uses: jossef/action-set-json-field@v2.1
+              with:
+                  file: static/system.json
+                  field: version
+                  value: ${{github.event.release.tag_name}}
+
+            - name: Update system.json download link
+              uses: jossef/action-set-json-field@v2.1
+              with:
+                  file: static/system.json
+                  field: download
+                  value: https://github.com/${{github.repository}}/releases/download/${{github.event.release.tag_name}}/sfrpg-${{github.event.release.tag_name}}.zip
+
+            # copy localizations
+            - run: npm run copyLocalization
+            # build src into dist
+            - run: npm run build
+            # create package
+            - run: npm run package

--- a/.github/workflows/pr_test.yml
+++ b/.github/workflows/pr_test.yml
@@ -27,21 +27,21 @@ jobs:
               with:
                   file: static/system.json
                   field: manifest
-                  value: https://github.com/${{github.repository}}/releases/download/${{github.event.release.tag_name}}/system.json
+                  value: https://github.com/${{github.repository}}/releases/download/build-test/system.json
 
             - name: Update system.json version number
               uses: jossef/action-set-json-field@v2.1
               with:
                   file: static/system.json
                   field: version
-                  value: ${{github.event.release.tag_name}}
+                  value: 0.0.0
 
             - name: Update system.json download link
               uses: jossef/action-set-json-field@v2.1
               with:
                   file: static/system.json
                   field: download
-                  value: https://github.com/${{github.repository}}/releases/download/${{github.event.release.tag_name}}/sfrpg-${{github.event.release.tag_name}}.zip
+                  value: https://github.com/${{github.repository}}/releases/download/build-test/sfrpg-0.0.0.zip
 
             # copy localizations
             - run: npm run copyLocalization


### PR DESCRIPTION
Builds the system against each PR submitted. Primarily to ensure that any dependency changes or build process changes are validated against the automated build process on the github machines.

This is useful for PRs like #1565 that make changes to the build process that work fine locally, but have issues on the github linux build servers.