### PR TITLE
Fix nanite surge uses not being per day

### DIFF
--- a/src/items/class-features/nanite_surge_(ex).json
+++ b/src/items/class-features/nanite_surge_(ex).json
@@ -115,7 +115,7 @@
     },
     "uses": {
       "max": "floor(@classes.nanocyte.levels/2) + @abilities.con.mod",
-      "per": "charges",
+      "per": "day",
       "value": 0
     }
   }


### PR DESCRIPTION
The uses of Nanite Surge are incorrectly set to "charges" instead of "day". This PR fixes it.