### PR TITLE
Remove the hash from the start of some the critical effect strings in the compendium

### DIFF
--- a/src/items/equipment/capture_pole_domination-class.json
+++ b/src/items/equipment/capture_pole_domination-class.json
@@ -79,7 +79,7 @@
       ]
     },
     "critical": {
-      "effect": "#Injection DC +2",
+      "effect": "Injection DC +2",
       "parts": []
     },
     "damage": {

--- a/src/items/equipment/needler_estoc_sharp-pointed.json
+++ b/src/items/equipment/needler_estoc_sharp-pointed.json
@@ -68,7 +68,7 @@
       ]
     },
     "critical": {
-      "effect": "#Injection DC +2",
+      "effect": "Injection DC +2",
       "parts": []
     },
     "damage": {

--- a/src/items/equipment/plasma_guide_series-42.json
+++ b/src/items/equipment/plasma_guide_series-42.json
@@ -78,7 +78,7 @@
       ]
     },
     "critical": {
-      "effect": "#Severe wound",
+      "effect": "Severe wound",
       "parts": []
     },
     "damage": {

--- a/src/items/equipment/plasma_guide_series-73.json
+++ b/src/items/equipment/plasma_guide_series-73.json
@@ -78,7 +78,7 @@
       ]
     },
     "critical": {
-      "effect": "#Severe wound",
+      "effect": "Severe wound",
       "parts": []
     },
     "damage": {

--- a/src/items/equipment/plasma_ring_single-valve.json
+++ b/src/items/equipment/plasma_ring_single-valve.json
@@ -78,7 +78,7 @@
       ]
     },
     "critical": {
-      "effect": "#Wound",
+      "effect": "Wound",
       "parts": []
     },
     "damage": {

--- a/src/items/equipment/radcannon_rapid-decay.json
+++ b/src/items/equipment/radcannon_rapid-decay.json
@@ -78,7 +78,7 @@
       ]
     },
     "critical": {
-      "effect": "#Irradiate",
+      "effect": "Irradiate",
       "parts": []
     },
     "damage": {

--- a/src/items/equipment/shadow_pistol_umbral.json
+++ b/src/items/equipment/shadow_pistol_umbral.json
@@ -78,7 +78,7 @@
       ]
     },
     "critical": {
-      "effect": "#Blind",
+      "effect": "Blind",
       "parts": []
     },
     "damage": {

--- a/src/items/equipment/syringe_stick_ultra-pointed.json
+++ b/src/items/equipment/syringe_stick_ultra-pointed.json
@@ -68,7 +68,7 @@
       ]
     },
     "critical": {
-      "effect": "#Injection DC +2",
+      "effect": "Injection DC +2",
       "parts": []
     },
     "damage": {

--- a/src/items/equipment/void_rifle_tomb-class.json
+++ b/src/items/equipment/void_rifle_tomb-class.json
@@ -78,7 +78,7 @@
       ]
     },
     "critical": {
-      "effect": "#Suffocate",
+      "effect": "Suffocate",
       "parts": []
     },
     "damage": {


### PR DESCRIPTION
A total of 9 items have a hash character at the start of their critical effect strings, which as far as I can see doesn't seem to do anything, so this looks like a mistake to me. This PR removes the hashes.