### PR TITLE
Fix typo in Nanite Surge max uses (nanoctye -> nanocyte)

### DIFF
--- a/src/items/class-features/nanite_surge_(ex).json
+++ b/src/items/class-features/nanite_surge_(ex).json
@@ -114,7 +114,7 @@
       "value": ""
     },
     "uses": {
-      "max": "floor(@classes.nanoctye.levels/2) + @abilities.con.mod",
+      "max": "floor(@classes.nanocyte.levels/2) + @abilities.con.mod",
       "per": "charges",
       "value": 0
     }


### PR DESCRIPTION
The formula for max uses of Nanite Surge has a typo of "nanoctye" which causes the calculation to be wrong. This PR fixes the typo.