### PR TITLE
Allow NPC crew to perform minor and open crew actions

### DIFF
--- a/src/module/actor/actor.js
+++ b/src/module/actor/actor.js
@@ -1086,13 +1086,24 @@ export class ActorSFRPG extends Mix(foundry.documents.Actor).with(ActorCondition
                 }
             } else {
                 /** Create 'fake' actors. */
-                rollContext.addContext("captain", this, actorData.system.crew.npcData.captain);
-                rollContext.addContext("pilot", this, actorData.system.crew.npcData.pilot);
-                rollContext.addContext("gunner", this, actorData.system.crew.npcData.gunner);
-                rollContext.addContext("engineer", this, actorData.system.crew.npcData.engineer);
-                rollContext.addContext("chiefMate", this, actorData.system.crew.npcData.chiefMate);
-                rollContext.addContext("magicOfficer", this, actorData.system.crew.npcData.magicOfficer);
-                rollContext.addContext("scienceOfficer", this, actorData.system.crew.npcData.scienceOfficer);
+                const crewRoles = ["captain", "pilot", "gunner", "engineer", "chiefMate", "magicOfficer", "scienceOfficer"];
+                const populatedRoles = [];
+                crewRoles.forEach((role) => {
+                    if (crewData.npcData[role]?.numberOfUses) {
+                        rollContext.addContext(
+                            role,
+                            { name: game.i18n.localize(SFRPG.starshipRoleNames[role]) },
+                            actorData.system.crew.npcData[role]
+                        );
+                        populatedRoles.push(role);
+                    }
+                });
+                const otherRoles = ["minorCrew", "openCrew"];
+                otherRoles.forEach((role) => {
+                    if (desiredSelectors.includes(role)) {
+                        rollContext.addSelector(role, populatedRoles);
+                    }
+                });
             }
         }
     }

--- a/src/module/actor/sheet/starship.js
+++ b/src/module/actor/sheet/starship.js
@@ -469,19 +469,7 @@ export class ActorSheetSFRPGStarship extends ActorSheetSFRPG {
             starshipWeapon:                     game.i18n.localize("SFRPG.StarshipSheet.Features.Prefixes.StarshipWeapons")
         };
 
-        if (!this.actor.system.crew.useNPCCrew) {
-            data.actions = ActorSheetSFRPGStarship.StarshipActionsCache;
-        } else {
-            data.actions = {
-                captain: ActorSheetSFRPGStarship.StarshipActionsCache.captain,
-                pilot: ActorSheetSFRPGStarship.StarshipActionsCache.pilot,
-                gunner: ActorSheetSFRPGStarship.StarshipActionsCache.gunner,
-                engineer: ActorSheetSFRPGStarship.StarshipActionsCache.engineer,
-                scienceOfficer: ActorSheetSFRPGStarship.StarshipActionsCache.scienceOfficer,
-                chiefMate: ActorSheetSFRPGStarship.StarshipActionsCache.chiefMate,
-                magicOfficer: ActorSheetSFRPGStarship.StarshipActionsCache.magicOfficer
-            };
-        }
+        data.actions = ActorSheetSFRPGStarship.StarshipActionsCache;
     }
 
     _prepareAttackString(item)  {


### PR DESCRIPTION
Currently the crew of NPC starships aren't able to use minor or open crew actions. This PR fixes that issue.