### PR TITLE
Fix hotbar

### DIFF
--- a/src/less/apps.less
+++ b/src/less/apps.less
@@ -719,11 +719,11 @@ img.icon-enricher {
 
 // SFRPG Macro Bar
 
-#hotbar.sfrpg {
-    ol#macro-list {
+#hotbar {
+    menu#action-bar.sfrpg {
         border: none;
 
-        .macro {
+        .slot {
             img {
                 &.greyscale {
                     filter: grayscale(1);
@@ -735,14 +735,16 @@ img.icon-enricher {
                 }
             }
 
-            span.macro-key {
+            span.key {
                 top: 0px;
                 right: 0px;
-                padding: 0 2px;
+                left: auto;
+                padding: 0 2px 2px 2px;
                 z-index: 1;
+                border-radius: 0 8px;
             }
 
-            footer.macro-footer {
+            footer.footer {
                 position: absolute;
                 bottom: 0px;
                 left: 0px;

--- a/src/module/actor/actor.js
+++ b/src/module/actor/actor.js
@@ -297,10 +297,14 @@ export class ActorSFRPG extends Mix(foundry.documents.Actor).with(ActorCondition
 
     /**
      * Delete any of corresponding timedEffect objects of the actor's items.
+     * Also remove linked hotbar instances from item apps before deleting so the hotbar isn't closed.
      */
     async _onDelete(options, userId) {
         for (const item of this.items) {
             game.sfrpg.timedEffects.get(item.uuid)?.delete();
+        }
+        for (const item of this.items) {
+            item.apps?.hotbar?.delete();
         }
 
         return super._onDelete(options, userId);

--- a/src/module/actor/actor.js
+++ b/src/module/actor/actor.js
@@ -302,7 +302,7 @@ export class ActorSFRPG extends Mix(foundry.documents.Actor).with(ActorCondition
     async _onDelete(options, userId) {
         for (const item of this.items) {
             game.sfrpg.timedEffects.get(item.uuid)?.delete();
-            item.apps?.hotbar?.delete();
+            delete item.apps[ui.hotbar.id];
         }
 
         return super._onDelete(options, userId);

--- a/src/module/actor/actor.js
+++ b/src/module/actor/actor.js
@@ -302,8 +302,6 @@ export class ActorSFRPG extends Mix(foundry.documents.Actor).with(ActorCondition
     async _onDelete(options, userId) {
         for (const item of this.items) {
             game.sfrpg.timedEffects.get(item.uuid)?.delete();
-        }
-        for (const item of this.items) {
             item.apps?.hotbar?.delete();
         }
 

--- a/src/module/apps/ui/hotbar.js
+++ b/src/module/apps/ui/hotbar.js
@@ -16,8 +16,7 @@ export class HotbarSFRPG extends foundry.applications.ui.Hotbar {
     /** @override */
     async _prepareContext() {
         const data = await super._prepareContext();
-
-        for (const slot of data.macros) {
+        for (const slot of data.slots) {
             const macro = slot.macro;
             if (!macro) continue;
 
@@ -51,6 +50,7 @@ export class HotbarSFRPG extends foundry.applications.ui.Hotbar {
                 slot.activeGlow = itemMacroDetails.macroType === "activate" && macroConfig.isActive;
                 slot.hasUses = itemMacroDetails.macroType === "activate" && macroConfig.hasUses;
 
+                slot.tooltip = `<strong>${slot.tooltip}</strong>`;
                 slot.tooltip += `
                     <br>
                     ${game.i18n.localize("DOCUMENT.Actor")}: ${item.actor.name}

--- a/src/module/apps/ui/hotbar.js
+++ b/src/module/apps/ui/hotbar.js
@@ -33,7 +33,7 @@ export class HotbarSFRPG extends foundry.applications.ui.Hotbar {
                     hasAttack: SFRPG.attackActions.includes(item.system.actionType) && (!["weapon", "shield"].includes(item.type) || item.system.equipped),
                     hasDamage: item.system.damage?.parts && item.system.damage.parts.length > 0 && (!["weapon", "shield"].includes(item.type) || item.system.equipped),
                     hasUses: item.hasUses(),
-                    hasActivation: item.canBeActivated(),
+                    hasActivation: item.canBeActivated() && item.system.duration?.units !== 'instantaneous',
                     isActive: item.isActive(),
                     hasCapacity: item.hasCapacity()
 
@@ -57,8 +57,10 @@ export class HotbarSFRPG extends foundry.applications.ui.Hotbar {
                     <br>
                 `;
                 if (itemMacroDetails.macroType === "activate") {
-                    slot.tooltip += macroConfig.isActive ? "Active" : "Inactive";
-                    slot.tooltip += "<br>";
+                    if (macroConfig.hasActivation) {
+                        slot.tooltip += macroConfig.isActive ? "Active" : "Inactive";
+                        slot.tooltip += "<br>";
+                    }
                     if (macroConfig.hasUses) slot.tooltip += `
                         ${game.i18n.localize("SFRPG.SpellBook.Uses")}: ${item.system.uses.value}/${item.system.uses.total}
                     `;

--- a/src/module/apps/ui/hotbar.js
+++ b/src/module/apps/ui/hotbar.js
@@ -58,7 +58,7 @@ export class HotbarSFRPG extends foundry.applications.ui.Hotbar {
                 `;
                 if (itemMacroDetails.macroType === "activate") {
                     if (macroConfig.hasActivation) {
-                        slot.tooltip += macroConfig.isActive ? "Active" : "Inactive";
+                        slot.tooltip += macroConfig.isActive ? game.i18n.localize("SFRPG.Macro.Active") : game.i18n.localize("SFRPG.Macro.Inactive");
                         slot.tooltip += "<br>";
                     }
                     if (macroConfig.hasUses) slot.tooltip += `

--- a/src/module/system/hotbar-macros.js
+++ b/src/module/system/hotbar-macros.js
@@ -232,13 +232,13 @@ export function connectToDocument(macro) {
     if (itemMacroDetails?.itemUuid) {
         const item = fromUuidSync(itemMacroDetails?.itemUuid);
         if (!item || !item.actor) return false;
-        item.apps[ui.hotbar.appId] = ui.hotbar;
+        item.apps[ui.hotbar.id] = ui.hotbar;
 
         // Attacking with a weapon with ammo triggers an update on the ammo, not the weapon, so listen to the ammo too.
         const childItems = _getChildItems(item);
         if (!childItems?.length) return;
         for (const child of childItems) {
-            child.apps[ui.hotbar.appId] = ui.hotbar;
+            child.apps[ui.hotbar.id] = ui.hotbar;
         }
 
         return true;

--- a/src/module/system/hotbar-macros.js
+++ b/src/module/system/hotbar-macros.js
@@ -265,18 +265,18 @@ function _getChildItems(item) {
 
 // Before deleting an item, remove it from the hotbar's apps, so the delete method doesn't close the hotbar.
 Hooks.on("preDeleteItem", (item) => {
-    delete item.apps[ui.hotbar.appId];
+    delete item.apps[ui.hotbar.id];
 });
 
 // Add update listeners to all child items whenever an item is updated, in case any child items were swapped.
 Hooks.on("updateItem", (item) => {
-    if (item.apps[ui.hotbar.appId]) {
+    if (item.apps[ui.hotbar.id]) {
         const childItems = _getChildItems(item);
         if (!childItems?.length) return;
 
         for (const child of childItems) {
-            if (child.apps[ui.hotbar.appId]) continue;
-            child.apps[ui.hotbar.appId] = ui.hotbar;
+            if (child.apps[ui.hotbar.id]) continue;
+            child.apps[ui.hotbar.id] = ui.hotbar;
         }
     }
 });

--- a/src/module/system/hotbar-macros.js
+++ b/src/module/system/hotbar-macros.js
@@ -8,12 +8,16 @@ const createMacroFnLookup = {
     AbilityCheck: createAbilityCheckMacro
 };
 
-Hooks.on("hotbarDrop", async (bar, data, slot) => {
+Hooks.on("hotbarDrop", (bar, data, slot) => {
     const createMacroFn = data && createMacroFnLookup[data.type];
-    if (createMacroFn) {
-        game.user.assignHotbarMacro(await createMacroFn(data), slot);
+    if (!bar.locked && createMacroFn) {
+        createMacroFn(data).then((macro) => {
+            game.user.assignHotbarMacro(macro, slot);
+        });
+        return false;
     } else {
         // silently ignore this hook, just in case someone else will pick it up.
+        return true;
     }
 });
 

--- a/src/module/system/hotbar-macros.js
+++ b/src/module/system/hotbar-macros.js
@@ -89,7 +89,7 @@ export function rollItemMacro(itemUuid, macroType) {
     }
 
     if (!item) {
-        return ui.notifications.error(`Cannot find the item associated with this item macro.`);
+        return ui.notifications.error(game.i18n.localize("SFRPG.Macro.ErrorMissingItem"));
     } else switch (macroType) {
         case "attack":
             return item.rollAttack({ event });

--- a/src/sfrpg.js
+++ b/src/sfrpg.js
@@ -33,6 +33,7 @@ import { NpcSkillToggleDialog } from './module/apps/npc-skill-toggle-dialog.js';
 import { ShortRestDialog } from './module/apps/short-rest.js';
 import { SpellCastDialog } from './module/apps/spell-cast-dialog.js';
 import { TraitSelectorSFRPG } from './module/apps/trait-selector.js';
+import { HotbarSFRPG } from "./module/apps/ui/hotbar.js";
 import { canvasHandler } from "./module/canvas/canvas.js";
 import { MeasuredTemplateSFRPG, TemplateLayerSFRPG } from "./module/canvas/template-overrides.js";
 import { addChatMessageContextOptions } from "./module/chat/chat-message-options.js";
@@ -216,7 +217,7 @@ Hooks.once('init', async function() {
     CONFIG.MeasuredTemplate.objectClass = MeasuredTemplateSFRPG;
     CONFIG.MeasuredTemplate.defaults.angle = 90; // SF uses 90 degree cones
 
-    //   CONFIG.ui.hotbar = HotbarSFRPG;
+    CONFIG.ui.hotbar = HotbarSFRPG;
 
     CONFIG.fontDefinitions["Exo2"] = {
         editor: true,

--- a/static/lang/de.json
+++ b/static/lang/de.json
@@ -1984,6 +1984,9 @@
         "LocalizationTerminator": "",
         "Long": "Lang",
         "Macro": {
+            "Active": "Active",
+            "ErrorMissingItem": "Cannot find the item associated with this item macro.",
+            "Inactive": "Inactive",
             "ViewActor": "Akteur zeigen",
             "ViewItem": "Gegenstand zeigen"
         },

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -1977,6 +1977,9 @@
         "LocalizationTerminator": "",
         "Long": "Long",
         "Macro": {
+            "Active": "Active",
+            "ErrorMissingItem": "Cannot find the item associated with this item macro.",
+            "Inactive": "Inactive",
             "ViewActor": "View Actor",
             "ViewItem": "View Item"
         },

--- a/static/lang/es.json
+++ b/static/lang/es.json
@@ -1973,6 +1973,9 @@
         "LocalizationTerminator": "",
         "Long": "Largo",
         "Macro": {
+            "Active": "Active",
+            "ErrorMissingItem": "Cannot find the item associated with this item macro.",
+            "Inactive": "Inactive",
             "ViewActor": "Ver Personaje",
             "ViewItem": "Ver Objeto"
         },

--- a/static/lang/fr.json
+++ b/static/lang/fr.json
@@ -1977,6 +1977,9 @@
         "LocalizationTerminator": "",
         "Long": "Long",
         "Macro": {
+            "Active": "Active",
+            "ErrorMissingItem": "Cannot find the item associated with this item macro.",
+            "Inactive": "Inactive",
             "ViewActor": "Vue Acteur",
             "ViewItem": "Vue Objet"
         },

--- a/static/lang/it.json
+++ b/static/lang/it.json
@@ -1985,6 +1985,9 @@
         "LocalizationTerminator": "",
         "Long": "Lungo",
         "Macro": {
+            "Active": "Active",
+            "ErrorMissingItem": "Cannot find the item associated with this item macro.",
+            "Inactive": "Inactive",
             "ViewActor": "View Actor",
             "ViewItem": "View Item"
         },

--- a/static/lang/ja.json
+++ b/static/lang/ja.json
@@ -1985,6 +1985,9 @@
         "LocalizationTerminator": "",
         "Long": "長距離",
         "Macro": {
+            "Active": "Active",
+            "ErrorMissingItem": "Cannot find the item associated with this item macro.",
+            "Inactive": "Inactive",
             "ViewActor": "View Actor",
             "ViewItem": "View Item"
         },

--- a/static/lang/pt-BR.json
+++ b/static/lang/pt-BR.json
@@ -1985,6 +1985,9 @@
         "LocalizationTerminator": "",
         "Long": "Longo",
         "Macro": {
+            "Active": "Active",
+            "ErrorMissingItem": "Cannot find the item associated with this item macro.",
+            "Inactive": "Inactive",
             "ViewActor": "View Actor",
             "ViewItem": "View Item"
         },

--- a/static/templates/ui/hotbar.hbs
+++ b/static/templates/ui/hotbar.hbs
@@ -1,44 +1,43 @@
-<div id="hotbar" class="flexrow sfrpg {{#if locked}}locked{{/if}}" data-tooltip-direction="UP">
-    <div id="hotbar-directory-controls" class="bar-controls flexcol">
-        <a id="bar-toggle" data-tooltip="MACRO.CollapseHotbar">
-            <i class="fas fa-caret-down"></i>
-        </a>
-        <a id="macro-directory" data-tooltip="MACRO.Directory">
-            <i class="fas fa-folder"></i>
-        </a>
+<aside id="hotbar">
+    <div id="hotbar-controls-left" class="hotbar-controls flexcol" data-tooltip-direction="LEFT">
+        <button type="button" class="ui-control fa-solid fa-volume icon" data-action="mute" data-tooltip
+                aria-label="{{localize 'HOTBAR.MUTE'}}"></button>
+        <button type="button" class="ui-control fa-solid fa-bars icon" data-action="menu" data-tooltip
+                aria-label="{{localize 'HOTBAR.MENU'}}"></button>
     </div>
-    <nav id="action-bar" class="flexrow {{barClass}}"  aria-label="{{localize 'MACRO.NavLabel'}}">
-        <ol id="macro-list" class="flexrow" data-page="{{page}}">
-            {{#each macros}}
-            <li class="macro {{this.cssClass}}" data-slot="{{this.slot}}"
-                {{#if this.macro}}data-macro-id="{{this.macro.id}}" data-tooltip="{{this.tooltip}}"{{/if}}>
-                <span class="macro-key">{{this.key}}</span>
-                {{#if this.icon}}
-                <img class="macro-icon {{#if this.greyscale}}greyscale{{/if}} {{#if this.activeGlow}}active{{/if}}" src="{{this.icon}}" alt="{{this.tooltip}}" />
-                {{/if}}
-                {{#if this.macro.macroConfig.item}}
-                    <i class="fas {{this.iconClass}} icon"></i>
-                    {{#if this.macro.macroConfig.hasCapacity}}
-                    <footer class="macro-footer">{{this.macro.macroConfig.capacityCurrent}}/{{this.macro.macroConfig.capacityMaximum}}</footer>
-                    {{else if this.macro.macroConfig.hasUses}}
-                    <footer class="macro-footer">{{this.macro.macroConfig.item.system.uses.value}}/{{this.macro.macroConfig.item.system.uses.total}}</footer>
+    <menu id="action-bar" class="flexrow sfrpg" data-tooltip-direction="UP">
+        {{#each slots as |slot|}}
+            <li class="slot {{slot.cssClass}}" role="button" data-action="execute" data-slot="{{slot.slot}}"
+                style="{{slot.style}}" aria-label="{{slot.ariaLabel}}"
+                {{#if slot.tooltip}}data-tooltip-html="{{slot.tooltip}}"{{/if}}>
+                {{#if slot.img}}<img class="slot-icon {{#if slot.greyscale}}greyscale{{/if}} {{#if slot.activeGlow}}active{{/if}}" src="{{slot.img}}" alt="{{slot.ariaLabel}}">{{/if}}
+                <span class="key">{{slot.key}}</span>
+                {{#if slot.macro.macroConfig.item}}
+                    <i class="fas {{slot.iconClass}} icon"></i>
+                    {{#if slot.macro.macroConfig.hasCapacity}}
+                        <footer class="footer">{{slot.macro.macroConfig.capacityCurrent}}/{{slot.macro.macroConfig.capacityMaximum}}</footer>
+                    {{else if slot.macro.macroConfig.hasUses}}
+                        <footer class="footer">{{slot.macro.macroConfig.item.system.uses.value}}/{{slot.macro.macroConfig.item.system.uses.total}}</footer>
                     {{/if}}
                 {{/if}}
             </li>
-            {{/each}}
-        </ol>
-        <div id="hotbar-lock" class="bar-controls flexcol" data-tooltip-direction="UP">
-            <a class="page-control" data-action="lock" data-tooltip="MACRO.{{ifThen locked "Unlock" "Lock"}}Bar">
-                <i class="fas fa-lock{{#unless locked}}-open{{/unless}}"></i>
-            </a>
+        {{/each}}
+    </menu>
+    <div id="hotbar-controls-right" class="hotbar-controls flexrow" data-tooltip-direction="RIGHT">
+        <nav id="hotbar-page-controls" class="flexcol">
+            <button type="button" class="plain hotbar-page-control page-next fa-solid fa-triangle icon"
+                    data-action="page" data-direction="1" data-tooltip aria-label="{{localize 'HOTBAR.PAGE_NEXT'}}">
+            </button>
+            <span class="hotbar-page-number">{{page}}</span>
+            <button type="button" class="plain hotbar-page-control page-prev fa-solid fa-triangle icon"
+                    data-action="page" data-direction="-1" data-tooltip aria-label="{{localize 'HOTBAR.PAGE_PREV'}}">
+            </button>
+        </nav>
+        <div class="flexcol">
+            <button type="button" class="ui-control fa-solid fa-unlock icon" data-action="lock" data-tooltip
+                    aria-label="{{localize 'HOTBAR.LOCK'}}"></button>
+            <button type="button" class="ui-control fa-solid fa-trash icon" data-action="clear" data-tooltip
+                    aria-label="{{localize 'HOTBAR.CLEAR'}}"></button>
         </div>
-        <div id="hotbar-page-controls" class="bar-controls flexcol" data-tooltip-direction="UP">
-            <a class="page-control" data-action="page-up" data-tooltip="MACRO.PageUp" alt="{{localize 'MACRO.PageUp'}}" >
-                <i class="fas fa-angle-up"></i></a>
-            <span class="page-number">{{page}}</span>
-            <a class="page-control" data-action="page-down" data-tooltip="MACRO.PageDown" alt="{{localize 'MACRO.PageDown'}}">
-                <i class="fas fa-angle-down"></i>
-            </a>
-        </div>
-    </nav>
-</div>
+    </div>
+</aside>


### PR DESCRIPTION
This is a PR for several small hotbar fixes:

- During the upgrade to Foundry v13 the custom hotbar implementation (HotbarSFRPG) was disabled. This pull request makes it compatible with Foundry v13 and re-enables it.
- Fixed the hotbarDrop not working properly
- The tick/cross icon in the corner of macro buttons and the Active/Inactive tooltip label no longer appear for items which have instantaneous duration

<img width="693" height="84" alt="hotbar-sfrpg-v13" src="https://github.com/user-attachments/assets/63c89528-7e67-4099-970f-21edae8de6c2" />
