### PR TITLE
Add system patch state to starship sheet

### DIFF
--- a/src/less/actors.less
+++ b/src/less/actors.less
@@ -613,6 +613,10 @@
             line-height: 20px;
             font-weight: bold;
             margin: 0;
+
+            &.narrow {
+                flex: 0 0 100px;
+            }
         }
 
         input {

--- a/src/module/config.js
+++ b/src/module/config.js
@@ -1345,6 +1345,13 @@ SFRPG.starshipRoleDisplayOrder = [
     "minorCrew"
 ];
 
+SFRPG.starshipSystemPatch = {
+    "unpatched": "SFRPG.StarshipSheet.Critical.Patch.Unpatched",
+    "heldTogether": "SFRPG.StarshipSheet.Critical.Patch.HeldTogether",
+    "patched": "SFRPG.StarshipSheet.Critical.Patch.Patched",
+    "robust": "SFRPG.StarshipSheet.Critical.Patch.Robust"
+};
+
 // starship value maps
 SFRPG.starshipSystemStatus = {
     "nominal": "SFRPG.StarshipSheet.Critical.Status.Nominal",

--- a/src/module/rules/actions/actor/starship/calculate-starship-critical-status.js
+++ b/src/module/rules/actions/actor/starship/calculate-starship-critical-status.js
@@ -10,11 +10,39 @@ export default function(engine) {
             wrecked: -4
         };
 
+        const critModsHeldTogether = {
+            nominal: 0,
+            glitching: 0,
+            malfunctioning: 0,
+            wrecked: -2
+        };
+
+        const critModsPatched = {
+            nominal: 0,
+            glitching: 0,
+            malfunctioning: -2,
+            wrecked: -4
+        };
+
         const critModsOther = {
             nominal: 0,
             glitching: 0,
             malfunctioning: -2,
             wrecked: -4
+        };
+
+        const critModsOtherHeldTogether = {
+            nominal: 0,
+            glitching: 0,
+            malfunctioning: 0,
+            wrecked: 0
+        };
+
+        const critModsOtherPatched = {
+            nominal: 0,
+            glitching: 0,
+            malfunctioning: 0,
+            wrecked: -2
         };
 
         /** Ensure Critical Status data is properly populated. */
@@ -25,6 +53,7 @@ export default function(engine) {
         data.attributes.systems = foundry.utils.mergeObject(data.attributes.systems, {
             lifeSupport: {
                 value: "nominal",
+                patch: "unpatched",
                 affectedRoles: {
                     captain: true
                 },
@@ -32,6 +61,7 @@ export default function(engine) {
             },
             sensors: {
                 value: "nominal",
+                patch: "unpatched",
                 affectedRoles: {
                     scienceOfficer: true
                 },
@@ -39,6 +69,7 @@ export default function(engine) {
             },
             weaponsArrayForward: {
                 value: "nominal",
+                patch: "unpatched",
                 affectedRoles: {
                     gunner: true
                 },
@@ -46,6 +77,7 @@ export default function(engine) {
             },
             weaponsArrayPort: {
                 value: "nominal",
+                patch: "unpatched",
                 affectedRoles: {
                     gunner: true
                 },
@@ -53,6 +85,7 @@ export default function(engine) {
             },
             weaponsArrayStarboard: {
                 value: "nominal",
+                patch: "unpatched",
                 affectedRoles: {
                     gunner: true
                 },
@@ -60,6 +93,7 @@ export default function(engine) {
             },
             weaponsArrayAft: {
                 value: "nominal",
+                patch: "unpatched",
                 affectedRoles: {
                     gunner: true
                 },
@@ -67,6 +101,7 @@ export default function(engine) {
             },
             engines: {
                 value: "nominal",
+                patch: "unpatched",
                 affectedRoles: {
                     pilot: true
                 },
@@ -74,6 +109,7 @@ export default function(engine) {
             },
             powerCore: {
                 value: "nominal",
+                patch: "unpatched",
                 affectedRoles: {
                     captain: true,
                     pilot: true,
@@ -90,9 +126,16 @@ export default function(engine) {
         }, {overwrite: false});
 
         for (const [key, systemData] of Object.entries(data.attributes.systems)) {
-            const modifier = critMods[systemData.value];
-            systemData.mod = modifier;
-            systemData.modOther = (key === "powerCore") ? critModsOther[systemData.value] : 0;
+            if (["patched", "robust"].includes(systemData.patch)) {
+                systemData.mod = critModsPatched[systemData.value];
+                systemData.modOther = (key === "powerCore") ? critModsOtherPatched[systemData.value] : 0;
+            } else if (systemData.patch === "heldTogether") {
+                systemData.mod = critModsHeldTogether[systemData.value];
+                systemData.modOther = (key === "powerCore") ? critModsOtherHeldTogether[systemData.value] : 0;
+            } else {
+                systemData.mod = critMods[systemData.value];
+                systemData.modOther = (key === "powerCore") ? critModsOther[systemData.value] : 0;
+            }
         }
 
         data.attributes.systems.weaponsArrayTurret = {

--- a/src/sfrpg.js
+++ b/src/sfrpg.js
@@ -514,6 +514,7 @@ Hooks.once("i18nInit", () => {
         "starshipArcs",
         "starshipRoles",
         "starshipSizes",
+        "starshipSystemPatch",
         "starshipSystemStatus",
         "starshipWeaponClass",
         "starshipWeaponProperties",

--- a/static/lang/de.json
+++ b/static/lang/de.json
@@ -2819,6 +2819,12 @@
                 "EditMessage": "Auswählen welche Rollen von Schäden an diesem System betroffen sind.",
                 "EditTitle": "Betroffene Rollen auswählen",
                 "Header": "Kritischer Schaden",
+                "Patch": {
+                    "HeldTogether": "Held Together",
+                    "Patched": "Patched",
+                    "Robust": "Patched Robustly",
+                    "Unpatched": "Unpatched"
+                },
                 "Status": {
                     "Glitching": "Gestört",
                     "Malfunctioning": "Fehlfunktion",
@@ -2830,10 +2836,10 @@
                     "LifeSupport": "Lebenserhaltung",
                     "PowerCore": "Energiekern",
                     "Sensors": "Sensoren",
-                    "WeaponsArrayAft": "Bewaffnung (Achtern)",
-                    "WeaponsArrayForward": "Bewaffnung (Bug)",
-                    "WeaponsArrayPort": "Bewaffnung (Backbord)",
-                    "WeaponsArrayStarboard": "Bewaffnung (Steuerbord)"
+                    "WeaponsArrayAft": "Achtern",
+                    "WeaponsArrayForward": "Bug",
+                    "WeaponsArrayPort": "Backbord",
+                    "WeaponsArrayStarboard": "Steuerbord"
                 }
             },
             "Damage": {

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -2812,6 +2812,12 @@
                 "EditMessage": "Select which roles are affected by damage to this system.",
                 "EditTitle": "Select affected roles",
                 "Header": "Critical Damage",
+                "Patch": {
+                    "HeldTogether": "Held Together",
+                    "Patched": "Patched",
+                    "Robust": "Patched Robustly",
+                    "Unpatched": "Unpatched"
+                },
                 "Status": {
                     "Glitching": "Glitching",
                     "Malfunctioning": "Malfunctioning",
@@ -2823,10 +2829,10 @@
                     "LifeSupport": "Life Support",
                     "PowerCore": "Power Core",
                     "Sensors": "Sensors",
-                    "WeaponsArrayAft": "Weapons (Aft)",
-                    "WeaponsArrayForward": "Weapons (Forward)",
-                    "WeaponsArrayPort": "Weapons (Port)",
-                    "WeaponsArrayStarboard": "Weapons (Starboard)"
+                    "WeaponsArrayAft": "Aft",
+                    "WeaponsArrayForward": "Forward",
+                    "WeaponsArrayPort": "Port",
+                    "WeaponsArrayStarboard": "Starboard"
                 }
             },
             "Damage": {

--- a/static/lang/es.json
+++ b/static/lang/es.json
@@ -2808,6 +2808,12 @@
                 "EditMessage": "Selecciona qué roles se ven afectados por el daño en este sistema.",
                 "EditTitle": "Seleccionar roles afectados",
                 "Header": "Daño Crítico",
+                "Patch": {
+                    "HeldTogether": "Held Together",
+                    "Patched": "Patched",
+                    "Robust": "Patched Robustly",
+                    "Unpatched": "Unpatched"
+                },
                 "Status": {
                     "Glitching": "Fallas",
                     "Malfunctioning": "Mal funcionamiento",
@@ -2819,10 +2825,10 @@
                     "LifeSupport": "Soporte Vital",
                     "PowerCore": "Núcleo de Energía",
                     "Sensors": "Sensores",
-                    "WeaponsArrayAft": "Armas (Popa)",
-                    "WeaponsArrayForward": "Armas (Proa)",
-                    "WeaponsArrayPort": "Armas (Babor)",
-                    "WeaponsArrayStarboard": "Armas (Estribor)"
+                    "WeaponsArrayAft": "Popa",
+                    "WeaponsArrayForward": "Proa",
+                    "WeaponsArrayPort": "Babor",
+                    "WeaponsArrayStarboard": "Estribor"
                 }
             },
             "Damage": {

--- a/static/lang/fr.json
+++ b/static/lang/fr.json
@@ -2812,6 +2812,12 @@
                 "EditMessage": "Sélectionnez les rôles qui sont affectés par les dégâts causés à ce système.",
                 "EditTitle": "Sélectionner les rôles affectés",
                 "Header": "Dégâts Critiques",
+                "Patch": {
+                    "HeldTogether": "Held Together",
+                    "Patched": "Patched",
+                    "Robust": "Patched Robustly",
+                    "Unpatched": "Unpatched"
+                },
                 "Status": {
                     "Glitching": "Dysfonctionnement",
                     "Malfunctioning": "Défaillant",
@@ -2823,10 +2829,10 @@
                     "LifeSupport": "Systèmes vitaux",
                     "PowerCore": "Réacteur",
                     "Sensors": "Détecteurs",
-                    "WeaponsArrayAft": "Armes (Poupe)",
-                    "WeaponsArrayForward": "Armes (Proue)",
-                    "WeaponsArrayPort": "Armes (Bâbord)",
-                    "WeaponsArrayStarboard": "Armes (Tribord)"
+                    "WeaponsArrayAft": "Poupe",
+                    "WeaponsArrayForward": "Proue",
+                    "WeaponsArrayPort": "Bâbord",
+                    "WeaponsArrayStarboard": "Tribord"
                 }
             },
             "Damage": {

--- a/static/lang/it.json
+++ b/static/lang/it.json
@@ -2820,6 +2820,12 @@
                 "EditMessage": "Seleziona i ruoli che sono interessati dal danno a questo sistema.",
                 "EditTitle": "Seleziona i ruoli interessati",
                 "Header": "Danno Critico",
+                "Patch": {
+                    "HeldTogether": "Held Together",
+                    "Patched": "Patched",
+                    "Robust": "Patched Robustly",
+                    "Unpatched": "Unpatched"
+                },
                 "Status": {
                     "Glitching": "Difettoso",
                     "Malfunctioning": "Malfunzionante",
@@ -2831,10 +2837,10 @@
                     "LifeSupport": "Sistema Vitale",
                     "PowerCore": "Nucleo Energetico",
                     "Sensors": "Sensori",
-                    "WeaponsArrayAft": "Armi (Poppa)",
-                    "WeaponsArrayForward": "Armi (Prua)",
-                    "WeaponsArrayPort": "Armi (Babordo)",
-                    "WeaponsArrayStarboard": "Armi (Tribordo)"
+                    "WeaponsArrayAft": "Poppa",
+                    "WeaponsArrayForward": "Prua",
+                    "WeaponsArrayPort": "Babordo",
+                    "WeaponsArrayStarboard": "Tribordo"
                 }
             },
             "Damage": {

--- a/static/lang/ja.json
+++ b/static/lang/ja.json
@@ -2820,6 +2820,12 @@
                 "EditMessage": "Select which roles are affected by damage to this system.",
                 "EditTitle": "Select affected roles",
                 "Header": "Critical Damage",
+                "Patch": {
+                    "HeldTogether": "Held Together",
+                    "Patched": "Patched",
+                    "Robust": "Patched Robustly",
+                    "Unpatched": "Unpatched"
+                },
                 "Status": {
                     "Glitching": "Glitching",
                     "Malfunctioning": "Malfunctioning",
@@ -2831,10 +2837,10 @@
                     "LifeSupport": "Life Support",
                     "PowerCore": "Power Core",
                     "Sensors": "Sensors",
-                    "WeaponsArrayAft": "Weapons Array (Aft)",
-                    "WeaponsArrayForward": "Weapons Array (Forward)",
-                    "WeaponsArrayPort": "Weapons Array (Port)",
-                    "WeaponsArrayStarboard": "Weapons Array (Starboard)"
+                    "WeaponsArrayAft": "Aft",
+                    "WeaponsArrayForward": "Forward",
+                    "WeaponsArrayPort": "Port",
+                    "WeaponsArrayStarboard": "Starboard"
                 }
             },
             "Damage": {

--- a/static/lang/pt-BR.json
+++ b/static/lang/pt-BR.json
@@ -2820,6 +2820,12 @@
                 "EditMessage": "Selecionar quais rolagens são afetadas por dano neste sistema.",
                 "EditTitle": "Selecionar Rolagem Afetada",
                 "Header": "Dano Critico",
+                "Patch": {
+                    "HeldTogether": "Held Together",
+                    "Patched": "Patched",
+                    "Robust": "Patched Robustly",
+                    "Unpatched": "Unpatched"
+                },
                 "Status": {
                     "Glitching": "Falhando",
                     "Malfunctioning": "Mau Funcionamento",
@@ -2831,10 +2837,10 @@
                     "LifeSupport": "Suporte Vital",
                     "PowerCore": "Núcleo Energia",
                     "Sensors": "Sensores",
-                    "WeaponsArrayAft": "Armas (popa)",
-                    "WeaponsArrayForward": "Armas (proa)",
-                    "WeaponsArrayPort": "Armas (bombordo)",
-                    "WeaponsArrayStarboard": "Armas (estibordo)"
+                    "WeaponsArrayAft": "Popa",
+                    "WeaponsArrayForward": "Proa",
+                    "WeaponsArrayPort": "Bombordo",
+                    "WeaponsArrayStarboard": "Estibordo"
                 }
             },
             "Damage": {

--- a/static/templates/actors/starship-sheet-full.hbs
+++ b/static/templates/actors/starship-sheet-full.hbs
@@ -394,53 +394,77 @@
                 <div class="flexrow">
                     <div class="flexcol">
                         <div class="form-group">
-                            <label for="system.attributes.systems.lifeSupport.value">{{localize "SFRPG.StarshipSheet.Critical.Systems.LifeSupport"}} <a class="critical-edit" data-system="lifeSupport" title="{{localize "SFRPG.StarshipSheet.Critical.Edit"}}"><i class="fas fa-edit"></i></a></label>
+                            <label class="narrow" for="system.attributes.systems.lifeSupport.value">{{localize "SFRPG.StarshipSheet.Critical.Systems.LifeSupport"}} <a class="critical-edit" data-system="lifeSupport" title="{{localize "SFRPG.StarshipSheet.Critical.Edit"}}"><i class="fas fa-edit"></i></a></label>
                             <select name="system.attributes.systems.lifeSupport.value">
                                 {{selectOptions (sfrpg "starshipSystemStatus") selected=system.attributes.systems.lifeSupport.value}}
                             </select>
+                            <select name="system.attributes.systems.lifeSupport.patch">
+                                {{selectOptions (sfrpg "starshipSystemPatch") selected=system.attributes.systems.lifeSupport.patch}}
+                            </select>
                         </div>
                         <div class="form-group">
-                            <label for="system.attributes.systems.sensors.value">{{localize "SFRPG.StarshipSheet.Critical.Systems.Sensors"}} <a class="critical-edit" data-system="sensors" title="{{localize "SFRPG.StarshipSheet.Critical.Edit"}}"><i class="fas fa-edit"></i></a></label>
+                            <label class="narrow" for="system.attributes.systems.sensors.value">{{localize "SFRPG.StarshipSheet.Critical.Systems.Sensors"}} <a class="critical-edit" data-system="sensors" title="{{localize "SFRPG.StarshipSheet.Critical.Edit"}}"><i class="fas fa-edit"></i></a></label>
                             <select name="system.attributes.systems.sensors.value">
                                 {{selectOptions (sfrpg "starshipSystemStatus") selected=system.attributes.systems.sensors.value}}
                             </select>
-                        </div>
-                        <div class="form-group">
-                            <label for="system.attributes.systems.engines.value">{{localize "SFRPG.StarshipSheet.Critical.Systems.Engines"}} <a class="critical-edit" data-system="engines" title="{{localize "SFRPG.StarshipSheet.Critical.Edit"}}"><i class="fas fa-edit"></i></a></label>
-                            <select name="system.attributes.systems.engines.value">
-                                {{selectOptions (sfrpg "starshipSystemStatus") selected=system.attributes.systems.engines.value}}
+                            <select name="system.attributes.systems.sensors.patch">
+                                {{selectOptions (sfrpg "starshipSystemPatch") selected=system.attributes.systems.sensors.patch}}
                             </select>
                         </div>
                         <div class="form-group">
-                            <label for="system.attributes.systems.powerCore.value">{{localize "SFRPG.StarshipSheet.Critical.Systems.PowerCore"}} <a class="critical-edit" data-system="powerCore" title="{{localize "SFRPG.StarshipSheet.Critical.Edit"}}"><i class="fas fa-edit"></i></a></label>
+                            <label class="narrow" for="system.attributes.systems.engines.value">{{localize "SFRPG.StarshipSheet.Critical.Systems.Engines"}} <a class="critical-edit" data-system="engines" title="{{localize "SFRPG.StarshipSheet.Critical.Edit"}}"><i class="fas fa-edit"></i></a></label>
+                            <select name="system.attributes.systems.engines.value">
+                                {{selectOptions (sfrpg "starshipSystemStatus") selected=system.attributes.systems.engines.value}}
+                            </select>
+                            <select name="system.attributes.systems.engines.patch">
+                                {{selectOptions (sfrpg "starshipSystemPatch") selected=system.attributes.systems.engines.patch}}
+                            </select>
+                        </div>
+                        <div class="form-group">
+                            <label class="narrow" for="system.attributes.systems.powerCore.value">{{localize "SFRPG.StarshipSheet.Critical.Systems.PowerCore"}} <a class="critical-edit" data-system="powerCore" title="{{localize "SFRPG.StarshipSheet.Critical.Edit"}}"><i class="fas fa-edit"></i></a></label>
                             <select name="system.attributes.systems.powerCore.value">
                                 {{selectOptions (sfrpg "starshipSystemStatus") selected=system.attributes.systems.powerCore.value}}
+                            </select>
+                            <select name="system.attributes.systems.powerCore.patch">
+                                {{selectOptions (sfrpg "starshipSystemPatch") selected=system.attributes.systems.powerCore.patch}}
                             </select>
                         </div>
                     </div>
                     <div class="flexcol">
                         <div class="form-group">
-                            <label for="system.attributes.systems.weaponsArrayForward.value">{{localize "SFRPG.StarshipSheet.Critical.Systems.WeaponsArrayForward"}} <a class="critical-edit" data-system="weaponsArrayForward" title="{{localize "SFRPG.StarshipSheet.Critical.Edit"}}"><i class="fas fa-edit"></i></a></label>
+                            <label class="narrow" for="system.attributes.systems.weaponsArrayForward.value">{{localize "SFRPG.StarshipSheet.Critical.Systems.WeaponsArrayForward"}} <a class="critical-edit" data-system="weaponsArrayForward" title="{{localize "SFRPG.StarshipSheet.Critical.Edit"}}"><i class="fas fa-edit"></i></a></label>
                             <select name="system.attributes.systems.weaponsArrayForward.value">
                                 {{selectOptions (sfrpg "starshipSystemStatus") selected=system.attributes.systems.weaponsArrayForward.value}}
                             </select>
+                            <select name="system.attributes.systems.weaponsArrayForward.patch">
+                                {{selectOptions (sfrpg "starshipSystemPatch") selected=system.attributes.systems.weaponsArrayForward.patch}}
+                            </select>
                         </div>
                         <div class="form-group">
-                            <label for="system.attributes.systems.weaponsArrayPort.value">{{localize "SFRPG.StarshipSheet.Critical.Systems.WeaponsArrayPort"}} <a class="critical-edit" data-system="weaponsArrayPort" title="{{localize "SFRPG.StarshipSheet.Critical.Edit"}}"><i class="fas fa-edit"></i></a></label>
+                            <label class="narrow" for="system.attributes.systems.weaponsArrayPort.value">{{localize "SFRPG.StarshipSheet.Critical.Systems.WeaponsArrayPort"}} <a class="critical-edit" data-system="weaponsArrayPort" title="{{localize "SFRPG.StarshipSheet.Critical.Edit"}}"><i class="fas fa-edit"></i></a></label>
                             <select name="system.attributes.systems.weaponsArrayPort.value">
                                 {{selectOptions (sfrpg "starshipSystemStatus") selected=system.attributes.systems.weaponsArrayPort.value}}
                             </select>
-                        </div>
-                        <div class="form-group">
-                            <label for="system.attributes.systems.weaponsArrayStarboard.value">{{localize "SFRPG.StarshipSheet.Critical.Systems.WeaponsArrayStarboard"}} <a class="critical-edit" data-system="weaponsArrayStarboard" title="{{localize "SFRPG.StarshipSheet.Critical.Edit"}}"><i class="fas fa-edit"></i></a></label>
-                            <select name="system.attributes.systems.weaponsArrayStarboard.value">
-                                {{selectOptions (sfrpg "starshipSystemStatus") selected=system.attributes.systems.weaponsArrayStarboard.value}}
+                            <select name="system.attributes.systems.weaponsArrayPort.patch">
+                                {{selectOptions (sfrpg "starshipSystemPatch") selected=system.attributes.systems.weaponsArrayPort.patch}}
                             </select>
                         </div>
                         <div class="form-group">
-                            <label for="system.attributes.systems.weaponsArrayAft.value">{{localize "SFRPG.StarshipSheet.Critical.Systems.WeaponsArrayAft"}} <a class="critical-edit" data-system="weaponsArrayAft" title="{{localize "SFRPG.StarshipSheet.Critical.Edit"}}"><i class="fas fa-edit"></i></a></label>
+                            <label class="narrow" for="system.attributes.systems.weaponsArrayStarboard.value">{{localize "SFRPG.StarshipSheet.Critical.Systems.WeaponsArrayStarboard"}} <a class="critical-edit" data-system="weaponsArrayStarboard" title="{{localize "SFRPG.StarshipSheet.Critical.Edit"}}"><i class="fas fa-edit"></i></a></label>
+                            <select name="system.attributes.systems.weaponsArrayStarboard.value">
+                                {{selectOptions (sfrpg "starshipSystemStatus") selected=system.attributes.systems.weaponsArrayStarboard.value}}
+                            </select>
+                            <select name="system.attributes.systems.weaponsArrayStarboard.patch">
+                                {{selectOptions (sfrpg "starshipSystemPatch") selected=system.attributes.systems.weaponsArrayStarboard.patch}}
+                            </select>
+                        </div>
+                        <div class="form-group">
+                            <label class="narrow" for="system.attributes.systems.weaponsArrayAft.value">{{localize "SFRPG.StarshipSheet.Critical.Systems.WeaponsArrayAft"}} <a class="critical-edit" data-system="weaponsArrayAft" title="{{localize "SFRPG.StarshipSheet.Critical.Edit"}}"><i class="fas fa-edit"></i></a></label>
                             <select name="system.attributes.systems.weaponsArrayAft.value">
                                 {{selectOptions (sfrpg "starshipSystemStatus") selected=system.attributes.systems.weaponsArrayAft.value}}
+                            </select>
+                            <select name="system.attributes.systems.weaponsArrayAft.patch">
+                                {{selectOptions (sfrpg "starshipSystemPatch") selected=system.attributes.systems.weaponsArrayAft.patch}}
                             </select>
                         </div>
                     </div>


### PR DESCRIPTION
This PR adds dropdown boxes to the starship sheet which allow you to set the patch state of each system (unpatched / held together / patched / patched robustly). Setting the patch state sets the system modifiers accordingly. This allows for tracking of the patch state without having to alter the original state of the system.