### PR TITLE
Fix icon of Expanded Cache (Su)

### DIFF
--- a/src/items/class-features/expanded_cache_(su).json
+++ b/src/items/class-features/expanded_cache_(su).json
@@ -2,7 +2,7 @@
   "_id": "AOXGw4Xz0A8OLyZH",
   "name": "Expanded Cache (Su)",
   "type": "feat",
-  "img": "icons/magic/symbols/runes-star-blue%20.webp",
+  "img": "icons/magic/symbols/runes-star-blue.webp",
   "system": {
     "type": "",
     "ability": null,


### PR DESCRIPTION
The icon path for Expanded Cache (Su) incorrectly has `%20` in causing a 404 error. This PR fixes it.