### PR TITLE
Fix starship combat hidden turn

### DIFF
--- a/src/module/combat/combat.js
+++ b/src/module/combat/combat.js
@@ -45,8 +45,6 @@ Vehicle has the following 3 phases: "Pilot Actions", "Chase Progress", and "Comb
 */
 
 export class CombatSFRPG extends foundry.documents.Combat {
-    static HiddenTurn = 0;
-
     /**
      * The current initiative count of the encounter
      */
@@ -66,15 +64,18 @@ export class CombatSFRPG extends foundry.documents.Combat {
         return super._preCreate(data, options, user);
     }
 
-    async begin() {
+    async startCombat() {
+        this._playCombatSound("startEncounter");
+
+        const combatType = this.getCombatType();
         const update = {
             "flags.sfrpg.startTime": game.time.worldTime,
-            "flags.sfrpg.combatType": this.getCombatType(),
+            "flags.sfrpg.combatType": combatType,
             "flags.sfrpg.phase": 0,
             "round": 1,
-            "turn": 0
+            "turn": combatType === "starship" ? null : 0
         };
-
+        Hooks.callAll("combatStart", this, update);
         await this.update(update);
 
         const currentPhase = this.getCurrentPhase();
@@ -123,7 +124,7 @@ export class CombatSFRPG extends foundry.documents.Combat {
         }[this.getCombatType()] || "desc";
 
         const turns = this.combatants.contents.sort(sortMethod === "asc" ? this._sortCombatantsAsc : this._sortCombatants);
-        this.turn = Math.clamp(this.turn, CombatSFRPG.HiddenTurn, turns.length - 1);
+        this.turn = this.turn === null ? null : Math.clamp(this.turn, 0, turns.length - 1);
 
         // Update state tracking
         const c = turns[this.turn];
@@ -363,7 +364,7 @@ export class CombatSFRPG extends foundry.documents.Combat {
         Hooks.callAll("onBeforeUpdateCombat", eventData);
 
         if (!newPhase.iterateTurns) {
-            nextTurn = CombatSFRPG.HiddenTurn;
+            nextTurn = null;
         }
 
         const updateData = {
@@ -902,10 +903,6 @@ async function onConfigClicked(combat, direction) {
     };
     await combat.update(update);
 }
-
-Hooks.on('combatStart', (combat) => {
-    combat.begin();
-});
 
 Hooks.on('renderCombatTracker', (app, html, data) => {
     const activeCombat = data.combat;


### PR DESCRIPTION
The starship combat currently uses 0 as the turn number during phases where everyone acts simultaneously. The code calls this a "hidden turn". However, this is not actually hidden. Instead it just highlights the first starship in the combatants list. That ship also gets the combat ring around it on the hex grid. This is misleading, as it seems to suggest it's that specific ship's turn, rather than being a phase where everyone acts simultaneously.

<img width="1263" height="770" alt="Screenshot 2025-08-19 103112" src="https://github.com/user-attachments/assets/d1f4d6c5-db23-4fa9-bfa1-fe0d73a2f3bb" />

This PR changes the turn value to null during these phases, which causes the UI to correctly not highlight anyone:

<img width="1077" height="670" alt="Screenshot 2025-08-19 105434" src="https://github.com/user-attachments/assets/6478ff02-3fe2-45d4-8928-5145da1febb6" />

I also took the opportunity to tidy up startCombat vs begin, which removed an incorrect data update being sent that contradicted the changes being made here (instead of calling the begin method from the combatStart hook triggered by startCombat method, just override startCombat instead)