### PR TITLE
Fix missing descriptions on Syringe Stick and Syringe Spear

### DIFF
--- a/src/items/equipment/syringe_spear_advanced.json
+++ b/src/items/equipment/syringe_spear_advanced.json
@@ -94,7 +94,7 @@
       "gmnotes": "",
       "short": "",
       "unidentified": "",
-      "value": ""
+      "value": "<p>At a glance, this weapon resembles a massive medicinal syringe that has been affixed to a pole roughly as long as the wielder’s body. A tank found at the butt of the spear allows substances to be poured into the weapon, and a spring-loaded mechanism automatically injects foes upon striking a successful blow. The exact origins of this dastardly weapon are unknown, though both the grays and a notorious race of subterranean creatures from Golarion are claimed to have designed this weapon for torturous experimentation.</p>"
     },
     "descriptors": [],
     "duration": {

--- a/src/items/equipment/syringe_spear_elite.json
+++ b/src/items/equipment/syringe_spear_elite.json
@@ -94,7 +94,7 @@
       "gmnotes": "",
       "short": "",
       "unidentified": "",
-      "value": ""
+      "value": "<p>At a glance, this weapon resembles a massive medicinal syringe that has been affixed to a pole roughly as long as the wielder’s body. A tank found at the butt of the spear allows substances to be poured into the weapon, and a spring-loaded mechanism automatically injects foes upon striking a successful blow. The exact origins of this dastardly weapon are unknown, though both the grays and a notorious race of subterranean creatures from Golarion are claimed to have designed this weapon for torturous experimentation.</p>"
     },
     "descriptors": [],
     "duration": {

--- a/src/items/equipment/syringe_spear_paragon.json
+++ b/src/items/equipment/syringe_spear_paragon.json
@@ -94,7 +94,7 @@
       "gmnotes": "",
       "short": "",
       "unidentified": "",
-      "value": ""
+      "value": "<p>At a glance, this weapon resembles a massive medicinal syringe that has been affixed to a pole roughly as long as the wielder’s body. A tank found at the butt of the spear allows substances to be poured into the weapon, and a spring-loaded mechanism automatically injects foes upon striking a successful blow. The exact origins of this dastardly weapon are unknown, though both the grays and a notorious race of subterranean creatures from Golarion are claimed to have designed this weapon for torturous experimentation.</p>"
     },
     "descriptors": [],
     "duration": {

--- a/src/items/equipment/syringe_spear_tactical.json
+++ b/src/items/equipment/syringe_spear_tactical.json
@@ -94,7 +94,7 @@
       "gmnotes": "",
       "short": "",
       "unidentified": "",
-      "value": ""
+      "value": "<p>At a glance, this weapon resembles a massive medicinal syringe that has been affixed to a pole roughly as long as the wielder’s body. A tank found at the butt of the spear allows substances to be poured into the weapon, and a spring-loaded mechanism automatically injects foes upon striking a successful blow. The exact origins of this dastardly weapon are unknown, though both the grays and a notorious race of subterranean creatures from Golarion are claimed to have designed this weapon for torturous experimentation.</p>"
     },
     "descriptors": [],
     "duration": {

--- a/src/items/equipment/syringe_stick_hyper-pointed.json
+++ b/src/items/equipment/syringe_stick_hyper-pointed.json
@@ -94,7 +94,7 @@
       "gmnotes": "",
       "short": "",
       "unidentified": "",
-      "value": ""
+      "value": "<p>This weapon is a lightweight, handheld auto-injector device designed to quickly inject drugs, poison, and similar substance into a creature when pressed against its body. A syringe stick’s patented spring-loaded design features a sturdy needle able to punch through the toughest armor, chitin, and hide. Despite its deadliness, it is difficult to discern a syringe stick from a medicinal auto-injector.</p>"
     },
     "descriptors": [],
     "duration": {

--- a/src/items/equipment/syringe_stick_sharp-pointed.json
+++ b/src/items/equipment/syringe_stick_sharp-pointed.json
@@ -94,7 +94,7 @@
       "gmnotes": "",
       "short": "",
       "unidentified": "",
-      "value": ""
+      "value": "<p>This weapon is a lightweight, handheld auto-injector device designed to quickly inject drugs, poison, and similar substance into a creature when pressed against its body. A syringe stick’s patented spring-loaded design features a sturdy needle able to punch through the toughest armor, chitin, and hide. Despite its deadliness, it is difficult to discern a syringe stick from a medicinal auto-injector.</p>"
     },
     "descriptors": [],
     "duration": {

--- a/src/items/equipment/syringe_stick_standard.json
+++ b/src/items/equipment/syringe_stick_standard.json
@@ -94,7 +94,7 @@
       "gmnotes": "",
       "short": "",
       "unidentified": "",
-      "value": ""
+      "value": "<p>This weapon is a lightweight, handheld auto-injector device designed to quickly inject drugs, poison, and similar substance into a creature when pressed against its body. A syringe stick’s patented spring-loaded design features a sturdy needle able to punch through the toughest armor, chitin, and hide. Despite its deadliness, it is difficult to discern a syringe stick from a medicinal auto-injector.</p>"
     },
     "descriptors": [],
     "duration": {

--- a/src/items/equipment/syringe_stick_supreme-pointed.json
+++ b/src/items/equipment/syringe_stick_supreme-pointed.json
@@ -94,7 +94,7 @@
       "gmnotes": "",
       "short": "",
       "unidentified": "",
-      "value": ""
+      "value": "<p>This weapon is a lightweight, handheld auto-injector device designed to quickly inject drugs, poison, and similar substance into a creature when pressed against its body. A syringe stick’s patented spring-loaded design features a sturdy needle able to punch through the toughest armor, chitin, and hide. Despite its deadliness, it is difficult to discern a syringe stick from a medicinal auto-injector.</p>"
     },
     "descriptors": [],
     "duration": {

--- a/src/items/equipment/syringe_stick_ultra-pointed.json
+++ b/src/items/equipment/syringe_stick_ultra-pointed.json
@@ -88,7 +88,7 @@
       "gmnotes": "",
       "short": "",
       "unidentified": "",
-      "value": ""
+      "value": "<p>This weapon is a lightweight, handheld auto-injector device designed to quickly inject drugs, poison, and similar substance into a creature when pressed against its body. A syringe stick’s patented spring-loaded design features a sturdy needle able to punch through the toughest armor, chitin, and hide. Despite its deadliness, it is difficult to discern a syringe stick from a medicinal auto-injector.</p>"
     },
     "descriptors": [],
     "duration": {


### PR DESCRIPTION
The item sets Syringe Stick and Syringe Spear are missing descriptions; this PR adds them.