### PR TITLE
Fix typo in starship sheet template (WeaponsArrayAft -> weaponsArrayAft)

### DIFF
--- a/static/templates/actors/starship-sheet-full.hbs
+++ b/static/templates/actors/starship-sheet-full.hbs
@@ -438,7 +438,7 @@
                             </select>
                         </div>
                         <div class="form-group">
-                            <label for="system.attributes.systems.weaponsArrayAft.value">{{localize "SFRPG.StarshipSheet.Critical.Systems.WeaponsArrayAft"}} <a class="critical-edit" data-system="WeaponsArrayAft" title="{{localize "SFRPG.StarshipSheet.Critical.Edit"}}"><i class="fas fa-edit"></i></a></label>
+                            <label for="system.attributes.systems.weaponsArrayAft.value">{{localize "SFRPG.StarshipSheet.Critical.Systems.WeaponsArrayAft"}} <a class="critical-edit" data-system="weaponsArrayAft" title="{{localize "SFRPG.StarshipSheet.Critical.Edit"}}"><i class="fas fa-edit"></i></a></label>
                             <select name="system.attributes.systems.weaponsArrayAft.value">
                                 {{selectOptions (sfrpg "starshipSystemStatus") selected=system.attributes.systems.weaponsArrayAft.value}}
                             </select>


### PR DESCRIPTION
This PR fixes a typo in the starship sheet template that stops the Critical Damage Weapons (Aft) role editor from opening.