### PR TITLE
Fix advantage and disadvantage buttons not working when calling DiceSFRPG.createRoll

### DIFF
--- a/src/module/dice.js
+++ b/src/module/dice.js
@@ -383,9 +383,9 @@ export class DiceSFRPG {
         if (mainDie) {
             let dieRoll = "1" + mainDie;
             if (mainDie === "d20") {
-                if (rollInfo.button === "Disadvantage") {
+                if (rollInfo.button === "disadvantage") {
                     dieRoll = "2d20kl";
-                } else if (rollInfo.button === "Advantage") {
+                } else if (rollInfo.button === "advantage") {
                     dieRoll = "2d20kh";
                 }
             }


### PR DESCRIPTION
There is a typo in DiceSFRPG.createRoll where "advantage" and "disadvantage" are incorrectly capitalized as "Advantage" and "Disadvantage". As a result, when you click those buttons on rolls created via this method, they don't work. This PR fixes this issue.