### PR TITLE
Starship action compendium fixes

### DIFF
--- a/src/items/starship-actions/miracle_worker_ship_repair.json
+++ b/src/items/starship-actions/miracle_worker_ship_repair.json
@@ -23,11 +23,14 @@
       "value": "<p>You restore a number of Hull Points equal to the starship’s base frame HP increment. If this raises the ship’s HP over a multiple of its @UUID[Compendium.sfrpg.rules.JournalEntry.1hTMc6MfkFkE54NK.JournalEntryPage.prwFRuwtGYNChHlr#critical-threshold-(ct):]{Critical Threshold}, you can repair critical damage to one system per multiple, reducing its severity by one step. For example, if your starship’s Critical Threshold is 8 and you restore 10 HP, reducing the damage to the hull from 17 HP to 7 HP, you could restore one system from @UUID[Compendium.sfrpg.rules.JournalEntry.y41YyBmHZYus6NCZ.JournalEntryPage.oEDt7byMjC9PQFj7#wrecked]{wrecked} to @UUID[Compendium.sfrpg.rules.JournalEntry.y41YyBmHZYus6NCZ.JournalEntryPage.oEDt7byMjC9PQFj7#glitching]{glitching}. Using this ability during starship combat is your action for the turn, and you can do it only during the @UUID[Compendium.sfrpg.rules.JournalEntry.y41YyBmHZYus6NCZ.JournalEntryPage.QuLY2ANfjGbBL66n#1.-engineering]{engineering phase}. See page 292 for more on @UUID[Compendium.sfrpg.rules.JournalEntry.1hTMc6MfkFkE54NK.JournalEntryPage.prwFRuwtGYNChHlr]{ship construction} and page 320 for more on @UUID[Compendium.sfrpg.rules.JournalEntry.y41YyBmHZYus6NCZ.JournalEntryPage.oEDt7byMjC9PQFj7]{damage to ships}.</p>\n<p>Enabled by the @UUID[Compendium.sfrpg.class-features.Item.D5vkMjJh78XE6KkS]{Miracle Worker} mechanic class feature available at Level 7.</p>"
     },
     "effectCritical": "",
-    "effectNormal": "",
+    "effectNormal": "You restore a number of Hull Points equal to the starship’s base frame HP increment. If this raises the ship’s HP over a multiple of its Critical Threshold, you can repair critical damage to one system per multiple, reducing its severity by one step. For example, if your starship’s Critical Threshold is 8 and you restore 10 HP, reducing the damage to the hull from 17 HP to 7 HP, you could restore one system from wrecked to glitching. Using this ability during starship combat is your action for the turn, and you can do it only during the engineering phase. <strong>Enabled by the mechanic class feature available at Level 7.</strong>",
     "formula": [],
     "isPush": false,
     "order": 0,
-    "phase": {},
+    "phase": {
+      "name": "Engineering phase",
+      "tooltip": "This action can be taken only during the engineering phase."
+    },
     "resolvePointCost": 0,
     "role": "",
     "selectorKey": "",

--- a/src/items/starship-actions/recalibrate_engine_(mechanic_only).json
+++ b/src/items/starship-actions/recalibrate_engine_(mechanic_only).json
@@ -25,8 +25,8 @@
       "unidentified": "",
       "value": "<h2>Normal effect</h2><p>The ship gains a +2 enhancement bonus to its speed for 1 turn, and the piloting check made in the Helm phase to determine the order of movement of starships gains a +2 enhancement bonus, but all other piloting checks made that turn take a –5 penalty.</p>\n<p>Requires the @UUID[Compendium.sfrpg.class-features.Item.esc4GLvaX3Qd3CUs]{Recalibrate Engine} mechanic trick.</p>"
     },
-    "effectCritical": "<p>None</p>",
-    "effectNormal": "<p>The ship gains a +2 enhancement bonus to its speed for 1 turn, and the piloting check made in the Helm phase to determine the order of movement of starships gains a +2 enhancement bonus, but all other piloting checks made that turn take a –5 penalty.</p>",
+    "effectCritical": "None",
+    "effectNormal": "The ship gains a +2 enhancement bonus to its speed for 1 turn, and the piloting check made in the Helm phase to determine the order of movement of starships gains a +2 enhancement bonus, but all other piloting checks made that turn take a –5 penalty.",
     "formula": [],
     "isPush": false,
     "order": 0,

--- a/src/items/starship-actions/vent_engines_(mechanic_only).json
+++ b/src/items/starship-actions/vent_engines_(mechanic_only).json
@@ -25,8 +25,8 @@
       "unidentified": "",
       "value": "<h2>Normal effect</h2><p>As your starship moves during the next helm phase, it fills a number of consecutive hexes it departs with hazardous energy; the number of hexes filled can’t exceed [[@abilities.int.mod]]{your Intelligence modifier}. The energy dissipates at the beginning of the following turn’s helm phase. Any starship that enters one or more of these hexes before then takes damage equal to [[/r 1d4]]{1d4} × your starship’s tier, distributed evenly across all four quadrants. You can use this action once per combat, though you can use it additional times by spending 1 Resolve Point for each additional use.</p>\n<p>Requires the @UUID[Compendium.sfrpg.class-features.Item.yTDughITUM5i65by]{Engine Plasma} mechanic trick.</p>"
     },
-    "effectCritical": "<p>None</p>",
-    "effectNormal": "<p>As your starship moves during the next helm phase, it fills a number of consecutive hexes it departs with hazardous energy; the number of hexes filled can’t exceed [[@abilities.int.mod]]{your Intelligence modifier}. The energy dissipates at the beginning of the following turn’s helm phase. Any starship that enters one or more of these hexes before then takes damage equal to [[/r 1d4]]{1d4} × your starship’s tier, distributed evenly across all four quadrants. You can use this action once per combat, though you can use it additional times by spending 1 Resolve Point for each additional use.</p>",
+    "effectCritical": "None",
+    "effectNormal": "As your starship moves during the next helm phase, it fills a number of consecutive hexes it departs with hazardous energy; the number of hexes filled can’t exceed [[@abilities.int.mod]]{your Intelligence modifier}. The energy dissipates at the beginning of the following turn’s helm phase. Any starship that enters one or more of these hexes before then takes damage equal to [[/r 1d4]]{1d4} × your starship’s tier, distributed evenly across all four quadrants. You can use this action once per combat, though you can use it additional times by spending 1 Resolve Point for each additional use.",
     "formula": [],
     "isPush": false,
     "order": 0,


### PR DESCRIPTION
A few minor corrections to the starship actions in the compendium.
- Fix \<p\> incorrectly being used in normal and critical effect strings for Recalibrate Engine and Vent Engines
- Fix missing normal effect string and phase on Miracle Worker Ship Repair