### PR TITLE
Fix turrets not being impacted by critical weapon system damage

### DIFF
--- a/src/module/rules/actions/actor/starship/calculate-starship-critical-status.js
+++ b/src/module/rules/actions/actor/starship/calculate-starship-critical-status.js
@@ -95,6 +95,15 @@ export default function(engine) {
             systemData.modOther = (key === "powerCore") ? critModsOther[systemData.value] : 0;
         }
 
+        data.attributes.systems.weaponsArrayTurret = {
+            mod: Math.min(
+                data.attributes.systems.weaponsArrayForward.mod,
+                data.attributes.systems.weaponsArrayPort.mod,
+                data.attributes.systems.weaponsArrayStarboard.mod,
+                data.attributes.systems.weaponsArrayAft.mod
+            )
+        };
+
         return fact;
     }, { required: ["stackModifiers"], closureParameters: ["stackModifiers"] } );
 }


### PR DESCRIPTION
Turrets currently ignore critical weapon system damage when rolling attacks. This PR fixes that issue by setting the modifier for turret weapons to the worst weapon array modifier.