### PR TITLE
Fix renderCombatTracker hook error

### DIFF
--- a/src/module/combat/combat.js
+++ b/src/module/combat/combat.js
@@ -927,18 +927,20 @@ Hooks.on('renderCombatTracker', (app, html, data) => {
         // Add buttons for switching combat type
         activeCombat.renderCombatTypeControls(header);
 
-        // Handle button clicks
-        const configureButtonPrev = header.querySelector('.combat-type-prev');
-        configureButtonPrev.addEventListener('click', ev => {
-            ev.preventDefault();
-            onConfigClicked(activeCombat, -1);
-        });
+        if (game.user.isGM) {
+            // Handle button clicks
+            const configureButtonPrev = header.querySelector('.combat-type-prev');
+            configureButtonPrev.addEventListener('click', ev => {
+                ev.preventDefault();
+                onConfigClicked(activeCombat, -1);
+            });
 
-        const configureButtonNext = header.querySelector('.combat-type-next');
-        configureButtonNext.addEventListener('click', ev => {
-            ev.preventDefault();
-            onConfigClicked(activeCombat, 1);
-        });
+            const configureButtonNext = header.querySelector('.combat-type-next');
+            configureButtonNext.addEventListener('click', ev => {
+                ev.preventDefault();
+                onConfigClicked(activeCombat, 1);
+            });
+        }
     }
 
     // Perform difficulty calculations, and display if appropriate


### PR DESCRIPTION
If a non-GM player opens the combat tracker while a combat exists, but before the first round of combat, the render hook currently tries to add event listeners to prev/next combat type buttons that don't exist for that non-GM player. This causes an error to be thrown:

<img width="933" height="310" alt="combat tracker error" src="https://github.com/user-attachments/assets/54591da0-a78d-4774-a30a-1ce6f4df544f" />


This PR fixes the issue, preventing the error from appearing.