### PR TITLE
Fix condition application issues

### DIFF
--- a/src/items/conditions/asleep.json
+++ b/src/items/conditions/asleep.json
@@ -5,6 +5,7 @@
   "img": "systems/sfrpg/icons/conditions/asleep.webp",
   "system": {
     "type": "condition",
+    "nameSlug": "asleep",
     "abilityMods": {
       "parts": []
     },

--- a/src/items/conditions/bleeding.json
+++ b/src/items/conditions/bleeding.json
@@ -5,6 +5,7 @@
   "img": "systems/sfrpg/icons/conditions/bleeding.webp",
   "system": {
     "type": "condition",
+    "nameSlug": "bleeding",
     "abilityMods": {
       "parts": []
     },

--- a/src/items/conditions/blinded.json
+++ b/src/items/conditions/blinded.json
@@ -5,6 +5,7 @@
   "img": "systems/sfrpg/icons/conditions/blinded.webp",
   "system": {
     "type": "condition",
+    "nameSlug": "blinded",
     "abilityMods": {
       "parts": []
     },

--- a/src/items/conditions/broken_(armor).json
+++ b/src/items/conditions/broken_(armor).json
@@ -5,6 +5,7 @@
   "img": "systems/sfrpg/icons/conditions/broken.webp",
   "system": {
     "type": "condition",
+    "nameSlug": "broken-armor",
     "abilityMods": {
       "parts": []
     },

--- a/src/items/conditions/broken_(tool_or_aug).json
+++ b/src/items/conditions/broken_(tool_or_aug).json
@@ -5,6 +5,7 @@
   "img": "systems/sfrpg/icons/conditions/broken.webp",
   "system": {
     "type": "condition",
+    "nameSlug": "broken-tool-or-aug",
     "abilityMods": {
       "parts": []
     },

--- a/src/items/conditions/broken_(vehicle).json
+++ b/src/items/conditions/broken_(vehicle).json
@@ -5,6 +5,7 @@
   "img": "systems/sfrpg/icons/conditions/broken.webp",
   "system": {
     "type": "condition",
+    "nameSlug": "broken-vehicle",
     "abilityMods": {
       "parts": []
     },

--- a/src/items/conditions/broken_(weapon).json
+++ b/src/items/conditions/broken_(weapon).json
@@ -5,6 +5,7 @@
   "img": "systems/sfrpg/icons/conditions/broken.webp",
   "system": {
     "type": "condition",
+    "nameSlug": "broken-weapon",
     "abilityMods": {
       "parts": []
     },

--- a/src/items/conditions/burning.json
+++ b/src/items/conditions/burning.json
@@ -5,6 +5,7 @@
   "img": "systems/sfrpg/icons/conditions/burning.webp",
   "system": {
     "type": "condition",
+    "nameSlug": "burning",
     "abilityMods": {
       "parts": []
     },

--- a/src/items/conditions/confused.json
+++ b/src/items/conditions/confused.json
@@ -5,6 +5,7 @@
   "img": "systems/sfrpg/icons/conditions/confused.webp",
   "system": {
     "type": "condition",
+    "nameSlug": "confused",
     "abilityMods": {
       "parts": []
     },

--- a/src/items/conditions/cowering.json
+++ b/src/items/conditions/cowering.json
@@ -5,6 +5,7 @@
   "img": "systems/sfrpg/icons/conditions/cowering.webp",
   "system": {
     "type": "condition",
+    "nameSlug": "cowering",
     "abilityMods": {
       "parts": []
     },

--- a/src/items/conditions/dazed.json
+++ b/src/items/conditions/dazed.json
@@ -5,6 +5,7 @@
   "img": "systems/sfrpg/icons/conditions/dazed.webp",
   "system": {
     "type": "condition",
+    "nameSlug": "dazed",
     "abilityMods": {
       "parts": []
     },

--- a/src/items/conditions/dazzled.json
+++ b/src/items/conditions/dazzled.json
@@ -5,6 +5,7 @@
   "img": "systems/sfrpg/icons/conditions/dazzled.webp",
   "system": {
     "type": "condition",
+    "nameSlug": "dazzled",
     "abilityMods": {
       "parts": []
     },

--- a/src/items/conditions/dead.json
+++ b/src/items/conditions/dead.json
@@ -10,6 +10,7 @@
   "img": "systems/sfrpg/icons/conditions/dead.webp",
   "system": {
     "type": "condition",
+    "nameSlug": "dead",
     "abilityMods": {
       "parts": []
     },

--- a/src/items/conditions/deafened.json
+++ b/src/items/conditions/deafened.json
@@ -5,6 +5,7 @@
   "img": "systems/sfrpg/icons/conditions/deafened.webp",
   "system": {
     "type": "condition",
+    "nameSlug": "deafened",
     "abilityMods": {
       "parts": []
     },

--- a/src/items/conditions/dying.json
+++ b/src/items/conditions/dying.json
@@ -5,6 +5,7 @@
   "img": "systems/sfrpg/icons/conditions/dying.webp",
   "system": {
     "type": "condition",
+    "nameSlug": "dying",
     "abilityMods": {
       "parts": []
     },

--- a/src/items/conditions/encumbered.json
+++ b/src/items/conditions/encumbered.json
@@ -5,6 +5,7 @@
   "img": "systems/sfrpg/icons/conditions/encumbered.webp",
   "system": {
     "type": "condition",
+    "nameSlug": "encumbered",
     "abilityMods": {
       "parts": []
     },

--- a/src/items/conditions/entangled.json
+++ b/src/items/conditions/entangled.json
@@ -5,6 +5,7 @@
   "img": "systems/sfrpg/icons/conditions/entangled.webp",
   "system": {
     "type": "condition",
+    "nameSlug": "entangled",
     "abilityMods": {
       "parts": []
     },

--- a/src/items/conditions/exhausted.json
+++ b/src/items/conditions/exhausted.json
@@ -5,6 +5,7 @@
   "img": "systems/sfrpg/icons/conditions/exhausted.webp",
   "system": {
     "type": "condition",
+    "nameSlug": "exhausted",
     "abilityMods": {
       "parts": []
     },

--- a/src/items/conditions/fascinated.json
+++ b/src/items/conditions/fascinated.json
@@ -5,6 +5,7 @@
   "img": "systems/sfrpg/icons/conditions/fascinated.webp",
   "system": {
     "type": "condition",
+    "nameSlug": "fascinated",
     "abilityMods": {
       "parts": []
     },

--- a/src/items/conditions/fatigued.json
+++ b/src/items/conditions/fatigued.json
@@ -5,6 +5,7 @@
   "img": "systems/sfrpg/icons/conditions/fatigued.webp",
   "system": {
     "type": "condition",
+    "nameSlug": "fatigued",
     "abilityMods": {
       "parts": []
     },

--- a/src/items/conditions/flat-footed.json
+++ b/src/items/conditions/flat-footed.json
@@ -5,6 +5,7 @@
   "img": "systems/sfrpg/icons/conditions/flatfooted.webp",
   "system": {
     "type": "condition",
+    "nameSlug": "flat-footed",
     "abilityMods": {
       "parts": []
     },

--- a/src/items/conditions/frightened.json
+++ b/src/items/conditions/frightened.json
@@ -5,6 +5,7 @@
   "img": "systems/sfrpg/icons/conditions/frightened.webp",
   "system": {
     "type": "condition",
+    "nameSlug": "frightened",
     "abilityMods": {
       "parts": []
     },

--- a/src/items/conditions/grappled.json
+++ b/src/items/conditions/grappled.json
@@ -5,6 +5,7 @@
   "img": "systems/sfrpg/icons/conditions/grappled.webp",
   "system": {
     "type": "condition",
+    "nameSlug": "grappled",
     "abilityMods": {
       "parts": []
     },

--- a/src/items/conditions/helpless.json
+++ b/src/items/conditions/helpless.json
@@ -5,6 +5,7 @@
   "img": "systems/sfrpg/icons/conditions/helpless.webp",
   "system": {
     "type": "condition",
+    "nameSlug": "helpless",
     "abilityMods": {
       "parts": []
     },

--- a/src/items/conditions/invisible.json
+++ b/src/items/conditions/invisible.json
@@ -5,6 +5,7 @@
   "img": "systems/sfrpg/icons/conditions/invisible.webp",
   "system": {
     "type": "condition",
+    "nameSlug": "invisible",
     "abilityMods": {
       "parts": []
     },

--- a/src/items/conditions/nauseated.json
+++ b/src/items/conditions/nauseated.json
@@ -5,6 +5,7 @@
   "img": "systems/sfrpg/icons/conditions/nauseated.webp",
   "system": {
     "type": "condition",
+    "nameSlug": "nauseated",
     "abilityMods": {
       "parts": []
     },

--- a/src/items/conditions/negative_level.json
+++ b/src/items/conditions/negative_level.json
@@ -5,6 +5,7 @@
   "img": "icons/svg/skull.svg",
   "system": {
     "type": "NegativeLevels",
+    "nameSlug": "negative-level",
     "abilityMods": {
       "parts": []
     },

--- a/src/items/conditions/off-kilter.json
+++ b/src/items/conditions/off-kilter.json
@@ -5,6 +5,7 @@
   "img": "systems/sfrpg/icons/conditions/offkilter.webp",
   "system": {
     "type": "condition",
+    "nameSlug": "off-kilter",
     "abilityMods": {
       "parts": []
     },

--- a/src/items/conditions/off-target.json
+++ b/src/items/conditions/off-target.json
@@ -5,6 +5,7 @@
   "img": "systems/sfrpg/icons/conditions/offtarget.webp",
   "system": {
     "type": "condition",
+    "nameSlug": "off-target",
     "abilityMods": {
       "parts": []
     },

--- a/src/items/conditions/overburdened.json
+++ b/src/items/conditions/overburdened.json
@@ -5,6 +5,7 @@
   "img": "systems/sfrpg/icons/conditions/overburdened.webp",
   "system": {
     "type": "condition",
+    "nameSlug": "overburdened",
     "abilityMods": {
       "parts": []
     },

--- a/src/items/conditions/panicked.json
+++ b/src/items/conditions/panicked.json
@@ -5,6 +5,7 @@
   "img": "systems/sfrpg/icons/conditions/panicked.webp",
   "system": {
     "type": "condition",
+    "nameSlug": "panicked",
     "abilityMods": {
       "parts": []
     },

--- a/src/items/conditions/paralyzed.json
+++ b/src/items/conditions/paralyzed.json
@@ -5,6 +5,7 @@
   "img": "systems/sfrpg/icons/conditions/paralyzed.webp",
   "system": {
     "type": "condition",
+    "nameSlug": "paralyzed",
     "abilityMods": {
       "parts": []
     },

--- a/src/items/conditions/pinned.json
+++ b/src/items/conditions/pinned.json
@@ -5,6 +5,7 @@
   "img": "systems/sfrpg/icons/conditions/pinned.webp",
   "system": {
     "type": "condition",
+    "nameSlug": "pinned",
     "abilityMods": {
       "parts": []
     },

--- a/src/items/conditions/prone.json
+++ b/src/items/conditions/prone.json
@@ -5,6 +5,7 @@
   "img": "systems/sfrpg/icons/conditions/prone.webp",
   "system": {
     "type": "condition",
+    "nameSlug": "prone",
     "abilityMods": {
       "parts": []
     },

--- a/src/items/conditions/shaken.json
+++ b/src/items/conditions/shaken.json
@@ -5,6 +5,7 @@
   "img": "systems/sfrpg/icons/conditions/shaken.webp",
   "system": {
     "type": "condition",
+    "nameSlug": "shaken",
     "abilityMods": {
       "parts": []
     },

--- a/src/items/conditions/sickened.json
+++ b/src/items/conditions/sickened.json
@@ -5,6 +5,7 @@
   "img": "systems/sfrpg/icons/conditions/sickened.webp",
   "system": {
     "type": "condition",
+    "nameSlug": "sickened",
     "abilityMods": {
       "parts": []
     },

--- a/src/items/conditions/stable.json
+++ b/src/items/conditions/stable.json
@@ -5,6 +5,7 @@
   "img": "systems/sfrpg/icons/conditions/stable.webp",
   "system": {
     "type": "condition",
+    "nameSlug": "stable",
     "abilityMods": {
       "parts": []
     },

--- a/src/items/conditions/staggered.json
+++ b/src/items/conditions/staggered.json
@@ -5,6 +5,7 @@
   "img": "systems/sfrpg/icons/conditions/staggered.webp",
   "system": {
     "type": "condition",
+    "nameSlug": "staggered",
     "abilityMods": {
       "parts": []
     },

--- a/src/items/conditions/stunned.json
+++ b/src/items/conditions/stunned.json
@@ -5,6 +5,7 @@
   "img": "systems/sfrpg/icons/conditions/stunned.webp",
   "system": {
     "type": "condition",
+    "nameSlug": "stunned",
     "abilityMods": {
       "parts": []
     },

--- a/src/items/conditions/unconscious.json
+++ b/src/items/conditions/unconscious.json
@@ -5,6 +5,7 @@
   "img": "systems/sfrpg/icons/conditions/unconscious.webp",
   "system": {
     "type": "condition",
+    "nameSlug": "unconscious",
     "abilityMods": {
       "parts": []
     },

--- a/src/module/actor/mixins/actor-conditions.js
+++ b/src/module/actor/mixins/actor-conditions.js
@@ -27,7 +27,7 @@ export const ActorConditionsMixin = (superclass) => class extends superclass {
             return undefined;
         }
 
-        const conditionItem = this.items.find(item => item.name.toLowerCase() === conditionName);
+        const conditionItem = this.items.find(item => (item.system.nameSlug === conditionName) || (item.name.toLowerCase() === conditionName)); // TODO: The 'or' is in place for backward compatibility. This should only use nameSlug once DataModels are implemented and migrations can be done easily.
         return conditionItem ?? null;
     }
 
@@ -49,8 +49,9 @@ export const ActorConditionsMixin = (superclass) => class extends superclass {
         if (enabled) {
             if (!conditionItem) {
                 const pack = game.packs.get("sfrpg.conditions");
+                const indexKey = CONFIG.SFRPG.statusEffects.find(e => e.id === conditionName).compendiumKey;
                 const index = pack.indexed ? pack.index : await pack.getIndex();
-                const entry = index.find(e => e.name.toLowerCase() === conditionName.toLowerCase());
+                const entry = index.get(indexKey);
 
                 if (entry) {
                     const entity = await pack.getDocument(entry._id);
@@ -76,7 +77,7 @@ export const ActorConditionsMixin = (superclass) => class extends superclass {
         // Since conditions sidestep Foundry status effects, simulate a status effect change.
         const tokens = this.getActiveTokens(true);
         for (const token of tokens) {
-            token._onApplyStatusEffect(conditionName.toLowerCase(), enabled);
+            token._onApplyStatusEffect(conditionName, enabled);
         }
 
         return enabled;

--- a/src/module/actor/mixins/actor-conditions.js
+++ b/src/module/actor/mixins/actor-conditions.js
@@ -12,7 +12,7 @@ export const ActorConditionsMixin = (superclass) => class extends superclass {
         }
 
         const conditionItem = this.getCondition(conditionName);
-        return (conditionItem !== undefined);
+        return conditionItem ?? null;
     }
 
     /**
@@ -27,31 +27,8 @@ export const ActorConditionsMixin = (superclass) => class extends superclass {
             return undefined;
         }
 
-        return this.items.find(item => this._isCondition(item) && item.name.toLowerCase() === conditionName.toLowerCase());
-
-    }
-
-    /**
-     * Get an Array of all conditions on the actor.
-     * @returns {Array} strings
-     * @public
-     */
-    getActiveConditions() {
-        return this.items.filter(item => this._isCondition(item));
-    }
-
-    /**
-     * Checks if the item is a feat containing the data requirements of condition.
-     * @param item foundry item document
-     * @returns {boolean}
-     * @private
-     */
-    _isCondition(item) {
-        return item.type === "effect" && item.system.requirements?.toLowerCase() === "condition";
-    }
-
-    _isStatusEffect(name) {
-        return CONFIG.SFRPG.statusEffects.find(effect => effect.id === name) !== undefined;
+        const conditionItem = this.items.find(item => item.name.toLowerCase() === conditionName);
+        return conditionItem ?? null;
     }
 
     /**
@@ -66,37 +43,33 @@ export const ActorConditionsMixin = (superclass) => class extends superclass {
             return;
         }
 
-        // Update condition item
+        // Find the relevant condition item on the actor, if it exists
         const conditionItem = this.getCondition(conditionName);
 
         if (enabled) {
             if (!conditionItem) {
                 const pack = game.packs.get("sfrpg.conditions");
                 const index = pack.indexed ? pack.index : await pack.getIndex();
-
                 const entry = index.find(e => e.name.toLowerCase() === conditionName.toLowerCase());
+
                 if (entry) {
                     const entity = await pack.getDocument(entry._id);
                     const itemData = entity.toObject();
-
                     const createdItems = await this.createEmbeddedDocuments("Item", [itemData]);
+
                     if (createdItems && createdItems.length > 0) {
                         await this._updateActorCondition(conditionName, true);
                         Hooks.callAll("onActorSetCondition", {actor: this, item: createdItems[0], conditionName, enabled});
-
                     }
                 }
-
             }
         } else {
             if (conditionItem) {
                 const effect = game.sfrpg.timedEffects.get(conditionItem.uuid);
                 effect.delete();
-
                 await this.deleteEmbeddedDocuments("Item", [conditionItem.id]);
                 await this._updateActorCondition(conditionName, false);
                 Hooks.callAll("onActorSetCondition", {actor: this, item: conditionItem, conditionName: conditionName, enabled: enabled});
-
             }
         }
 
@@ -107,6 +80,49 @@ export const ActorConditionsMixin = (superclass) => class extends superclass {
         }
 
         return enabled;
+    }
+
+    /** Redirect to `setCondition` if possible. */
+    async toggleStatusEffect(statusId, options) {
+        return this._isStatusEffect(statusId) && !("overlay" in options)
+            ? this.setCondition(statusId, !this.hasCondition(statusId))
+            : super.toggleStatusEffect(statusId, options);
+    }
+
+    /**
+     * Checks if the Flat-Footed condition should be enabled based on other conditions in SFRPG.conditionsCausingFlatFooted.
+     * @param conditionName The condition being added or removed
+     * @param enabled True if the condition is being added
+     * @private
+     */
+    _checkFlatFooted(conditionName, enabled) {
+        const hasFlatFooted =  this.hasCondition("flat-footed");
+        let hasCausingCondition = false;
+        for (const condition of CONFIG.SFRPG.conditionsCausingFlatFooted) {
+            if (this.hasCondition(condition)) {
+                hasCausingCondition = true;
+                break;
+            }
+        }
+
+        let shouldBeFlatFooted = (conditionName === "flat-footed" && enabled) || hasFlatFooted;
+        const causesFlatFooted = CONFIG.SFRPG.conditionsCausingFlatFooted.includes(conditionName);
+        if (causesFlatFooted) {
+            shouldBeFlatFooted = hasCausingCondition || enabled;
+        }
+
+        return this.setCondition("flat-footed", shouldBeFlatFooted);
+
+    }
+
+    /**
+     * Checks if the item is an effect in the status effects list
+     * @param item foundry item document
+     * @returns {boolean}
+     * @private
+     */
+    _isStatusEffect(name) {
+        return CONFIG.SFRPG.statusEffects.find(effect => effect.id === name) !== undefined;
     }
 
     /**
@@ -122,40 +138,5 @@ export const ActorConditionsMixin = (superclass) => class extends superclass {
 
         await this.update(updateData);
         this._checkFlatFooted(conditionName, enabled);
-    }
-
-    /**
-     * Checks if the Flat-Footed condition should be enabled based on other conditions in SFRPG.conditionsCausingFlatFooted.
-     * @param conditionName The condition being added or removed
-     * @param enabled True if the condition is being added
-     * @private
-     */
-    _checkFlatFooted(conditionName, enabled) {
-        const flatFooted = "flat-footed";
-        const hasFlatFooted =  this.hasCondition(flatFooted);
-
-        let hasCausingCondition = false;
-        for (const condition of CONFIG.SFRPG.conditionsCausingFlatFooted) {
-            if (this.hasCondition(condition)) {
-                hasCausingCondition = true;
-                break;
-            }
-
-        }
-
-        let shouldBeFlatFooted = (conditionName === flatFooted && enabled) || hasFlatFooted;
-
-        const causesFlatFooted = CONFIG.SFRPG.conditionsCausingFlatFooted.includes(conditionName);
-        if (causesFlatFooted) shouldBeFlatFooted = hasCausingCondition || enabled;
-
-        return this.setCondition(flatFooted, shouldBeFlatFooted);
-
-    }
-
-    /** Redirect to `setCondition` if possible. */
-    async toggleStatusEffect(statusId, options) {
-        return this._isStatusEffect(statusId) && !("overlay" in options)
-            ? this.setCondition(statusId, !this.hasCondition(statusId))
-            : super.toggleStatusEffect(statusId, options);
     }
 };

--- a/src/module/config.js
+++ b/src/module/config.js
@@ -1672,17 +1672,20 @@ SFRPG.statusEffects = [
     {
         id: "asleep",
         name: "SFRPG.ConditionsAsleep",
-        img: "systems/sfrpg/icons/conditions/asleep.webp"
+        img: "systems/sfrpg/icons/conditions/asleep.webp",
+        compendiumKey: "3iTdt2NRgIyrychR"
     },
     {
         id: "bleeding",
         name: "SFRPG.ConditionsBleeding",
-        img: "systems/sfrpg/icons/conditions/bleeding.webp"
+        img: "systems/sfrpg/icons/conditions/bleeding.webp",
+        compendiumKey: "v9RNVTqyTyaPchvd"
     },
     {
         id: "blinded",
         name: "SFRPG.ConditionsBlinded",
-        img: "systems/sfrpg/icons/conditions/blinded.webp"
+        img: "systems/sfrpg/icons/conditions/blinded.webp",
+        compendiumKey: "tOpF6qjnlnKc10t7"
     },
     {
         id: "broken",
@@ -1693,162 +1696,194 @@ SFRPG.statusEffects = [
     {
         id: "burning",
         name: "SFRPG.ConditionsBurning",
-        img: "systems/sfrpg/icons/conditions/burning.webp"
+        img: "systems/sfrpg/icons/conditions/burning.webp",
+        compendiumKey: "8LdyXZl9PeXXFE8O"
     },
     {
         id: "confused",
         name: "SFRPG.ConditionsConfused",
-        img: "systems/sfrpg/icons/conditions/confused.webp"
+        img: "systems/sfrpg/icons/conditions/confused.webp",
+        compendiumKey: "8rIj0ewW4bL8Uph5"
     },
     {
         id: "cowering",
         name: "SFRPG.ConditionsCowering",
-        img: "systems/sfrpg/icons/conditions/cowering.webp"
+        img: "systems/sfrpg/icons/conditions/cowering.webp",
+        compendiumKey: "4WXJOFZ4s7TJUW6D"
     },
     {
         id: "dazed",
         name: "SFRPG.ConditionsDazed",
-        img: "systems/sfrpg/icons/conditions/dazed.webp"
+        img: "systems/sfrpg/icons/conditions/dazed.webp",
+        compendiumKey: "2XWEujYSyryB4oHm"
     },
     {
         id: "dazzled",
         name: "SFRPG.ConditionsDazzled",
-        img: "systems/sfrpg/icons/conditions/dazzled.webp"
+        img: "systems/sfrpg/icons/conditions/dazzled.webp",
+        compendiumKey: "YjE6UGzwOTfO9p4g"
     },
     {
         id: "dead",
         name: "SFRPG.ConditionsDead",
-        img: "systems/sfrpg/icons/conditions/dead.webp"
+        img: "systems/sfrpg/icons/conditions/dead.webp",
+        compendiumKey: "nEJIWMKbPjqKuelo"
     },
     {
         id: "deafened",
         name: "SFRPG.ConditionsDeafened",
-        img: "systems/sfrpg/icons/conditions/deafened.webp"
+        img: "systems/sfrpg/icons/conditions/deafened.webp",
+        compendiumKey: "D8JvCEmOiWKe2UDx"
     },
     {
         id: "dying",
         name: "SFRPG.ConditionsDying",
-        img: "systems/sfrpg/icons/conditions/dying.webp"
+        img: "systems/sfrpg/icons/conditions/dying.webp",
+        compendiumKey: "4MxAK5uS0zMNWhUK"
     },
     {
         id: "encumbered",
         name: "SFRPG.ConditionsEncumbered",
-        img: "systems/sfrpg/icons/conditions/encumbered.webp"
+        img: "systems/sfrpg/icons/conditions/encumbered.webp",
+        compendiumKey: "OwZA6flUQPH0jPA0"
     },
     {
         id: "entangled",
         name: "SFRPG.ConditionsEntangled",
-        img: "systems/sfrpg/icons/conditions/entangled.webp"
+        img: "systems/sfrpg/icons/conditions/entangled.webp",
+        compendiumKey: "nFBcsp5FS1Wi46Fc"
     },
     {
         id: "exhausted",
         name: "SFRPG.ConditionsExhausted",
-        img: "systems/sfrpg/icons/conditions/exhausted.webp"
+        img: "systems/sfrpg/icons/conditions/exhausted.webp",
+        compendiumKey: "33ynSbmexuxC3cAQ"
     },
     {
         id: "fascinated",
         name: "SFRPG.ConditionsFascinated",
-        img: "systems/sfrpg/icons/conditions/fascinated.webp"
+        img: "systems/sfrpg/icons/conditions/fascinated.webp",
+        compendiumKey: "7PPRS6krnvaTHbxh"
     },
     {
         id: "fatigued",
         name: "SFRPG.ConditionsFatigued",
-        img: "systems/sfrpg/icons/conditions/fatigued.webp"
+        img: "systems/sfrpg/icons/conditions/fatigued.webp",
+        compendiumKey: "JGFn4MrDZ6X5vrzU"
     },
     {
         id: "flat-footed",
         name: "SFRPG.ConditionsFlatFooted",
-        img: "systems/sfrpg/icons/conditions/flatfooted.webp"
+        img: "systems/sfrpg/icons/conditions/flatfooted.webp",
+        compendiumKey: "MZ8OoH1GE9qDMyCD"
     },
     {
         id: "frightened",
         name: "SFRPG.ConditionsFrightened",
-        img: "systems/sfrpg/icons/conditions/frightened.webp"
+        img: "systems/sfrpg/icons/conditions/frightened.webp",
+        compendiumKey: "DtwiUWi8dpzkq4tM"
     },
     {
         id: "grappled",
         name: "SFRPG.ConditionsGrappled",
-        img: "systems/sfrpg/icons/conditions/grappled.webp"
+        img: "systems/sfrpg/icons/conditions/grappled.webp",
+        compendiumKey: "4AkWDHGM6gHDepHN"
     },
     {
         id: "helpless",
         name: "SFRPG.ConditionsHelpless",
-        img: "systems/sfrpg/icons/conditions/helpless.webp"
+        img: "systems/sfrpg/icons/conditions/helpless.webp",
+        compendiumKey: "RxvbSB9ZgSCBu2jw"
     },
     {
         id: "invisible",
         name: "SFRPG.ConditionsInvisible",
-        img: "systems/sfrpg/icons/conditions/invisible.webp"
+        img: "systems/sfrpg/icons/conditions/invisible.webp",
+        compendiumKey: "ZANamqgukV0AyXBb"
     },
     {
         id: "nauseated",
         name: "SFRPG.ConditionsNauseated",
-        img: "systems/sfrpg/icons/conditions/nauseated.webp"
+        img: "systems/sfrpg/icons/conditions/nauseated.webp",
+        compendiumKey: "LoRydw1D4bqlbkA2"
     },
     {
         id: "off-kilter",
         name: "SFRPG.ConditionsOffKilter",
-        img: "systems/sfrpg/icons/conditions/offkilter.webp"
+        img: "systems/sfrpg/icons/conditions/offkilter.webp",
+        compendiumKey: "QnGpBSHSTiszjPSb"
     },
     {
         id: "off-target",
         name: "SFRPG.ConditionsOffTarget",
-        img: "systems/sfrpg/icons/conditions/offtarget.webp"
+        img: "systems/sfrpg/icons/conditions/offtarget.webp",
+        compendiumKey: "yUtkoIshf4dPruNd"
     },
     {
         id: "overburdened",
         name: "SFRPG.ConditionsOverburdened",
-        img: "systems/sfrpg/icons/conditions/overburdened.webp"
+        img: "systems/sfrpg/icons/conditions/overburdened.webp",
+        compendiumKey: "11k3ObUIXEYFGrg9"
     },
     {
         id: "panicked",
         name: "SFRPG.ConditionsPanicked",
-        img: "systems/sfrpg/icons/conditions/panicked.webp"
+        img: "systems/sfrpg/icons/conditions/panicked.webp",
+        compendiumKey: "BVdjvpucmvQU4cc1"
     },
     {
         id: "paralyzed",
         name: "SFRPG.ConditionsParalyzed",
-        img: "systems/sfrpg/icons/conditions/paralyzed.webp"
+        img: "systems/sfrpg/icons/conditions/paralyzed.webp",
+        compendiumKey: "NV4qXRDgb7zTNkW2"
     },
     {
         id: "pinned",
         name: "SFRPG.ConditionsPinned",
-        img: "systems/sfrpg/icons/conditions/pinned.webp"
+        img: "systems/sfrpg/icons/conditions/pinned.webp",
+        compendiumKey: "XgK4EdO5D3Fj3iWz"
     },
     {
         id: "prone",
         name: "SFRPG.ConditionsProne",
-        img: "systems/sfrpg/icons/conditions/prone.webp"
+        img: "systems/sfrpg/icons/conditions/prone.webp",
+        compendiumKey: "XeRGqHVtcZ7vsgJ0"
     },
     {
         id: "shaken",
         name: "SFRPG.ConditionsShaken",
-        img: "systems/sfrpg/icons/conditions/shaken.webp"
+        img: "systems/sfrpg/icons/conditions/shaken.webp",
+        compendiumKey: "nywSVEeDvp1bk7L3"
     },
     {
         id: "sickened",
         name: "SFRPG.ConditionsSickened",
-        img: "systems/sfrpg/icons/conditions/sickened.webp"
+        img: "systems/sfrpg/icons/conditions/sickened.webp",
+        compendiumKey: "ZacF0l6IwqBwToTJ"
     },
     {
         id: "stable",
         name: "SFRPG.ConditionsStable",
-        img: "systems/sfrpg/icons/conditions/stable.webp"
+        img: "systems/sfrpg/icons/conditions/stable.webp",
+        compendiumKey: "H51jmhxF9XuwDOE7"
     },
     {
         id: "staggered",
         name: "SFRPG.ConditionsStaggered",
-        img: "systems/sfrpg/icons/conditions/staggered.webp"
+        img: "systems/sfrpg/icons/conditions/staggered.webp",
+        compendiumKey: "aAQ6SW6iK0EVq8Ce"
     },
     {
         id: "stunned",
         name: "SFRPG.ConditionsStunned",
-        img: "systems/sfrpg/icons/conditions/stunned.webp"
+        img: "systems/sfrpg/icons/conditions/stunned.webp",
+        compendiumKey: "CvsDp0GvojxiF2jz"
     },
     {
         id: "unconscious",
         name: "SFRPG.ConditionsUnconscious",
-        img: "systems/sfrpg/icons/conditions/unconscious.webp"
+        img: "systems/sfrpg/icons/conditions/unconscious.webp",
+        compendiumKey: "lf8pbezocjYIvR9y"
     }
 ];
 

--- a/src/module/token/token-hud.js
+++ b/src/module/token/token-hud.js
@@ -140,7 +140,9 @@ export class SFRPGTokenHUD extends foundry.applications.hud.TokenHUD {
         if (!statuses) return;
 
         for (const [condition, enabled] of Object.entries(statuses)) {
-            if (enabled) this.object.actor.setCondition(condition, false);
+            if (enabled) {
+                await this.object.actor.setCondition(condition, false);
+            }
         }
 
         for (const effect of this.object.actor.effects) {


### PR DESCRIPTION
This attempts to resolve a race condition by adding an additional await in condition application code. In addition, condition application code is cleaned up a bit.

A `nameSlug` field is added to the condition items so they can be referenced by this instead of their name, which should allow for more robust translation of item names in the compendium.

Resolves #1002 